### PR TITLE
Dataflow combinator library.

### DIFF
--- a/swim-system-java/swim-core-java/swim.concurrent/src/main/java/swim/concurrent/Recurring.java
+++ b/swim-system-java/swim-core-java/swim.concurrent/src/main/java/swim/concurrent/Recurring.java
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swim.dataflow.graph.impl;
+package swim.concurrent;
 
 import java.util.concurrent.atomic.AtomicReference;
-import swim.concurrent.Schedule;
-import swim.concurrent.TimerFunction;
-import swim.concurrent.TimerRef;
 
 /**
  * A recurring time event (it will reschedule itself on successful completion).
@@ -114,10 +111,8 @@ public abstract class Recurring implements TimerFunction {
         stop();
         throw ex;
       } finally {
-        if (state.get() == State.RUNNING) {
-          if (ref != null) {
-            ref.reschedule(periodMillis);
-          }
+        if (state.get() == State.RUNNING && ref != null) {
+          ref.reschedule(periodMillis);
         }
       }
     }

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/module-info.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/module-info.java
@@ -23,4 +23,18 @@ module swim.dataflow {
   requires transitive swim.streamlet;
 
   exports swim.dataflow;
+  exports swim.dataflow.graph;
+  exports swim.dataflow.graph.windows;
+  exports swim.dataflow.graph.windows.eviction;
+  exports swim.dataflow.graph.windows.triggers;
+  exports swim.dataflow.graph.sampling;
+  exports swim.dataflow.graph.timestamps;
+  exports swim.dataflow.graph.statistics;
+  exports swim.dataflow.graph.statistics.model;
+  exports swim.dataflow.graph.sinks;
+  exports swim.dataflow.graph.impl;
+  exports swim.dataflow.graph.impl.partitions;
+  exports swim.dataflow.graph.impl.windows;
+  exports swim.dataflow.graph.persistence;
+  exports swim.dataflow.connector;
 }

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction.java
@@ -1,0 +1,64 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.Require;
+
+/**
+ * Abstract implementation of {@link Junction} that provides methods to pass values on to any number
+ * of {@link Receptacle}s.
+ *
+ * @param <T> The type of the values.
+ */
+public abstract class AbstractJunction<T> implements Junction<T> {
+
+  /**
+   * Receptacles subscribed to the output of this junction.
+   */
+  private FingerTrieSeq<Receptacle<? super T>> receptacles = FingerTrieSeq.empty();
+
+  @Override
+  public final void subscribe(final Receptacle<? super T> receiver) {
+    Require.that(receiver != null, "Receiver must not be null.");
+    receptacles = receptacles.appended(receiver);
+  }
+
+  /**
+   * Emit a value to the subscribers.
+   *
+   * @param value The value.
+   */
+  protected final void emit(final Deferred<? extends T> value) {
+    for (final Receptacle<? super T> receptacle : receptacles) {
+      emitOn(value, receptacle);
+    }
+  }
+
+  /**
+   * Emit a value to the subscribers.
+   *
+   * @param value The value.
+   */
+  protected final void emit(final T value) {
+    emit(Deferred.value(value));
+  }
+
+  private static <U1, U2 extends U1> void emitOn(final Deferred<U2> value,
+                                                 final Receptacle<U1> receptacle) {
+    receptacle.notifyChange(Deferred.covCast(value));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import swim.collections.FingerTrieSeq;
 import swim.dataflow.graph.Require;
+import swim.util.Deferred;
 
 /**
  * Abstract implementation of {@link Junction} that provides methods to pass values on to any number

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction2.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Abstract {@link Junction} that consumers data from two input sources.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractJunction2.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Abstract {@link Junction} that consumers data from two input sources.
+ *
+ * @param <In1> The type of the first input.
+ * @param <In2> The type of the second input.
+ * @param <Out> The type of the output.
+ */
+public abstract class AbstractJunction2<In1, In2, Out> extends AbstractJunction<Out> implements Junction2<In1, In2, Out> {
+
+  private final Receptacle<In1> firstReceptacle = this::notifyChangeFirst;
+
+  private final Receptacle<In2> secondReceptacle = this::notifyChangeSecond;
+
+  /**
+   * Handle a change on the first input.
+   *
+   * @param value The input value.
+   */
+  protected abstract void notifyChangeFirst(Deferred<In1> value);
+
+  /**
+   * Handle a change on the second input.
+   *
+   * @param value The input value.
+   */
+  protected abstract void notifyChangeSecond(Deferred<In2> value);
+
+
+  @Override
+  public final Receptacle<In1> first() {
+    return firstReceptacle;
+  }
+
+  @Override
+  public final Receptacle<In2> second() {
+    return secondReceptacle;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction.java
@@ -1,0 +1,160 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Require;
+
+/**
+ * Abstract implementation of {@link MapJunction} which provides methods to pass on changes to the values for each
+ * key to any number of subscribers to the outputs of the junction.
+ *
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+public abstract class AbstractMapJunction<K, V> implements MapJunction<K, V> {
+  private FingerTrieSeq<MapReceptacle<K, ? super V>> receptacles = FingerTrieSeq.empty();
+  private HashTrieMap<K, FingerTrieSeq<Receptacle<? super V>>> keyReceptacles = HashTrieMap.empty();
+
+  @Override
+  public final void subscribe(final MapReceptacle<K, ? super V> receiver) {
+    Require.that(receiver != null, "Receiver must not be null.");
+    receptacles = receptacles.appended(receiver);
+  }
+
+  @Override
+  public final Handle<K, V> subscribe(final K key, final Receptacle<? super V> receiver) {
+    final FingerTrieSeq<Receptacle<? super V>> seq;
+    if (keyReceptacles.containsKey(key)) {
+      seq = keyReceptacles.get(key);
+    } else {
+      seq = FingerTrieSeq.empty();
+    }
+    keyReceptacles = keyReceptacles.updated(key, seq.appended(receiver));
+    return new SubHandle(key, receiver);
+  }
+
+  /**
+   * Handle which allows consumers to unsubscribe from a key of the map.
+   */
+  private final class SubHandle implements Handle<K, V> {
+
+    private final K key;
+    private final Receptacle<? super V> target;
+
+    private SubHandle(final K key, final Receptacle<? super V> target) {
+      this.key = key;
+      this.target = target;
+    }
+
+    @Override
+    public K key() {
+      return key;
+    }
+
+    @Override
+    public MapJunction<K, V> owner() {
+      return AbstractMapJunction.this;
+    }
+
+    @Override
+    public void unsubscribe() {
+      final FingerTrieSeq<Receptacle<? super V>> receps = keyReceptacles.get(key);
+      if (receps != null) {
+        keyReceptacles = keyReceptacles.updated(key, receps.removed(target));
+      }
+    }
+  }
+
+  /**
+   * Emit a value for a specific key.
+   *
+   * @param key   The key.
+   * @param value The updated value for the key.
+   * @param map   View of the state of the map after the update.
+   */
+  protected final void emit(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    for (final MapReceptacle<K, ? super V> receptacle : receptacles) {
+      emitOn(key, value, map, receptacle);
+    }
+    if (keyReceptacles.containsKey(key)) {
+      for (final Receptacle<? super V> receptacle : keyReceptacles.get(key)) {
+        emitOn(value, receptacle);
+      }
+    }
+  }
+
+  /**
+   * Emit a value for a specific key.
+   *
+   * @param key   The key.
+   * @param value The updated value for the key.
+   * @param map   View of the state of the map after the update.
+   */
+  protected final void emit(final K key, final V value, final MapView<K, V> map) {
+    emit(key, Deferred.value(value), Deferred.value(map));
+  }
+
+  /**
+   * Emit a removal fom the map.
+   *
+   * @param key The key to remove.
+   * @param map View of the state of the map after the removal.
+   */
+  protected final void emitRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    for (final MapReceptacle<K, ? super V> receptacle : receptacles) {
+      receptacle.notifyRemoval(key, covCast(map));
+    }
+  }
+
+  /**
+   * Emit a removal fom the map.
+   *
+   * @param key The key to remove.
+   * @param map View of the state of the map after the removal.
+   */
+  protected final void emitRemoval(final K key, final MapView<K, V> map) {
+    emitRemoval(key, Deferred.value(map));
+  }
+
+  /**
+   * Emit a value for a specific key.
+   *
+   * @param key   The key.
+   * @param value The updated value for the key.
+   * @param map   View of the state of the map after the update.
+   */
+  protected final void emit(final K key, final V value, final Deferred<MapView<K, V>> map) {
+    emit(key, Deferred.value(value), map);
+  }
+
+  private static <K, U1, U2 extends U1> void emitOn(final K key, final Deferred<U2> value,
+                                                    final Deferred<MapView<K, U2>> map,
+                                                    final MapReceptacle<K, U1> receptacle) {
+    receptacle.notifyChange(key, Deferred.covCast(value), covCast(map));
+  }
+
+  private static <U1, U2 extends U1> void emitOn(final Deferred<U2> value,
+                                                 final Receptacle<U1> receptacle) {
+    receptacle.notifyChange(Deferred.covCast(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <K, U1, U2 extends U1> Deferred<MapView<K, U1>> covCast(final Deferred<MapView<K, U2>> def) {
+    return (Deferred<MapView<K, U1>>) (Deferred<?>) def;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import swim.collections.FingerTrieSeq;
 import swim.collections.HashTrieMap;
 import swim.dataflow.graph.Require;
+import swim.util.Deferred;
 
 /**
  * Abstract implementation of {@link MapJunction} which provides methods to pass on changes to the values for each

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction2.java
@@ -1,0 +1,77 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Abstract {@link MapJunction} with two inputs, one of which is a map, the other of which is a simple value.
+ *
+ * @param <KeyIn>  The type of the input keys.
+ * @param <KeyOut> The type of the output keys.
+ * @param <ValIn>  The type of the input values.
+ * @param <ValOut> The type of the output values.
+ * @param <T>      The type of the data on the auxiliary channel.
+ */
+public abstract class AbstractMapJunction2<KeyIn, KeyOut, ValIn, ValOut, T> extends AbstractMapJunction<KeyOut, ValOut>
+    implements MapJunction2<KeyIn, KeyOut, ValIn, ValOut, T> {
+
+  /**
+   * Handler for changes to the values on the map input.
+   *
+   * @param key   The key.
+   * @param value The new value.
+   * @param map   View of the state of the map.
+   */
+  protected abstract void notifyChange(KeyIn key, Deferred<ValIn> value, Deferred<MapView<KeyIn, ValIn>> map);
+
+  /**
+   * Handler for removals of the values on the map input.
+   *
+   * @param key The key being removed.
+   * @param map View of the state of the map.
+   */
+  protected abstract void notifyRemoval(KeyIn key, Deferred<MapView<KeyIn, ValIn>> map);
+
+  /**
+   * Handler for changes on the auxiliary channel.
+   *
+   * @param value The new value.
+   */
+  protected abstract void notifyChange(Deferred<T> value);
+
+
+  private final MapReceptacle<KeyIn, ValIn> dataReceptacle = new MapReceptacle<KeyIn, ValIn>() {
+    @Override
+    public void notifyChange(final KeyIn key, final Deferred<ValIn> value, final Deferred<MapView<KeyIn, ValIn>> map) {
+      AbstractMapJunction2.this.notifyChange(key, value, map);
+    }
+
+    @Override
+    public void notifyRemoval(final KeyIn key, final Deferred<MapView<KeyIn, ValIn>> map) {
+      AbstractMapJunction2.this.notifyRemoval(key, map);
+    }
+  };
+
+  private final Receptacle<T> sideReceptacle = AbstractMapJunction2.this::notifyChange;
+
+  @Override
+  public final MapReceptacle<KeyIn, ValIn> first() {
+    return dataReceptacle;
+  }
+
+  @Override
+  public final Receptacle<T> second() {
+    return sideReceptacle;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/AbstractMapJunction2.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Abstract {@link MapJunction} with two inputs, one of which is a map, the other of which is a simple value.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Bundle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Bundle.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Interface for junctions that aggregate any number of inputs into a singel output.
+ *
+ * @param <In>  The type of the inputs.
+ * @param <Out> The type of the output.
+ */
+public interface Bundle<In, Out> extends Junction<Out> {
+
+  /**
+   * @return The input receptacles.
+   */
+  Iterable<Receptacle<In>> inputs();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/CollectionToMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/CollectionToMapConduit.java
@@ -1,0 +1,78 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Collection;
+import java.util.function.Function;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
+import swim.structure.Form;
+
+/**
+ * Conduit that consumes collections and emits them as key/value pairs from a {@link MapJunction}.
+ *
+ * @param <T> The type of the members of the collections.
+ * @param <C> The type of the collections.
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+public class CollectionToMapConduit<T, C extends Collection<T>, K, V> extends AbstractMapJunction<K, V> implements ValueToMapConduit<C, K, V> {
+
+  private final MapPersister<K, V> persister;
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+
+  /**
+   * @param toKey   Extract keys from the members of the collection.
+   * @param toValue Extract values from the members of the collection.
+   */
+  public CollectionToMapConduit(final Function<T, K> toKey, final Function<T, V> toValue,
+                                final MapPersister<K, V> persister) {
+    this.toKey = toKey;
+    this.toValue = toValue;
+    this.persister = persister;
+  }
+
+  /**
+   * @param toKey   Extract keys from the members of the collection.
+   * @param toValue Extract values from the members of the collection.
+   */
+  public CollectionToMapConduit(final Function<T, K> toKey, final Function<T, V> toValue,
+                                final Form<V> valForm) {
+    this(toKey, toValue, new TrivialMapPersister<>(valForm));
+  }
+
+  @Override
+  public void notifyChange(final Deferred<C> defColl) {
+    final C col = defColl.get();
+    HashTrieSet<K> toRemove = HashTrieSet.from(persister.keys());
+    for (final T entry : col) {
+      final K key = toKey.apply(entry);
+      final V value = toValue.apply(entry);
+      toRemove = toRemove.removed(key);
+      if (!value.equals(persister.get(key))) {
+        persister.put(key, value);
+        emit(key, value, persister.get());
+      }
+    }
+    for (final K key : toRemove) {
+      if (persister.containsKey(key)) {
+        persister.remove(key);
+        emitRemoval(key, persister.get());
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/CollectionToMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/CollectionToMapConduit.java
@@ -20,6 +20,7 @@ import swim.collections.HashTrieSet;
 import swim.dataflow.graph.persistence.MapPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 /**
  * Conduit that consumes collections and emits them as key/value pairs from a {@link MapJunction}.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Conduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Conduit.java
@@ -1,0 +1,25 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * A simple pipe that accepts values on a single input and produces them on a single output.
+ *
+ * @param <In>  The type of the inputs.
+ * @param <Out> The type of the outputs.
+ */
+public interface Conduit<In, Out> extends Receptacle<In>, Junction<Out> {
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Deferred.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Deferred.java
@@ -1,0 +1,134 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+
+/**
+ * Deferred computation of a value.
+ *
+ * @param <T> The type of the value.
+ */
+@FunctionalInterface
+public interface Deferred<T> {
+
+  /**
+   * @return Evaluate the result.
+   */
+  T get();
+
+  /**
+   * Apply a function over the computed value.
+   *
+   * @param f   The function.
+   * @param <U> The type of the result.
+   * @return The new deferred value.
+   */
+  default <U> Deferred<U> andThen(final Function<T, U> f) {
+    return () -> f.apply(get());
+  }
+
+  /**
+   * Memoize the result of this computation for successive calls to {@link #get}.
+   *
+   * @return The memoized, deferred value.
+   */
+  default Deferred<T> memoize() {
+    return new Memoized<>(this);
+  }
+
+  /**
+   * Apply a deferred function to a deferred input.
+   *
+   * @param f     The function.
+   * @param value The value.
+   * @param <U1>  The type of the input.
+   * @param <U2>  The type of the ouput.
+   * @return The deferred result.
+   */
+  static <U1, U2> Deferred<U2> apply(final Deferred<Function<U1, ? extends U2>> f, final Deferred<U1> value) {
+    return () -> f.get().apply(value.get());
+  }
+
+  /**
+   * Convert an already evaluated value to a constant deferred value.
+   *
+   * @param val The value.
+   * @param <T> The type of the value.
+   * @return The trivial deferred result.
+   */
+  static <T> Deferred<T> value(final T val) {
+    return new Deferred<T>() {
+      @Override
+      public T get() {
+        return val;
+      }
+
+      @Override
+      public Deferred<T> memoize() {
+        return this;
+      }
+    };
+  }
+
+  /**
+   * {@link Deferred} is covariance in its type parameter by the Java type checker cannot verify this. Perform a
+   * covariant cast on an instance.
+   *
+   * @param value The deferred value.
+   * @param <U1>  The target type.
+   * @param <U2>  The extension of the target type.
+   * @return The same deferred instance with the requested type.
+   */
+  @SuppressWarnings("unchecked")
+  static <U1, U2 extends U1> Deferred<U1> covCast(final Deferred<U2> value) {
+    return (Deferred<U1>) value;
+  }
+
+}
+
+/**
+ * Memoizing wrapper around a deferred value.
+ *
+ * @param <U> The type of the result.
+ */
+class Memoized<U> implements Deferred<U> {
+
+  private Deferred<U> source;
+  private U value = null;
+
+  /**
+   * @param valSrc The deferred value to memoize.
+   */
+  Memoized(final Deferred<U> valSrc) {
+    source = valSrc;
+  }
+
+  @Override
+  public U get() {
+    if (source != null) {
+      value = source.get();
+      //Allow the source to be garbage collected after we have evaluated it.
+      source = null;
+    }
+    return value;
+  }
+
+  @Override
+  public Deferred<U> memoize() {
+    return this;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import swim.dataflow.graph.Require;
 import swim.dataflow.graph.persistence.ListPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.util.Deferred;
 
 /**
  * Conduit that buffers the values it receives and emits the values a fixed number of samples previous to the

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayConduit.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+
+/**
+ * Conduit that buffers the values it receives and emits the values a fixed number of samples previous to the
+ * most recently received value.
+ *
+ * @param <T> The type of the values.
+ */
+public class DelayConduit<T> extends AbstractJunction<T> implements Conduit<T, T> {
+
+  private final ListPersister<T> persister;
+  private final int bufferSize;
+
+  /**
+   * Stores the buffer persistently.
+   *
+   * @param persister Persistence for the buffer.
+   * @param step      Number of samples of delay.
+   */
+  public DelayConduit(final ListPersister<T> persister, final int step) {
+    Require.that(step >= 1, "Delay must be at least 1.");
+    this.persister = persister;
+    bufferSize = step + 1;
+  }
+
+  /**
+   * Stores the buffer transiently.
+   *
+   * @param step Number of samples of delay.
+   */
+  public DelayConduit(final int step) {
+    this(new TrivialListPersister<>(), step);
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    persister.append(value.get());
+    persister.takeEnd(bufferSize);
+    if (persister.size() == bufferSize) {
+      emit(persister.get(0));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayMapConduit.java
@@ -22,6 +22,7 @@ import swim.dataflow.graph.persistence.ListPersister;
 import swim.dataflow.graph.persistence.SetPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
+import swim.util.Deferred;
 
 /**
  * Conduit that buffers the values it receives and emits the values a fixed number of samples previous to the

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/DelayMapConduit.java
@@ -1,0 +1,113 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Map;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
+
+/**
+ * Conduit that buffers the values it receives and emits the values a fixed number of samples previous to the
+ * most recently received value, for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class DelayMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapConduit<K, K, V, V> {
+
+  private HashTrieMap<K, ListPersister<V>> buffers;
+  private final Function<K, ListPersister<V>> bufferPersisters;
+  private final SetPersister<K> keys;
+  private final int bufferSize;
+
+  /**
+   * Store the buffers persistently.
+   *
+   * @param bufferPersisters Factory for persistent buffers.
+   * @param keys             Persistence for the active keys.
+   * @param step             Number of samples of delay.
+   */
+  public DelayMapConduit(final Function<K, ListPersister<V>> bufferPersisters,
+                         final SetPersister<K> keys,
+                         final int step) {
+    Require.that(step >= 1, "Delay must be at least 1.");
+    this.buffers = HashTrieMap.empty();
+    for (final K key : keys.get()) {
+      buffers = buffers.updated(key, bufferPersisters.apply(key));
+    }
+    this.bufferPersisters = bufferPersisters;
+    this.keys = keys;
+    this.bufferSize = step + 1;
+  }
+
+  /**
+   * Store the buffers transiently.
+   *
+   * @param step Number of samples of delay.
+   */
+  public DelayMapConduit(final int step) {
+    this(k -> new TrivialListPersister<>(), new TrivialSetPersisiter<>(), step);
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    ListPersister<V> buf = buffers.get(key);
+    if (buf == null) {
+      buf = bufferPersisters.apply(key);
+      buffers = buffers.updated(key, buf);
+      keys.add(key);
+    }
+    buf.append(value.get());
+    buf.takeEnd(bufferSize);
+    if (buf.size() == bufferSize) {
+      final MapView<K, V> view = createView();
+      final V current = buf.get(0);
+      emit(key, current, view);
+    }
+  }
+
+  private MapView<K, V> createView() {
+    HashTrieMap<K, V> snapshot = HashTrieMap.empty();
+    for (final Map.Entry<K, ListPersister<V>> entry : buffers.entrySet()) {
+      final ListPersister<V> buf = entry.getValue();
+      if (buf.size() >= bufferSize) {
+        snapshot = snapshot.updated(entry.getKey(), buf.get(0));
+      }
+    }
+    return MapView.wrap(snapshot);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    final ListPersister<V> buf = buffers.get(key);
+    if (buf != null) {
+      try {
+        buffers = buffers.removed(key);
+        keys.remove(key);
+      } finally {
+        buf.close();
+      }
+      final MapView<K, V> view = createView();
+      emitRemoval(key, view);
+    }
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import java.util.function.Predicate;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that only passes some of its input values to the output.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredConduit.java
@@ -1,0 +1,42 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Predicate;
+
+/**
+ * {@link Conduit} that only passes some of its input values to the output.
+ *
+ * @param <T> The type of the values.
+ */
+public class FilteredConduit<T> extends AbstractJunction<T> implements Conduit<T, T> {
+
+  private final Predicate<T> predicate;
+
+  /**
+   * @param predicate Predicate to assess the inputs.
+   */
+  public FilteredConduit(final Predicate<T> predicate) {
+    this.predicate = predicate;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    final Deferred<T> memoized = value.memoize();
+    if (predicate.test(memoized.get())) {
+      emit(memoized);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredMapConduit.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.function.BiPredicate;
 import swim.collections.HashTrieMap;
 import swim.collections.HashTrieSet;
+import swim.util.Deferred;
 
 /**
  * {@link MapConduit} that filters out some key/value pairs from it's input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FilteredMapConduit.java
@@ -1,0 +1,80 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Map;
+import java.util.function.BiPredicate;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+
+/**
+ * {@link MapConduit} that filters out some key/value pairs from it's input.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class FilteredMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapConduit<K, K, V, V> {
+
+  private final BiPredicate<K, V> predicate;
+  private HashTrieSet<K> keys = HashTrieSet.empty();
+
+  /**
+   * @param predicate Predicate on the key/value pairs.
+   */
+  public FilteredMapConduit(final BiPredicate<K, V> predicate) {
+    this.predicate = predicate;
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    final V val = value.get();
+    if (predicate.test(key, val)) {
+      keys = keys.added(key);
+      emit(key, val, map.andThen(m -> filterMap(m, predicate)));
+    } else if (keys.contains(key)) {
+      //In the case where a key was in the map but its new value leads to it being filtered, emit a removal notification.
+      keys = keys.removed(key);
+      emitRemoval(key, map.andThen(m -> filterMap(m, predicate)));
+    }
+  }
+
+  /**
+   * Filter a {@link MapView} by a predicate on the key value pairs.
+   *
+   * @param view      The view.
+   * @param predicate The predicate.
+   * @param <K>       The type of the keys.
+   * @param <V>       The type of teh values.
+   * @return The filtered view.
+   */
+  private static <K, V> MapView<K, V> filterMap(final MapView<K, V> view, final BiPredicate<K, V> predicate) {
+    HashTrieMap<K, V> filtered = HashTrieMap.empty();
+    for (final Map.Entry<K, Deferred<V>> entry : view) {
+      final V val = entry.getValue().get();
+      if (predicate.test(entry.getKey(), entry.getValue().get())) {
+        filtered = filtered.updated(entry.getKey(), val);
+      }
+    }
+    return MapView.wrap(filtered);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    if (keys.contains(key)) {
+      keys = keys.removed(key);
+      emitRemoval(key, map.andThen(m -> filterMap(m, predicate)));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * A conduit that only emits the first value it receives.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueConduit.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * A conduit that only emits the first value it receives.
+ *
+ * @param <T> The type of the values.
+ */
+public class FirstValueConduit<T> extends AbstractJunction<T> implements Conduit<T, T> {
+
+  private final ValuePersister<T> persister;
+
+  /**
+   * Store the first value persistently.
+   *
+   * @param persister Persistence for the value.
+   */
+  public FirstValueConduit(final ValuePersister<T> persister) {
+    this.persister = persister;
+  }
+
+  /**
+   * Store the first value transiently.
+   */
+  public FirstValueConduit() {
+    this(new TrivialValuePersister<>(null));
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    final T fromState = persister.get();
+    if (fromState == null) {
+      final T first = value.get();
+      persister.set(value.get());
+      emit(first);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueMapConduit.java
@@ -1,0 +1,67 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
+import swim.structure.Form;
+
+/**
+ * A conduit that only emits the first value it receives for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class FirstValueMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapConduit<K, K, V, V> {
+
+  private final boolean resetOnRemoval;
+  private final MapPersister<K, V> state;
+
+  /**
+   * Store the first values persistently.
+   * @param resetOnRemoval Whether to reset the first value on removal of a key.
+   * @param state Persister for the state.
+   */
+  public FirstValueMapConduit(final boolean resetOnRemoval, final MapPersister<K, V> state) {
+    this.state = state;
+    this.resetOnRemoval = resetOnRemoval;
+  }
+
+  /**
+   * Store the first values transiently.
+   * @param resetOnRemoval Whether to reset the first value on removal of a key.
+   * @param form The form of the values.
+   */
+  public FirstValueMapConduit(final boolean resetOnRemoval, final Form<V> form) {
+    this(resetOnRemoval, new TrivialMapPersister<>(form));
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    if (!state.containsKey(key)) {
+      final V first = value.get();
+      state.put(key, value.get());
+      emit(key, Deferred.value(first), Deferred.value(state.get()));
+    }
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    if (resetOnRemoval && state.containsKey(key)) {
+      state.remove(key);
+      emitRemoval(key, state.get());
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FirstValueMapConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import swim.dataflow.graph.persistence.MapPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 /**
  * A conduit that only emits the first value it receives for each key.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapConduit.java
@@ -1,0 +1,78 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.function.Function;
+import swim.collections.FingerTrieSeq;
+import swim.concurrent.AbstractTimer;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+
+/**
+ * {@link Conduit} that, for each values of its input, emits a sequence of output values on a configured period.
+ *
+ * @param <In>  The type of the inputs.
+ * @param <Out> The type of the outputs.
+ */
+public class FlatMapConduit<In, Out> extends AbstractJunction<Out> implements Conduit<In, Out> {
+
+  private FingerTrieSeq<Out> queue = FingerTrieSeq.empty();
+  private final Function<In, Iterable<Out>> flatMapFun;
+  private final AbstractTimer timer;
+
+  /**
+   * @param flatMapFun Function to transform the inputs to the outputs.
+   * @param schedule   Used to schedule the output emission.
+   * @param delay      Period between outputs.
+   */
+  public FlatMapConduit(final Function<In, Iterable<Out>> flatMapFun,
+                        final Schedule schedule,
+                        final Duration delay) {
+    Require.that(Duration.ZERO.compareTo(delay) < 0, "The delay between outputs must be positive.");
+    this.flatMapFun = flatMapFun;
+    final long delayMs = delay.toMillis();
+    timer = new AbstractTimer() {
+      @Override
+      public void runTimer() {
+        final FingerTrieSeq<Out> q = queue;
+        final Out toEmit = q.head();
+        queue = q.tail();
+        emit(toEmit);
+        if (!queue.isEmpty()) {
+          timerContext.reschedule(delayMs);
+        }
+      }
+    };
+    schedule.timer(timer);
+  }
+
+  @Override
+  public void notifyChange(final Deferred<In> value) {
+    final Iterable<Out> outputs = flatMapFun.apply(value.get());
+    final Iterator<Out> it = outputs.iterator();
+    if (it.hasNext()) {
+      final boolean wasEmpty = queue.isEmpty();
+      while (it.hasNext()) {
+        queue = queue.appended(it.next());
+      }
+      if (wasEmpty) {
+        timer.runTimer();
+      }
+    }
+
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapConduit.java
@@ -21,6 +21,7 @@ import swim.collections.FingerTrieSeq;
 import swim.concurrent.AbstractTimer;
 import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that, for each values of its input, emits a sequence of output values on a configured period.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapEntriesConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapEntriesConduit.java
@@ -1,0 +1,66 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Pair;
+
+/**
+ * {@link Conduit} that transforms the entries of a map using a function that produces a sequence of key values pairs
+ * for each each entry in the input.
+ *
+ * @param <K1> The type of the input keys.
+ * @param <K2> The type of the output keys.
+ * @param <V1> The type of the input values.
+ * @param <V2> The type of the output values.
+ */
+public class FlatMapEntriesConduit<K1, K2, V1, V2> extends AbstractMapJunction<K2, V2> implements MapConduit<K1, K2, V1, V2> {
+
+  private final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> onUpdate;
+  private final Function<K1, Set<K2>> onRemove;
+  private HashTrieMap<K2, V2> state = HashTrieMap.empty();
+
+  /**
+   * @param onUpdate Function to transform the values.
+   * @param onRemove Function to determine which keys should be removed from the output when a key is removed from
+   *                 the input.
+   */
+  public FlatMapEntriesConduit(final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> onUpdate,
+                               final Function<K1, Set<K2>> onRemove) {
+    this.onUpdate = onUpdate;
+    this.onRemove = onRemove;
+  }
+
+  @Override
+  public void notifyChange(final K1 key, final Deferred<V1> value, final Deferred<MapView<K1, V1>> map) {
+    for (final Pair<K2, V2> pair : onUpdate.apply(key, value.get())) {
+      state = state.updated(pair.getFirst(), pair.getSecond());
+      emit(pair.getFirst(), pair.getSecond(), Deferred.value(MapView.wrap(state)));
+    }
+  }
+
+  @Override
+  public void notifyRemoval(final K1 key, final Deferred<MapView<K1, V1>> map) {
+    for (final K2 toRemove : onRemove.apply(key)) {
+      if (state.containsKey(toRemove)) {
+        state = state.removed(toRemove);
+        emitRemoval(toRemove, Deferred.value(MapView.wrap(state)));
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapEntriesConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/FlatMapEntriesConduit.java
@@ -19,6 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import swim.collections.HashTrieMap;
 import swim.dataflow.graph.Pair;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that transforms the entries of a map using a function that produces a sequence of key values pairs

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityConduit.java
@@ -1,0 +1,28 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Trivial {@link Conduit} that passes its values on unchanged.
+ *
+ * @param <T> The type of the values.
+ */
+public final class IdentityConduit<T> extends AbstractJunction<T> implements Conduit<T, T> {
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    emit(value);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityConduit.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Trivial {@link Conduit} that passes its values on unchanged.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityMapConduit.java
@@ -1,5 +1,7 @@
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Trivial {@link MapConduit} that passes its values on unchanged.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/IdentityMapConduit.java
@@ -1,0 +1,19 @@
+package swim.dataflow.connector;
+
+/**
+ * Trivial {@link MapConduit} that passes its values on unchanged.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class IdentityMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapConduit<K, K, V, V> {
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    emit(key, value, map);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    emitRemoval(key, map);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/JoinOnKeyJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/JoinOnKeyJunction.java
@@ -22,6 +22,7 @@ import swim.collections.HashTrieMap;
 import swim.collections.HashTrieSet;
 import swim.dataflow.graph.Iterables;
 import swim.dataflow.graph.JoinKind;
+import swim.util.Deferred;
 
 /**
  * {@link Junction} that combines together two map inputs (with a common key type) to produce a joined output map

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/JoinOnKeyJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/JoinOnKeyJunction.java
@@ -1,0 +1,205 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.Iterables;
+import swim.dataflow.graph.JoinKind;
+
+/**
+ * {@link Junction} that combines together two map inputs (with a common key type) to produce a joined output map
+ * based on their values.
+ *
+ * @param <Key> The shared key type.
+ * @param <L>   The left input value type.
+ * @param <R>   The right input value type.
+ * @param <Out> The output value type.
+ */
+public class JoinOnKeyJunction<Key, L, R, Out> extends AbstractMapJunction<Key, Out> implements MapJoinJunction<Key, L, R, Key, Out> {
+
+  private final BiFunction<L, R, Out> combine;
+  private final Function<L, Out> leftOnly;
+  private final Function<R, Out> rightOnly;
+  private final JoinKind kind;
+  private HashTrieSet<Key> leftKeys = HashTrieSet.empty();
+  private HashTrieSet<Key> rightKeys = HashTrieSet.empty();
+  private HashTrieSet<Key> joinedKeys = HashTrieSet.empty();
+  private Deferred<MapView<Key, R>> rightMap = Deferred.value(MapView.wrap(HashTrieMap.empty()));
+  private Deferred<MapView<Key, L>> leftMap = Deferred.value(MapView.wrap(HashTrieMap.empty()));
+
+  /**
+   * @param combine   Combines together values with the same key.
+   * @param leftOnly  Produces a value when only the left stream provides a value for a key (may be {@code  null}).
+   * @param rightOnly Produces a value when only the right stream provides a value for a key (may be {@code  null}).
+   */
+  public JoinOnKeyJunction(final BiFunction<L, R, Out> combine,
+                           final Function<L, Out> leftOnly,
+                           final Function<R, Out> rightOnly) {
+    this.combine = combine;
+    this.leftOnly = leftOnly;
+    this.rightOnly = rightOnly;
+    if (leftOnly == null) {
+      if (rightOnly == null) {
+        kind = JoinKind.INNER;
+      } else {
+        kind = JoinKind.RIGHT;
+      }
+    } else if (rightOnly == null) {
+      kind = JoinKind.LEFT;
+    } else {
+      kind = JoinKind.FULL;
+    }
+  }
+
+  public JoinOnKeyJunction(final BiFunction<L, R, Out> combine) {
+    this(combine, null, null);
+  }
+
+  private static boolean requiresRight(final JoinKind kind) {
+    return kind == JoinKind.INNER || kind == JoinKind.RIGHT;
+  }
+
+  private static boolean requiresLeft(final JoinKind kind) {
+    return kind == JoinKind.INNER || kind == JoinKind.LEFT;
+  }
+
+  private final MapReceptacle<Key, L> leftReceptacle = new MapReceptacle<Key, L>() {
+
+    @Override
+    public void notifyChange(final Key key, final Deferred<L> value, final Deferred<MapView<Key, L>> map) {
+      leftKeys = leftKeys.added(key);
+      leftMap = map;
+      if (rightKeys.contains(key) || !requiresRight(kind)) {
+        if (!joinedKeys.contains(key)) {
+          joinedKeys = joinedKeys.added(key);
+        }
+        final MapView<Key, Out> joinedView = joinedMapView(leftMap, rightMap, joinedKeys);
+        emit(key, joinedView.get(key), Deferred.value(joinedView));
+      }
+    }
+
+    @Override
+    public void notifyRemoval(final Key key, final Deferred<MapView<Key, L>> map) {
+      leftKeys = leftKeys.removed(key);
+      leftMap = map;
+      if (joinedKeys.contains(key)) {
+        if (requiresLeft(kind) || !rightKeys.contains(key)) {
+          joinedKeys = joinedKeys.removed(key);
+          emitRemoval(key, joinedMapView(leftMap, rightMap, joinedKeys));
+        } else {
+          final MapView<Key, Out> joinedView = joinedMapView(leftMap, rightMap, joinedKeys);
+          emit(key, joinedView.get(key), Deferred.value(joinedView));
+        }
+      }
+      leftMap = map;
+    }
+  };
+
+  private final MapReceptacle<Key, R> rightReceptcale = new MapReceptacle<Key, R>() {
+    @Override
+    public void notifyChange(final Key key, final Deferred<R> value, final Deferred<MapView<Key, R>> map) {
+      rightKeys = rightKeys.added(key);
+      rightMap = map;
+      if (leftKeys.contains(key) || !requiresLeft(kind)) {
+        if (!joinedKeys.contains(key)) {
+          joinedKeys = joinedKeys.added(key);
+        }
+        final MapView<Key, Out> joinedView = joinedMapView(leftMap, rightMap, joinedKeys);
+        emit(key, joinedView.get(key), Deferred.value(joinedView));
+      }
+    }
+
+    @Override
+    public void notifyRemoval(final Key key, final Deferred<MapView<Key, R>> map) {
+      rightKeys = rightKeys.removed(key);
+      rightMap = map;
+      if (joinedKeys.contains(key)) {
+        if (requiresRight(kind) || !leftKeys.contains(key)) {
+          joinedKeys = joinedKeys.removed(key);
+          emitRemoval(key, joinedMapView(leftMap, rightMap, joinedKeys));
+        } else {
+          final MapView<Key, Out> joinedView = joinedMapView(leftMap, rightMap, joinedKeys);
+          emit(key, joinedView.get(key), Deferred.value(joinedView));
+        }
+
+      }
+      rightMap = map;
+    }
+  };
+
+  @Override
+  public MapReceptacle<Key, L> first() {
+    return leftReceptacle;
+  }
+
+  @Override
+  public MapReceptacle<Key, R> second() {
+    return rightReceptcale;
+  }
+
+  /**
+   * Create a lazy map view that joines together the map views from the left and right input channels.
+   *
+   * @param left       The left map view.
+   * @param right      The right map view.
+   * @param joinedKeys The keys that should exist in the joined map.
+   * @return The map view.
+   */
+  private MapView<Key, Out> joinedMapView(final Deferred<MapView<Key, L>> left,
+                                          final Deferred<MapView<Key, R>> right,
+                                          final HashTrieSet<Key> joinedKeys) {
+
+    final SetView<Key> keys = SetView.wrap(joinedKeys);
+
+    final MapView<Key, L> leftView = left.get();
+    final MapView<Key, R> rightView = right.get();
+    return new MapView<Key, Out>() {
+      @Override
+      public boolean containsKey(final Key key) {
+        return joinedKeys.contains(key);
+      }
+
+      @Override
+      public Iterator<Map.Entry<Key, Deferred<Out>>> iterator() {
+        return Iterables.mapIterable(keys, k -> MapView.entryFor(k, get(k))).iterator();
+      }
+
+      @Override
+      public SetView<Key> keys() {
+        return keys;
+      }
+
+      @Override
+      public Deferred<Out> get(final Key key) {
+        final boolean inLeft = leftView.containsKey(key);
+        final boolean inRight = rightView.containsKey(key);
+        if (inLeft && inRight) {
+          return () -> combine.apply(leftView.get(key).get(), rightView.get(key).get());
+        } else if (inLeft) {
+          return () -> leftOnly.apply(leftView.get(key).get());
+        } else if (inRight) {
+          return () -> rightOnly.apply(rightView.get(key).get());
+        } else {
+          return null;
+        }
+      }
+    };
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction.java
@@ -1,0 +1,31 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Fundamental interface for all non-map connectors. Represents a flow component that can produce values of some type.
+ *
+ * @param <T> The type of the values.
+ */
+public interface Junction<T> {
+
+  /**
+   * Subscribe to the outputs of this junction.
+   *
+   * @param receiver Receptacle that accepts the outputs.
+   */
+  void subscribe(Receptacle<? super T> receiver);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction2.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * A {@link Junction} that has two input channels.
+ *
+ * @param <In1> The type of the first input channel.
+ * @param <In2> The type of the second input channel.
+ * @param <Out> The type of the outputs derived from the inputs.
+ */
+public interface Junction2<In1, In2, Out> extends Junction<Out> {
+
+  Receptacle<In1> first();
+
+  Receptacle<In2> second();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction3.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Junction3.java
@@ -1,0 +1,33 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * A {@link Junction} that has three input channels.
+ *
+ * @param <In1> The type of the first input channel.
+ * @param <In2> The type of the second input channel.
+ * @param <In3> The type of the third input channel.
+ * @param <Out> The type of the outputs derived from the inputs.
+ */
+public interface Junction3<In1, In2, In3, Out> extends Junction<Out> {
+
+  Receptacle<In1> first();
+
+  Receptacle<In2> second();
+
+  Receptacle<In3> third();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapCollector.java
@@ -1,0 +1,50 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+
+/**
+ * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs.
+ *
+ * @param <T> The type of the input values.
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+public class MapCollector<T, K, V> extends AbstractMapJunction<K, V> implements ValueToMapConduit<T, K, V> {
+
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+  private HashTrieMap<K, Deferred<V>> mapState = HashTrieMap.empty();
+
+  /**
+   * @param toKey   Gets the map key for an input.
+   * @param toValue Gets the map value for an input.
+   */
+  public MapCollector(final Function<T, K> toKey, final Function<T, V> toValue) {
+    this.toKey = toKey;
+    this.toValue = toValue;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> el) {
+    final T element = el.get();
+    final K key = toKey.apply(element);
+    final Deferred<V> value = Deferred.value(toValue.apply(element));
+    mapState = mapState.updated(key, value);
+    emit(key, value, Deferred.value(MapView.wrap(mapState)));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapCollector.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.Function;
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapConduit.java
@@ -1,0 +1,26 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * A conduit that consumes a map and outputs another map.
+ *
+ * @param <KIn>  The type of the input keys.
+ * @param <KOut> The type of the output keys.
+ * @param <VIn>  The type of the input values.
+ * @param <VOut> The type of the output values.
+ */
+public interface MapConduit<KIn, KOut, VIn, VOut> extends MapReceptacle<KIn, VIn>, MapJunction<KOut, VOut> {
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapExtractor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapExtractor.java
@@ -1,0 +1,41 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Map;
+import swim.collections.HashTrieMap;
+
+/**
+ * Consumes the keys and values of a map and outputs them a single object.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class MapExtractor<K, V> extends AbstractJunction<Map<K, V>> implements MapToValueConduit<K, V, Map<K, V>> {
+
+  private HashTrieMap<K, V> acc = HashTrieMap.empty();
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    acc = acc.updated(key, value.get());
+    emit(acc);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    acc = acc.removed(key);
+    emit(acc);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapExtractor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapExtractor.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.Map;
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * Consumes the keys and values of a map and outputs them a single object.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJoinJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJoinJunction.java
@@ -1,0 +1,37 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * {@link MapJunction} that consumes two map inputs with the same key type and generates another map output.
+ *
+ * @param <KIn>  The input key type.
+ * @param <VIn1> The first input value type.
+ * @param <VIn2> The second input value type.
+ * @param <KOut> The output key type.
+ * @param <VOut> The output value type.
+ */
+public interface MapJoinJunction<KIn, VIn1, VIn2, KOut, VOut> extends MapJunction<KOut, VOut> {
+
+  /**
+   * @return The first input receptacle.
+   */
+  MapReceptacle<KIn, VIn1> first();
+
+  /**
+   * @return The second input receptacle.
+   */
+  MapReceptacle<KIn, VIn2> second();
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJunction.java
@@ -1,0 +1,66 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Fundamental interface for all map connectors. Represents a flow component that represents the state of a map from
+ * some key type to some value type.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public interface MapJunction<K, V> {
+
+  /**
+   * Handle representing a subscription to the values of a specific key.
+   *
+   * @param <K> The type of the key.
+   * @param <V> The type of the value.
+   */
+  interface Handle<K, V> {
+
+    /**
+     * @return The key that this is attache dto.
+     */
+    K key();
+
+    /**
+     * @return The junction that owns this handle.
+     */
+    MapJunction<K, V> owner();
+
+    /**
+     * Remove this subscription.
+     */
+    void unsubscribe();
+  }
+
+  /**
+   * Subscribe the outputs of this junction.
+   *
+   * @param receiver Receives updates and removals for all keys.
+   */
+  void subscribe(MapReceptacle<K, ? super V> receiver);
+
+  /**
+   * Subscribe to the values of a single key.
+   *
+   * @param key      The key.
+   * @param receiver Receives updates for that key only.
+   * @return Handle representing the subscription.
+   */
+  Handle<K, V> subscribe(K key, Receptacle<? super V> receiver);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJunction2.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapJunction2.java
@@ -1,0 +1,38 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * A {@link MapJunction} with two inputs, one consuming map data and the other simple values.
+ *
+ * @param <KIn>  The type of the input keys.
+ * @param <KOut> The type of the output keys.
+ * @param <VIn>  The type of the input map values.
+ * @param <VOut> The type of the output map values.
+ * @param <T>    The type of the auxiliary channel.
+ */
+public interface MapJunction2<KIn, KOut, VIn, VOut, T> extends MapJunction<KOut, VOut> {
+
+  /**
+   * @return The map input channel.
+   */
+  MapReceptacle<KIn, VIn> first();
+
+  /**
+   * @return The auxiliary input channel.
+   */
+  Receptacle<T> second();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapKeysCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapKeysCollector.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.Set;
 import swim.collections.HashTrieSet;
+import swim.util.Deferred;
 
 /**
  * Conduit that collects the keys from a {@link MapJunction} and outputs the current key set as a single value.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapKeysCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapKeysCollector.java
@@ -1,0 +1,41 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Set;
+import swim.collections.HashTrieSet;
+
+/**
+ * Conduit that collects the keys from a {@link MapJunction} and outputs the current key set as a single value.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The value type of the map.
+ */
+public class MapKeysCollector<K, V> extends AbstractJunction<Set<K>> implements MapToValueConduit<K, V, Set<K>> {
+
+  private HashTrieSet<K> keys = HashTrieSet.empty();
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    keys = keys.added(key);
+    emit(keys);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    keys = keys.removed(key);
+    emit(keys);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapMemoizingConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapMemoizingConduit.java
@@ -1,0 +1,41 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.collections.HashTrieMap;
+
+/**
+ * Conduit that memoizes the state of a {@link MapJunction}.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class MapMemoizingConduit<K, V> extends AbstractMapJunction<K, V> implements MapConduit<K, K, V, V> {
+
+  private HashTrieMap<K, V> mapState = HashTrieMap.empty();
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    final V val = value.get();
+    mapState = mapState.updated(key, val);
+    emit(key, Deferred.value(val), Deferred.value(MapView.wrap(mapState)));
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    mapState = mapState.removed(key);
+    emitRemoval(key, Deferred.value(MapView.wrap(mapState)));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapMemoizingConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapMemoizingConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * Conduit that memoizes the state of a {@link MapJunction}.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapReceptacle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapReceptacle.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Interface for handlers that can consume the output of a {@link MapJunction}.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapReceptacle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapReceptacle.java
@@ -1,0 +1,42 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Interface for handlers that can consume the output of a {@link MapJunction}.
+ *
+ * @param <K> The type of the map keys.
+ * @param <V> The type of the map values.
+ */
+public interface MapReceptacle<K, V> {
+
+  /**
+   * Handle an update to the map.
+   *
+   * @param key   The key being updated.
+   * @param value The new value.
+   * @param map   View of the current state of the map.
+   */
+  void notifyChange(K key, Deferred<V> value, Deferred<MapView<K, V>> map);
+
+  /**
+   * Handle an removal from the map.
+   *
+   * @param key The key being removed.
+   * @param map View of the current state of the map.
+   */
+  void notifyRemoval(K key, Deferred<MapView<K, V>> map);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapToValueConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapToValueConduit.java
@@ -1,0 +1,25 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Conduit that consumes the entries of a map and reduces them to a value.
+ *
+ * @param <KIn> The type of the input keys.
+ * @param <VIn> The type of the input values.
+ * @param <Out> The type of the output.
+ */
+public interface MapToValueConduit<KIn, VIn, Out> extends MapReceptacle<KIn, VIn>, Junction<Out> {
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapView.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapView.java
@@ -1,0 +1,600 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.Iterables;
+
+/**
+ * Immutable view of the current state of a {@link MapJunction}.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public interface MapView<K, V> extends Iterable<Map.Entry<K, Deferred<V>>> {
+
+  /**
+   * Expose a deferred {@link HashTrieMap} through a view.
+   *
+   * @param map The underlying map.
+   * @param <K> The type of the keys.
+   * @param <V> The type of the values.
+   * @return The view.
+   */
+  static <K, V> MapView<K, V> wrap(final HashTrieMap<K, Deferred<V>> map) {
+    return new MapWrapper<>(map);
+  }
+
+  /**
+   * Create an immutable view of a Java map.
+   *
+   * @param map The underlying map.
+   * @param <K> The type of the keys.
+   * @param <V> The type of the values.
+   * @return The view.
+   */
+  static <K, V> MapView<K, V> wrap(final Map<K, V> map) {
+    return new JavaMapView<>(map, null, null);
+  }
+
+  /**
+   * Expose a {@link HashTrieMap} through a view.
+   *
+   * @param map The underlying map.
+   * @param <K> The type of the keys.
+   * @param <V> The type of the values.
+   * @return The view.
+   */
+  static <K, V> MapView<K, V> wrapSimple(final HashTrieMap<K, V> map) {
+    return new SimpleMapWrapper<>(map);
+  }
+
+  /**
+   * {@link MapView}s are covariant in their second parameter but this cannot be determined by the Java type checker.
+   * Peform a covariance cast on a map view.
+   *
+   * @param view The map view.
+   * @param <K>  The type of the keys.
+   * @param <V1> The target value type.
+   * @param <V2> The initial value type.
+   * @return The same view instance.
+   */
+  @SuppressWarnings("unchecked")
+  static <K, V1, V2 extends V1> MapView<K, V1> covCast(final MapView<K, V2> view) {
+    return (MapView<K, V1>) view;
+  }
+
+  /**
+   * Defer the value of a map entry.
+   *
+   * @param entry The entry.
+   * @param <K>   The type of the key.
+   * @param <V>   The type of the value.
+   * @return The deferred entry.
+   */
+  static <K, V> Map.Entry<K, Deferred<V>> deferValue(final Map.Entry<K, V> entry) {
+    return new Map.Entry<K, Deferred<V>>() {
+      @Override
+      public K getKey() {
+        return entry.getKey();
+      }
+
+      @Override
+      public Deferred<V> getValue() {
+        return Deferred.value(entry.getValue());
+      }
+
+      @Override
+      public Deferred<V> setValue(final Deferred<V> value) {
+        entry.setValue(value.get());
+        return value;
+      }
+    };
+  }
+
+  //Create a map entry.
+  static <K, V> Map.Entry<K, V> entryFor(final K key, final V val) {
+    return new Map.Entry<K, V>() {
+      @Override
+      public K getKey() {
+        return key;
+      }
+
+      @Override
+      public V getValue() {
+        return val;
+      }
+
+      @Override
+      public V setValue(final V value) {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  /**
+   * @return Immutable view of the keys.
+   */
+  SetView<K> keys();
+
+  /**
+   * Get the deferred value for a key.
+   *
+   * @param key The key.
+   * @return The deferred value.
+   */
+  Deferred<V> get(K key);
+
+  /**
+   * @return The number of entries.
+   */
+  default int size() {
+    return keys().size();
+  }
+
+  /**
+   * @param key A key.
+   * @return Whether this contains the key.
+   */
+  default boolean containsKey(final K key) {
+    return keys().contains(key);
+  }
+
+  /**
+   * Create a new view which is the same as this view only containing an updated entry.
+   *
+   * @param key   The updated key.
+   * @param value The new value.
+   * @return The new view.
+   */
+  default MapView<K, V> updated(final K key, final Deferred<V> value) {
+    return memoize().updated(key, value);
+  }
+
+  /**
+   * Create a new view which is the same as this view only with an entry removed.
+   *
+   * @param key The removed key.
+   * @return The new view.
+   */
+  default MapView<K, V> removed(final K key) {
+    return memoize().removed(key);
+  }
+
+  /**
+   * Create a new view that has the same keys as this view but with the values transformed.
+   *
+   * @param f   The function to apply to the values.
+   * @param <U> The type of the transformed values.
+   * @return The transformed view.
+   */
+  default <U> MapView<K, U> map(final Function<V, U> f) {
+    return map((k, v) -> f.apply(v));
+  }
+
+  /**
+   * Create a new view that has the same keys as this view but with the values transformed.
+   *
+   * @param f   The function to apply to the values (taking the key into account).
+   * @param <U> The type of the transformed values.
+   * @return The transformed view.
+   */
+  default <U> MapView<K, U> map(final BiFunction<K, V, ? extends U> f) {
+    return new TransformedMapView<>(this, f, null);
+  }
+
+  /**
+   * Create a view that is the same as this view but with some keys filtered out.
+   *
+   * @param p The predicate to filter the keys.
+   * @return The filtered view.
+   */
+  default MapView<K, V> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(this, p);
+  }
+
+  /**
+   * Memoize this view.
+   *
+   * @return The memoized view.
+   */
+  default MapView<K, V> memoize() {
+    HashTrieMap<K, Deferred<V>> memoized = HashTrieMap.empty();
+    for (final Map.Entry<K, Deferred<V>> entry : this) {
+      memoized = memoized.updated(entry.getKey(), entry.getValue().memoize());
+    }
+    return new MapWrapper<>(memoized);
+  }
+}
+
+class MapWrapper<K, V> implements MapView<K, V> {
+
+  private final HashTrieMap<K, Deferred<V>> wrapped;
+  private SetView<K> keys = null;
+
+  MapWrapper(final HashTrieMap<K, Deferred<V>> wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public SetView<K> keys() {
+    if (keys == null) {
+      keys = SetView.wrap(wrapped.keySet());
+    }
+    return keys;
+  }
+
+  @Override
+  public Deferred<V> get(final K key) {
+    return wrapped.get(key);
+  }
+
+  @Override
+  public MapView<K, V> updated(final K key, final Deferred<V> value) {
+    return new MapWrapper<>(wrapped.updated(key, value));
+  }
+
+  @Override
+  public MapView<K, V> removed(final K key) {
+    return new MapWrapper<>(wrapped.removed(key));
+  }
+
+  @Override
+  public <U> MapView<K, U> map(final BiFunction<K, V, ? extends U> f) {
+    return new TransformedMapView<>(this, f, null);
+  }
+
+  @Override
+  public MapView<K, V> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(this, p);
+  }
+
+  @Override
+  public MapView<K, V> memoize() {
+    HashTrieMap<K, Deferred<V>> memoized = HashTrieMap.empty();
+    for (final Map.Entry<K, Deferred<V>> entry : wrapped) {
+      memoized = memoized.updated(entry.getKey(), entry.getValue().memoize());
+    }
+    return new MapWrapper<>(memoized);
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, Deferred<V>>> iterator() {
+    return wrapped.entrySet().iterator();
+  }
+
+
+}
+
+class SimpleMapWrapper<K, V> implements MapView<K, V> {
+
+  private final HashTrieMap<K, V> wrapped;
+  private SetView<K> keys = null;
+
+  SimpleMapWrapper(final HashTrieMap<K, V> wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public SetView<K> keys() {
+    if (keys == null) {
+      keys = SetView.wrap(wrapped.keySet());
+    }
+    return keys;
+  }
+
+  @Override
+  public Deferred<V> get(final K key) {
+    if (wrapped.containsKey(key)) {
+      return Deferred.value(wrapped.get(key));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public MapView<K, V> updated(final K key, final Deferred<V> value) {
+    HashTrieMap<K, Deferred<V>> map = HashTrieMap.empty();
+    for (final Map.Entry<K, V> entry : wrapped.entrySet()) {
+      map = map.updated(entry.getKey(), Deferred.value(entry.getValue()));
+    }
+    return new MapWrapper<>(map.updated(key, value));
+  }
+
+  @Override
+  public MapView<K, V> removed(final K key) {
+    if (!wrapped.containsKey(key)) {
+      return this;
+    } else {
+      HashTrieMap<K, Deferred<V>> map = HashTrieMap.empty();
+      for (final Map.Entry<K, V> entry : wrapped.entrySet()) {
+        if (!entry.getKey().equals(key)) {
+          map = map.updated(entry.getKey(), Deferred.value(entry.getValue()));
+        }
+      }
+      return new MapWrapper<>(map);
+    }
+  }
+
+  @Override
+  public <U> MapView<K, U> map(final BiFunction<K, V, ? extends U> f) {
+    return new TransformedMapView<>(this, f, null);
+  }
+
+  @Override
+  public MapView<K, V> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(this, p);
+  }
+
+  @Override
+  public MapView<K, V> memoize() {
+    return this;
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, Deferred<V>>> iterator() {
+    return Iterables.mapIterable(wrapped.entrySet(), MapView::deferValue).iterator();
+  }
+}
+
+class FilteredMapView<K, V> implements MapView<K, V> {
+
+  private final MapView<K, V> wrapped;
+  private final Predicate<K> predicate;
+
+  FilteredMapView(final MapView<K, V> wrapped, final Predicate<K> predicate) {
+    this.wrapped = wrapped;
+    this.predicate = predicate;
+  }
+
+  @Override
+  public SetView<K> keys() {
+    return wrapped.keys().filter(predicate);
+  }
+
+  @Override
+  public Deferred<V> get(final K key) {
+    if (predicate.test(key)) {
+      return wrapped.get(key);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public MapView<K, V> updated(final K key, final Deferred<V> value) {
+    if (predicate.test(key)) {
+      return new FilteredMapView<>(wrapped.updated(key, value), predicate);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public MapView<K, V> removed(final K key) {
+    if (predicate.test(key) && wrapped.containsKey(key)) {
+      return new FilteredMapView<>(wrapped.removed(key), predicate);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public <U> MapView<K, U> map(final BiFunction<K, V, ? extends U> f) {
+    return new TransformedMapView<>(this, f, null);
+  }
+
+  @Override
+  public MapView<K, V> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(wrapped, predicate.and(p));
+  }
+
+  @Override
+  public MapView<K, V> memoize() {
+    HashTrieMap<K, Deferred<V>> map = HashTrieMap.empty();
+    for (final K key : wrapped.keys()) {
+      if (predicate.test(key)) {
+        map = map.updated(key, wrapped.get(key).memoize());
+      }
+    }
+    return new MapWrapper<>(map);
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, Deferred<V>>> iterator() {
+    return Iterables.filterIterable(wrapped, entry -> predicate.test(entry.getKey())).iterator();
+  }
+}
+
+class TransformedMapView<K, V, U> implements MapView<K, U> {
+
+  private final MapView<K, V> base;
+  private final BiFunction<K, V, ? extends U> f;
+  private final MapView<K, U> delta;
+  private SetView<K> keys = null;
+
+  TransformedMapView(final MapView<K, V> base, final BiFunction<K, V, ? extends U> f,
+                     final MapView<K, U> delta) {
+    this.base = base;
+    this.f = f;
+    this.delta = delta;
+  }
+
+  @Override
+  public SetView<K> keys() {
+    if (keys == null) {
+      keys = base.keys();
+      if (delta != null) {
+        for (final K key : delta.keys()) {
+          keys = keys.added(key);
+        }
+      }
+    }
+    return base.keys();
+  }
+
+  @Override
+  public Deferred<U> get(final K key) {
+    if (delta != null && delta.containsKey(key)) {
+      return delta.get(key);
+    } else if (base.containsKey(key)) {
+      return base.get(key).andThen(v -> f.apply(key, v));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public MapView<K, U> updated(final K key, final Deferred<U> value) {
+    final MapView<K, U> newDelta = delta == null ? new MapWrapper<>(HashTrieMap.empty()) : delta;
+    return new TransformedMapView<>(base, f, newDelta.updated(key, value));
+  }
+
+  @Override
+  public MapView<K, U> removed(final K key) {
+    if (base.containsKey(key) || (delta != null && delta.containsKey(key))) {
+      return new TransformedMapView<>(base.removed(key), f, delta != null ? delta.removed(key) : null);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public <U1> MapView<K, U1> map(final BiFunction<K, U, ? extends U1> f2) {
+    return new TransformedMapView<>(base, (k, v) -> f2.apply(k, f.apply(k, v)), delta != null ? delta.map(f2) : null);
+  }
+
+  @Override
+  public MapView<K, U> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(this, p);
+  }
+
+  @Override
+  public MapView<K, U> memoize() {
+    HashTrieMap<K, Deferred<U>> map = HashTrieMap.empty();
+    for (final K key : base.keys()) {
+      map = map.updated(key, Deferred.covCast(base.get(key).andThen(v -> f.apply(key, v)).memoize()));
+    }
+    if (delta != null) {
+      for (final K key : delta.keys()) {
+        map = map.updated(key, delta.get(key).memoize());
+      }
+    }
+    return new MapWrapper<>(map);
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, Deferred<U>>> iterator() {
+    return Iterables.mapIterable(keys, k -> MapView.entryFor(k, get(k))).iterator();
+  }
+}
+
+class JavaMapView<K, V> implements MapView<K, V> {
+
+  private final Map<K, V> wrapped;
+  private final SetView<K> keys;
+  private final MapView<K, V> delta;
+  private final HashTrieSet<K> removals;
+
+
+  JavaMapView(final Map<K, V> wrapped, final MapView<K, V> delta, final HashTrieSet<K> removals) {
+    this.wrapped = wrapped;
+    this.delta = delta;
+    HashTrieSet<K> keysBuilder = HashTrieSet.from(wrapped.keySet());
+    if (delta != null) {
+      for (final K key : delta.keys()) {
+        keysBuilder = keysBuilder.added(key);
+      }
+    }
+    if (removals != null) {
+      for (final K key : removals) {
+        keysBuilder = keysBuilder.removed(key);
+      }
+    }
+    keys = SetView.wrap(keysBuilder);
+    this.removals = removals;
+  }
+
+  @Override
+  public SetView<K> keys() {
+    return keys;
+  }
+
+  @Override
+  public Deferred<V> get(final K key) {
+    if (delta != null && delta.containsKey(key)) {
+      return delta.get(key);
+    } else if ((removals == null || !removals.contains(key) && wrapped.containsKey(key))) {
+      return Deferred.value(wrapped.get(key));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public MapView<K, V> updated(final K key, final Deferred<V> value) {
+
+    return new JavaMapView<>(wrapped, delta.updated(key, value), removals == null ? null : removals.removed(key));
+  }
+
+  @Override
+  public MapView<K, V> removed(final K key) {
+    if ((removals == null || !removals.contains(key)) && wrapped.containsKey(key)) {
+      return new JavaMapView<>(wrapped, delta.removed(key),
+          removals == null ? HashTrieSet.<K>empty().added(key) : removals.added(key));
+    } else if (delta.containsKey(key)) {
+      return new JavaMapView<>(wrapped, delta.removed(key), removals);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public <U> MapView<K, U> map(final BiFunction<K, V, ? extends U> f) {
+    return new TransformedMapView<>(this, f, null);
+  }
+
+  @Override
+  public MapView<K, V> filter(final Predicate<K> p) {
+    return new FilteredMapView<>(this, p);
+  }
+
+  @Override
+  public MapView<K, V> memoize() {
+    HashTrieMap<K, Deferred<V>> map = HashTrieMap.empty();
+    for (final Map.Entry<K, V> entry : wrapped.entrySet()) {
+      if (!removals.contains(entry.getKey())) {
+        map = map.updated(entry.getKey(), Deferred.value(entry.getValue()));
+      }
+    }
+    for (final K key : delta.keys()) {
+      if (!removals.contains(key)) {
+        map = map.updated(key, delta.get(key));
+      }
+    }
+    return new MapWrapper<>(map);
+  }
+
+  @Override
+  public Iterator<Map.Entry<K, Deferred<V>>> iterator() {
+    return Iterables.mapIterable(keys, k -> MapView.entryFor(k, get(k))).iterator();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapView.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MapView.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import swim.collections.HashTrieMap;
 import swim.collections.HashTrieSet;
 import swim.dataflow.graph.Iterables;
+import swim.util.Deferred;
 
 /**
  * Immutable view of the current state of a {@link MapJunction}.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MemoizingConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MemoizingConduit.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * {@link Conduit} that memoizes the values that pass through it.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MemoizingConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/MemoizingConduit.java
@@ -1,0 +1,27 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * {@link Conduit} that memoizes the values that pass through it.
+ *
+ * @param <T> The type of the values.
+ */
+public class MemoizingConduit<T> extends AbstractJunction<T> implements Conduit<T, T> {
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    emit(value.memoize());
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalConduit.java
@@ -1,0 +1,83 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Base class for conduits that have an auxiliary control stream to modify their behaviour.
+ *
+ * @param <In>    The type of the main inputs.
+ * @param <Out>   The type of the outputs.
+ * @param <Mode>  The type of the auxiliary control input.
+ * @param <State> The type of the internal state that is modified by the control input.
+ */
+public abstract class ModalConduit<In, Out, Mode, State> extends AbstractJunction2<In, Mode, Out> implements Junction2<In, Mode, Out> {
+
+  /**
+   * Change current mode of the conduit.
+   *
+   * @param mode The control value.
+   * @return The new value of the state.
+   */
+  protected abstract Deferred<State> changeMode(Deferred<Mode> mode);
+
+  /**
+   * Handle a change on the main input.
+   *
+   * @param modal The current value of the internal state.
+   * @param value The new input value.
+   */
+  protected abstract void notifyChange(Deferred<State> modal, Deferred<In> value);
+
+  /**
+   * The internal state.
+   */
+  private Deferred<State> state;
+  private final ValuePersister<Mode> modePersister;
+
+  /**
+   * @param init The initial value of the state.
+   */
+  protected ModalConduit(final State init) {
+    state = Deferred.value(init);
+    modePersister = null;
+  }
+
+  /**
+   * @param modePersister Persistence for mode.
+   * @param init The initial state.
+   */
+  protected ModalConduit(final ValuePersister<Mode> modePersister, final Deferred<State> init) {
+    state = init;
+    this.modePersister = modePersister;
+  }
+
+  protected void notifyChangeFirst(final Deferred<In> value) {
+    notifyChange(state, value);
+  }
+
+  protected void notifyChangeSecond(final Deferred<Mode> value) {
+    if (modePersister != null) {
+      final Deferred<Mode> memVal = value.memoize();
+      modePersister.set(memVal.get());
+      state = changeMode(memVal);
+    } else {
+      state = changeMode(value);
+    }
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Base class for conduits that have an auxiliary control stream to modify their behaviour.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredConduit.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Filtered conduit where the behaviour of the filtering is controlled by an auxiliary input.
+ *
+ * @param <T>    The type of the data.
+ * @param <Mode> The type of the auxiliary control values.
+ */
+public class ModalFilteredConduit<T, Mode> extends ModalConduit<T, T, Mode, Predicate<T>> {
+
+  private final Function<Mode, Predicate<T>> switcher;
+
+  /**
+   * @param init     The initial mode.
+   * @param switcher Switches the predicate according to the mode.
+   */
+  public ModalFilteredConduit(final Mode init, final Function<Mode, Predicate<T>> switcher) {
+    super(switcher.apply(init));
+    this.switcher = switcher;
+  }
+
+  /**
+   * @param modePersister Persistence for the mode.
+   * @param switcher      Switches the predicate according to the mode.
+   */
+  public ModalFilteredConduit(final ValuePersister<Mode> modePersister, final Function<Mode, Predicate<T>> switcher) {
+    super(modePersister, Deferred.value(switcher.apply(modePersister.get())));
+    this.switcher = switcher;
+  }
+
+  @Override
+  protected Deferred<Predicate<T>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher).memoize();
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<Predicate<T>> modal, final Deferred<T> value) {
+    final Deferred<T> memoized = value.memoize();
+    if (modal.get().test(memoized.get())) {
+      emit(memoized);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Filtered conduit where the behaviour of the filtering is controlled by an auxiliary input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredMapConduit.java
@@ -1,0 +1,126 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Filtered map conduit where the behaviour of the filtering is controlled by an auxiliary control input.
+ *
+ * @param <Key>   The type of the keys.
+ * @param <Value> The type of the values.
+ * @param <Mode>  The type of the control values
+ */
+public class ModalFilteredMapConduit<Key, Value, Mode> extends ModalMapConduit<Key, Key, Value, Value, Mode, BiPredicate<Key, Value>> {
+
+  private final Function<Mode, BiPredicate<Key, Value>> switcher;
+  private HashTrieMap<Key, Value> filtered = HashTrieMap.empty();
+  private Deferred<MapView<Key, Value>> view = null;
+
+  /**
+   * @param init     The initial value of the mode.
+   * @param switcher Switches the filter based on the mode.
+   */
+  public ModalFilteredMapConduit(final Mode init, final Function<Mode, BiPredicate<Key, Value>> switcher) {
+    super(switcher.apply(init));
+    this.switcher = switcher;
+  }
+
+  /**
+   * @param modePersister Persistence for the mode.
+   * @param switcher      Switches the filter based on the mode.
+   */
+  public ModalFilteredMapConduit(final ValuePersister<Mode> modePersister,
+                                 final Function<Mode, BiPredicate<Key, Value>> switcher) {
+    super(modePersister, switcher.apply(modePersister.get()));
+    this.switcher = switcher;
+  }
+
+  @Override
+  protected Deferred<BiPredicate<Key, Value>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher).memoize();
+  }
+
+  @Override
+  protected void didChangeMode(final Deferred<BiPredicate<Key, Value>> state) {
+    if (view != null) {
+      final BiPredicate<Key, Value> predicate = state.get();
+      final HashSet<Key> toRemove = new HashSet<>();
+      for (final Map.Entry<Key, Value> entry : filtered.entrySet()) {
+        if (!predicate.test(entry.getKey(), entry.getValue())) {
+          toRemove.add(entry.getKey());
+        }
+      }
+      final ArrayList<Pair<Key, Value>> toRestore = new ArrayList<>();
+      final MapView<Key, Value> matView = view.get();
+      for (final Map.Entry<Key, Deferred<Value>> entry : matView) {
+        final Key k = entry.getKey();
+        if (!filtered.containsKey(k)) {
+          final Value v = entry.getValue().get();
+          if (predicate.test(k, v)) {
+            toRestore.add(Pair.pair(k, v));
+          }
+        }
+      }
+
+      //The changes are simultaneous so we apply them all at once before emitting the events.
+      for (final Key key : toRemove) {
+        filtered = filtered.removed(key);
+      }
+      for (final Pair<Key, Value> entry : toRestore) {
+        filtered = filtered.updated(entry.getFirst(), entry.getSecond());
+      }
+      for (final Key key : toRemove) {
+        emitRemoval(key, MapView.wrap(filtered));
+      }
+      for (final Pair<Key, Value> entry : toRestore) {
+        emit(entry.getFirst(), Deferred.value(entry.getSecond()), Deferred.value(MapView.wrap(filtered)));
+      }
+    }
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<BiPredicate<Key, Value>> state, final Key key, final Deferred<Value> value, final Deferred<MapView<Key, Value>> map) {
+    view = map;
+    final BiPredicate<Key, Value> predicate = state.get();
+    final Value newVal = value.get();
+    if (predicate.test(key, newVal)) {
+      filtered = filtered.updated(key, newVal);
+      emit(key, newVal, Deferred.value(MapView.wrap(filtered)));
+    } else {
+      //If a key that was previously not filtered is now not passing the filter, remove it.
+      if (filtered.containsKey(key)) {
+        filtered = filtered.removed(key);
+        emitRemoval(key, Deferred.value(MapView.wrap(filtered)));
+      }
+    }
+  }
+
+  @Override
+  protected void notifyRemoval(final Deferred<BiPredicate<Key, Value>> state, final Key key, final Deferred<MapView<Key, Value>> map) {
+    view = map;
+    if (filtered.containsKey(key)) {
+      filtered = filtered.removed(key);
+      emitRemoval(key, Deferred.value(MapView.wrap(filtered)));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFilteredMapConduit.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import swim.collections.HashTrieMap;
 import swim.dataflow.graph.Pair;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Filtered map conduit where the behaviour of the filtering is controlled by an auxiliary control input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFlatMapConduit.java
@@ -22,6 +22,7 @@ import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that, for each values of its input, emits a sequence of output values on a configured period. The

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalFlatMapConduit.java
@@ -1,0 +1,170 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.function.Function;
+import swim.collections.FingerTrieSeq;
+import swim.concurrent.AbstractTimer;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * {@link Conduit} that, for each values of its input, emits a sequence of output values on a configured period. The
+ * function that is applied is modified by an auxiliary control input. Additionally, the period for the outputs can
+ * be controlled using another input channel.
+ *
+ * @param <In>   The type of the inputs.
+ * @param <Out>  The type of the outputs.
+ * @param <Mode> The type of the control input.
+ */
+public class ModalFlatMapConduit<In, Out, Mode> extends AbstractJunction<Out> implements Junction3<In, Duration, Mode, Out> {
+
+  private FingerTrieSeq<Out> queue = FingerTrieSeq.empty();
+  private final Function<Mode, Function<In, Iterable<Out>>> switcher;
+  private Function<In, Iterable<Out>> flatMapFun;
+  private final AbstractTimer timer;
+  private final ValuePersister<Duration> periodPersister;
+  private final ValuePersister<Mode> modePersister;
+
+  /**
+   * @param initMode The initial value of the mode.
+   * @param switcher Alters the function to apply depending on the mode.
+   * @param schedule Scheduler for timing the output emission.
+   * @param delay    Period between outputs.
+   */
+  public ModalFlatMapConduit(final Mode initMode,
+                             final Function<Mode, Function<In, Iterable<Out>>> switcher,
+                             final Schedule schedule,
+                             final Duration delay) {
+    this(new TrivialValuePersister<>(initMode),
+        switcher,
+        schedule,
+        new TrivialValuePersister<>(delay));
+  }
+
+  /**
+   * @param initMode The initial value of the mode.
+   * @param switcher Alters the function to apply depending on the mode.
+   * @param schedule Scheduler for timing the output emission.
+   * @param periodPersister Durable persistence for the period.
+   */
+  public ModalFlatMapConduit(final Mode initMode,
+                             final Function<Mode, Function<In, Iterable<Out>>> switcher,
+                             final Schedule schedule,
+                             final ValuePersister<Duration> periodPersister) {
+    this(new TrivialValuePersister<>(initMode),
+        switcher,
+        schedule,
+        periodPersister);
+  }
+
+  /**
+   * @param modePersister   Persistence for the mode.
+   * @param switcher Alters the function to apply depending on the mode.
+   * @param schedule Scheduler for timing the output emission.
+   * @param delay    Period between outputs.
+   */
+  public ModalFlatMapConduit(final ValuePersister<Mode> modePersister,
+                             final Function<Mode, Function<In, Iterable<Out>>> switcher,
+                             final Schedule schedule,
+                             final Duration delay) {
+    this(modePersister,
+        switcher,
+        schedule,
+        new TrivialValuePersister<>(delay));
+  }
+
+  /**
+   * @param modePersister   Persistence for the mode.
+   * @param switcher        Alters the function to apply depending on the mode.
+   * @param schedule        Scheduler for timing the output emission.
+   * @param periodPersister Durable persistence for the period.
+   */
+  public ModalFlatMapConduit(final ValuePersister<Mode> modePersister,
+                             final Function<Mode, Function<In, Iterable<Out>>> switcher,
+                             final Schedule schedule,
+                             final ValuePersister<Duration> periodPersister) {
+    Require.that(periodPersister.get() != null && Duration.ZERO.compareTo(periodPersister.get()) < 0,
+        "The delay must be positive.");
+    this.modePersister = modePersister;
+    this.switcher = switcher;
+    this.flatMapFun = switcher.apply(modePersister.get());
+    this.periodPersister = periodPersister;
+    timer = new AbstractTimer() {
+      @Override
+      public void runTimer() {
+        final FingerTrieSeq<Out> q = queue;
+        final Out toEmit = q.head();
+        queue = q.tail();
+        emit(toEmit);
+        if (!queue.isEmpty()) {
+          timerContext.reschedule(periodPersister.get().toMillis());
+        }
+      }
+    };
+    schedule.timer(timer);
+
+  }
+
+  private final Receptacle<In> dataReceptacle = new Receptacle<In>() {
+    @Override
+    public void notifyChange(final Deferred<In> value) {
+      final boolean wasEmpty = queue.isEmpty();
+      for (final Out val : flatMapFun.apply(value.get())) {
+        queue = queue.appended(val);
+      }
+      if (wasEmpty) {
+        timer.runTimer();
+      }
+    }
+  };
+
+  private final Receptacle<Duration> delayReceptacle = new Receptacle<Duration>() {
+    @Override
+    public void notifyChange(final Deferred<Duration> value) {
+      final Duration newDelay = value.get();
+      if (Duration.ZERO.compareTo(newDelay) < 0) {
+        periodPersister.set(newDelay);
+      }
+    }
+  };
+
+  private final Receptacle<Mode> modeReceptacle = new Receptacle<Mode>() {
+    @Override
+    public void notifyChange(final Deferred<Mode> value) {
+      final Mode mode = value.get();
+      modePersister.set(mode);
+      flatMapFun = switcher.apply(mode);
+    }
+  };
+
+  @Override
+  public Receptacle<In> first() {
+    return dataReceptacle;
+  }
+
+  @Override
+  public Receptacle<Duration> second() {
+    return delayReceptacle;
+  }
+
+  @Override
+  public Receptacle<Mode> third() {
+    return modeReceptacle;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFetchConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFetchConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that selects values from a {@link MapJunction} according to a variable key.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFetchConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFetchConduit.java
@@ -1,0 +1,70 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * {@link Conduit} that selects values from a {@link MapJunction} according to a variable key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class ModalKeyFetchConduit<K, V> extends AbstractJunction<V> {
+
+  private final ValuePersister<K> keyPersister;
+
+  private final Receptacle<K> keyReceptcale;
+
+  private final MapReceptacle<K, V> mapReceptacle = new MapReceptacle<K, V>() {
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      final K selected = keyPersister.get();
+      if (selected != null && selected.equals(key)) {
+        emit(value);
+      }
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+
+    }
+  };
+
+  public ModalKeyFetchConduit(final ValuePersister<K> keyPersister) {
+    this.keyPersister = keyPersister;
+    this.keyReceptcale = value -> this.keyPersister.set(value.get());
+  }
+
+  public ModalKeyFetchConduit() {
+    this(new TrivialValuePersister<>(null));
+  }
+
+  /**
+   * @return Channel to select the key.
+   */
+  public Receptacle<K> keySelector() {
+    return keyReceptcale;
+  }
+
+  /**
+   * @return Input channel for the map data.
+   */
+  public MapReceptacle<K, V> mapInput() {
+    return mapReceptacle;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFilterConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFilterConduit.java
@@ -1,0 +1,103 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Filtered {@link MapConduit} that filters solely by key using a predicate that is modified by an auxiliary control
+ * input.
+ *
+ * @param <Key>  The type of the keys.
+ * @param <Val>  The type of the values.
+ * @param <Mode> The type of the control values.
+ */
+public class ModalKeyFilterConduit<Key, Val, Mode> extends ModalMapConduit<Key, Key, Val, Val, Mode, Predicate<Key>> {
+
+  private final Function<Mode, Predicate<Key>> switcher;
+  private HashTrieSet<Key> keys = HashTrieSet.empty();
+  private Deferred<MapView<Key, Val>> view = null;
+
+  /**
+   * @param init     The initial value of the mode.
+   * @param switcher Alters the predicate based on the mode.
+   */
+  public ModalKeyFilterConduit(final Mode init, final Function<Mode, Predicate<Key>> switcher) {
+    super(switcher.apply(init));
+    this.switcher = switcher;
+  }
+
+  /**
+   * @param modePersister Persistence for the mode.
+   * @param switcher      Alters the predicate based on the mode.
+   */
+  public ModalKeyFilterConduit(final ValuePersister<Mode> modePersister,
+                               final Function<Mode, Predicate<Key>> switcher) {
+    super(modePersister, switcher.apply(modePersister.get()));
+    this.switcher = switcher;
+  }
+
+  @Override
+  protected Deferred<Predicate<Key>> changeMode(final Deferred<Mode> mode) {
+    if (view == null) {
+      return mode.andThen(switcher).memoize();
+    } else {
+      final Predicate<Key> newPredicate = switcher.apply(mode.get());
+
+      final MapView<Key, Val> matView = view.get();
+
+      final Deferred<MapView<Key, Val>> filteredView = Deferred.value(matView.filter(newPredicate));
+
+      for (final Map.Entry<Key, Deferred<Val>> entry : matView) {
+        final Key k = entry.getKey();
+        if (newPredicate.test(k)) {
+          if (!keys.contains(k)) {
+            keys = keys.added(k);
+            emit(k, entry.getValue(), filteredView);
+          }
+        } else if (keys.contains(k)) {
+          keys = keys.removed(k);
+          emitRemoval(k, filteredView);
+        }
+      }
+
+      return Deferred.value(newPredicate);
+    }
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<Predicate<Key>> state, final Key key, final Deferred<Val> value, final Deferred<MapView<Key, Val>> map) {
+    view = map;
+    final Predicate<Key> predicate = state.get();
+    if (predicate.test(key)) {
+      keys = keys.added(key);
+      emit(key, value, map.andThen(m -> m.filter(predicate)));
+    }
+  }
+
+  @Override
+  protected void notifyRemoval(final Deferred<Predicate<Key>> state, final Key key, final Deferred<MapView<Key, Val>> map) {
+    view = map;
+    final Predicate<Key> predicate = state.get();
+    if (predicate.test(key)) {
+      keys = keys.removed(key);
+      emitRemoval(key, map.andThen(m -> m.filter(predicate)));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFilterConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalKeyFilterConduit.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import swim.collections.HashTrieSet;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Filtered {@link MapConduit} that filters solely by key using a predicate that is modified by an auxiliary control

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalMapConduit.java
@@ -1,0 +1,108 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Base class for map conduits that have an auxiliary control stream to modify their behaviour.
+ *
+ * @param <KeyIn>  The type of the input keys.
+ * @param <KeyOut> The type of the output keys.
+ * @param <ValIn>  The type of the input values.
+ * @param <ValOut> The type of the output values.
+ * @param <Mode>   The type of the auxiliary control input.
+ * @param <State>  The type of the internal state that is modified by the control input.
+ */
+public abstract class ModalMapConduit<KeyIn, KeyOut, ValIn, ValOut, Mode, State> extends AbstractMapJunction2<KeyIn, KeyOut, ValIn, ValOut, Mode> {
+
+  /**
+   * Update the state for a new mode.
+   *
+   * @param mode The mode.
+   * @return The updated state value.
+   */
+  protected abstract Deferred<State> changeMode(Deferred<Mode> mode);
+
+  /**
+   * Called after the state changes.
+   * @param state The new state.
+   */
+  protected void didChangeMode(final Deferred<State> state) {
+
+  }
+
+  private Deferred<State> state;
+  private final ValuePersister<Mode> modePersister;
+
+  /**
+   * @param init The initial value of the state.
+   */
+  protected ModalMapConduit(final State init) {
+    state = Deferred.value(init);
+    this.modePersister = null;
+  }
+
+  protected ModalMapConduit(final ValuePersister<Mode> modePersister, final State init) {
+    this.modePersister = modePersister;
+    state = Deferred.value(init);
+  }
+
+  /**
+   * Handle an update on the main channel.
+   *
+   * @param state The current value of the state.
+   * @param keyIn The updated key.
+   * @param value The new value.
+   * @param map   View on the current state of the map.
+   */
+  protected abstract void notifyChange(Deferred<State> state,
+                                       KeyIn keyIn,
+                                       Deferred<ValIn> value,
+                                       Deferred<MapView<KeyIn, ValIn>> map);
+
+  /**
+   * Handle a removal on the main channel.
+   *
+   * @param state The current value of the state.
+   * @param keyIn The removed key.
+   * @param map   View on the current state of the map.
+   */
+  protected abstract void notifyRemoval(Deferred<State> state,
+                                        KeyIn keyIn,
+                                        Deferred<MapView<KeyIn, ValIn>> map);
+
+  @Override
+  protected final void notifyChange(final KeyIn keyIn, final Deferred<ValIn> value, final Deferred<MapView<KeyIn, ValIn>> map) {
+    notifyChange(state, keyIn, value, map);
+  }
+
+  @Override
+  protected void notifyRemoval(final KeyIn keyIn, final Deferred<MapView<KeyIn, ValIn>> map) {
+    notifyRemoval(state, keyIn, map);
+  }
+
+  @Override
+  protected final void notifyChange(final Deferred<Mode> value) {
+    if (modePersister != null) {
+      final Deferred<Mode> memVal = value.memoize();
+      modePersister.set(memVal.get());
+      state = changeMode(memVal);
+    } else {
+      state = changeMode(value);
+    }
+    didChangeMode(state);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalMapConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Base class for map conduits that have an auxiliary control stream to modify their behaviour.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Conduit that maintains an external state where the function that updates the state can be modified by an auxiliary

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulConduit.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Conduit that maintains an external state where the function that updates the state can be modified by an auxiliary
+ * control input.
+ *
+ * @param <In>    The input type.
+ * @param <Mode>  The type of the control values.
+ * @param <State> The type of the internal state.
+ */
+public class ModalStatefulConduit<In, Mode, State>
+    extends ModalConduit<In, State, Mode, BiFunction<State, In, State>> {
+
+
+  private final Function<Mode, BiFunction<State, In, State>> switcher;
+  private final ValuePersister<State> state;
+
+  @Override
+  protected Deferred<BiFunction<State, In, State>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher);
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<BiFunction<State, In, State>> modal, final Deferred<In> value) {
+    final State newState = modal.get().apply(state.get(), value.get());
+    state.set(newState);
+    emit(newState);
+  }
+
+  /**
+   * @param modePersister  External persistence for the mode.
+   * @param statePersister External persistence for the state.
+   * @param switcher       Controls the update function according to the mode.
+   */
+  public ModalStatefulConduit(final ValuePersister<Mode> modePersister,
+                              final ValuePersister<State> statePersister,
+                              final Function<Mode, BiFunction<State, In, State>> switcher) {
+    super(modePersister, Deferred.value(switcher.apply(modePersister.get())));
+    this.switcher = switcher;
+    this.state = statePersister;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulMapConduit.java
@@ -18,6 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import swim.dataflow.graph.persistence.MapPersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Map conduit that maintains an external state where the function that updates the state can be modified by an

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalStatefulMapConduit.java
@@ -1,0 +1,74 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Map conduit that maintains an external state where the function that updates the state can be modified by an
+ * auxiliary control input.
+ *
+ * @param <Key>   The key type.
+ * @param <ValIn> The input value type.
+ * @param <Mode>  The type of the control values.
+ * @param <State> The type of the internal state.
+ */
+public class ModalStatefulMapConduit<Key, ValIn, Mode, State>
+    extends ModalMapConduit<Key, Key, ValIn, State, Mode, BiFunction<State, ValIn, State>> {
+
+  private final MapPersister<Key, State> statePersister;
+  private final Function<Mode, BiFunction<State, ValIn, State>> switcher;
+
+  /**
+   * @param modePersister  External persistence for the mode.
+   * @param statePersister External persistence for the state.
+   * @param switcher       Alters the update function based on the mode.
+   */
+  public ModalStatefulMapConduit(final ValuePersister<Mode> modePersister,
+                                 final MapPersister<Key, State> statePersister,
+                                 final Function<Mode, BiFunction<State, ValIn, State>> switcher) {
+    super(modePersister, switcher.apply(modePersister.get()));
+    this.statePersister = statePersister;
+    this.switcher = switcher;
+  }
+
+  @Override
+  protected Deferred<BiFunction<State, ValIn, State>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher);
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<BiFunction<State, ValIn, State>> update,
+                              final Key key,
+                              final Deferred<ValIn> value,
+                              final Deferred<MapView<Key, ValIn>> map) {
+    final State existing = statePersister.getOrDefault(key);
+    final State newState = update.get().apply(existing, value.get());
+    statePersister.put(key, newState);
+    emit(key, newState, statePersister.get());
+  }
+
+  @Override
+  protected void notifyRemoval(final Deferred<BiFunction<State, ValIn, State>> state,
+                               final Key key, final Deferred<MapView<Key, ValIn>> map) {
+    if (statePersister.containsKey(key)) {
+      statePersister.remove(key);
+      emitRemoval(key, Deferred.value(statePersister.get()));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalTransformConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalTransformConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.Function;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Conduit that transforms its inputs using a function that can be modified by an auxiliary control input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalTransformConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ModalTransformConduit.java
@@ -1,0 +1,59 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Conduit that transforms its inputs using a function that can be modified by an auxiliary control input.
+ *
+ * @param <In>   The input type.
+ * @param <Out>  The output type.
+ * @param <Mode> The type of the control values.
+ */
+public class ModalTransformConduit<In, Out, Mode> extends ModalConduit<In, Out, Mode, Function<In, ? extends Out>> {
+
+  private final Function<Mode, Function<In, ? extends Out>> switcher;
+
+  @Override
+  protected Deferred<Function<In, ? extends Out>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher).memoize();
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<Function<In, ? extends Out>> modal, final Deferred<In> value) {
+    emit(Deferred.apply(modal, value));
+  }
+
+  /**
+   * @param init     The initial value of the mode.
+   * @param switcher Alters the transform based on the mode.
+   */
+  public ModalTransformConduit(final Mode init, final Function<Mode, Function<In, ? extends Out>> switcher) {
+    super(switcher.apply(init));
+    this.switcher = switcher;
+  }
+
+  /**
+   * @param switcher Alters the transform based on the mode.
+   */
+  public ModalTransformConduit(final ValuePersister<Mode> modePersister,
+                               final Function<Mode, Function<In, ? extends Out>> switcher) {
+    super(modePersister, Deferred.value(switcher.apply(modePersister.get())));
+    this.switcher = switcher;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/PeriodicConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/PeriodicConduit.java
@@ -15,10 +15,11 @@
 package swim.dataflow.connector;
 
 import java.time.Duration;
+import swim.concurrent.Recurring;
 import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
 import swim.dataflow.graph.StreamInterpretation;
-import swim.dataflow.graph.impl.Recurring;
+import swim.util.Deferred;
 
 /**
  * Conduit that emits its outputs on a timer rather than on receipt of input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/PeriodicConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/PeriodicConduit.java
@@ -1,0 +1,78 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.impl.Recurring;
+
+/**
+ * Conduit that emits its outputs on a timer rather than on receipt of input.
+ *
+ * @param <T> The type of the data.
+ */
+public class PeriodicConduit<T> extends AbstractJunction<T> implements Receptacle<T> {
+
+  private Deferred<T> current = null;
+  private final Schedule schedule;
+  private Recurring recurring = null;
+  private final long periodMs;
+  private final StreamInterpretation interp;
+
+  /**
+   * @param schedule Scheduler for triggering the output.
+   * @param period   The period between output emit events.
+   * @param interp   The semantic interpretation of the stream.
+   */
+  public PeriodicConduit(final Schedule schedule,
+                         final Duration period,
+                         final StreamInterpretation interp) {
+    Require.that(Duration.ZERO.compareTo(period) < 0, "The period between outputs must be positive.");
+    this.schedule = schedule;
+    this.periodMs = period.toMillis();
+    this.interp = interp;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    current = value;
+    if (recurring == null) {
+      recurring = new Recurring(schedule, periodMs) {
+        @Override
+        protected void onTrigger() {
+          final Deferred<T> toEmit = current;
+          if (toEmit != null) {
+            if (interp == StreamInterpretation.DISCRETE) {
+              current = null;
+            }
+            emit(toEmit);
+          }
+        }
+      };
+      recurring.start();
+    }
+  }
+
+  /**
+   * Stop the periodic events.
+   */
+  public void stop() {
+    if (recurring != null) {
+      recurring.stop();
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/RateLimitedMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/RateLimitedMapConduit.java
@@ -18,11 +18,12 @@ import java.time.Duration;
 import java.util.Map;
 import swim.collections.HashTrieMap;
 import swim.collections.HashTrieSet;
+import swim.concurrent.Recurring;
 import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
-import swim.dataflow.graph.impl.Recurring;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Map conduit that emits its outputs on a timer rather than on receipt of input. The changes that occur between two

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/RateLimitedMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/RateLimitedMapConduit.java
@@ -1,0 +1,149 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.Map;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.impl.Recurring;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Map conduit that emits its outputs on a timer rather than on receipt of input. The changes that occur between two
+ * output events are saved up and then, when an output triggers, all keys that have changed in the interim are emitted.
+ * The period can be controlled by an auxiliary input.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class RateLimitedMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapJunction2<K, K, V, V, Duration> {
+
+  private HashTrieSet<K> keys = HashTrieSet.empty();
+  private HashTrieMap<K, Deferred<V>> delta = HashTrieMap.empty();
+  private HashTrieSet<K> removals = HashTrieSet.empty();
+  private Deferred<MapView<K, V>> view = null;
+
+  private final Schedule schedule;
+  private Recurring recurring = null;
+  private final ValuePersister<Duration> period;
+
+  /**
+   * @param schedule  Schedule used to trigger the output events.
+   * @param persister Durable persistence for the period.
+   */
+  public RateLimitedMapConduit(final Schedule schedule,
+                               final ValuePersister<Duration> persister) {
+    Require.that(Duration.ZERO.compareTo(persister.get()) < 0, "The period between outputs must be positive.");
+    this.schedule = schedule;
+    this.period = persister;
+  }
+
+  /**
+   * @param schedule Schedule used to trigger the output events.
+   * @param period   Period between events.
+   */
+  public RateLimitedMapConduit(final Schedule schedule,
+                               final Duration period) {
+    this(schedule, new TrivialValuePersister<>(period));
+  }
+
+  /**
+   * Start the timer that will trigger the outputs.
+   */
+  private void initTimer() {
+    recurring = new Recurring(schedule, period.get().toMillis()) {
+      @Override
+      protected void onTrigger() {
+        if (view != null) {
+          for (final Map.Entry<K, Deferred<V>> entry : delta) {
+            emit(entry.getKey(), entry.getValue(), view);
+            keys = keys.added(entry.getKey());
+          }
+          for (final K key : removals) {
+            emitRemoval(key, view);
+            keys = keys.removed(key);
+          }
+        }
+      }
+    };
+  }
+
+  /**
+   * Stop the periodic events.
+   */
+  public void stop() {
+    if (recurring != null) {
+      recurring.stop();
+    }
+  }
+
+  private final MapReceptacle<K, V> dataReceptacle = new MapReceptacle<K, V>() {
+
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      view = map;
+      if (removals.contains(key)) {
+        removals = removals.removed(key);
+      }
+      delta = delta.updated(key, value);
+      if (recurring == null) {
+        initTimer();
+        recurring.start();
+      }
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+      view = map;
+      if (delta.containsKey(key)) {
+        delta = delta.removed(key);
+      }
+      if (keys.contains(key)) {
+        removals = removals.added(key);
+      }
+      if (recurring == null) {
+        initTimer();
+        recurring.start();
+      }
+    }
+  };
+
+  @Override
+  public MapReceptacle<K, V> first() {
+    return dataReceptacle;
+  }
+
+  private final Receptacle<Duration> periodReceptacle = new Receptacle<Duration>() {
+    @Override
+    public void notifyChange(final Deferred<Duration> value) {
+      final Duration newPeriod = value.get();
+      if (Duration.ZERO.compareTo(newPeriod) < 0) {
+        period.set(newPeriod);
+        if (recurring != null) {
+          recurring.setPeriod(newPeriod.toMillis());
+        }
+      }
+    }
+  };
+
+  @Override
+  public Receptacle<Duration> second() {
+    return periodReceptacle;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Receptacle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Receptacle.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Interface for handlers that can consume the outputs of a {@link Junction}.
+ *
+ * @param <T> The type of the values.
+ */
+@FunctionalInterface
+public interface Receptacle<T> {
+
+  /**
+   * @param value The new value.
+   */
+  void notifyChange(Deferred<T> value);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Receptacle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/Receptacle.java
@@ -14,6 +14,8 @@
 
 package swim.dataflow.connector;
 
+import swim.util.Deferred;
+
 /**
  * Interface for handlers that can consume the outputs of a {@link Junction}.
  *

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ReduceFieldsConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ReduceFieldsConduit.java
@@ -1,0 +1,63 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import swim.collections.BTreeMap;
+
+/**
+ * Reduces the entries of a map to a sequence of values for each update/removal.
+ * @param <Key> The type of the map keys.
+ * @param <Value> The type of the map values.
+ * @param <Out> The reduced output type.
+ */
+public class ReduceFieldsConduit<Key, Value, Out> extends AbstractJunction<Out> implements MapToValueConduit<Key, Value, Out> {
+
+  private BTreeMap<Key, Value, Out> state = BTreeMap.empty();
+  private final Out seed;
+  private final BiFunction<Out, ? super Value, Out> operation;
+  private final BinaryOperator<Out> combiner;
+
+  /**
+   * @param seed Seed value for an empty map.
+   * @param operation Add a contribution into the reduction.
+   * @param combiner Combine together two sub-reductions.
+   */
+  public ReduceFieldsConduit(final Out seed,
+                             final BiFunction<Out, ? super Value, Out> operation,
+                             final BinaryOperator<Out> combiner) {
+    this.seed = seed;
+    this.operation = operation;
+    this.combiner = combiner;
+  }
+
+  @Override
+  public void notifyChange(final Key key, final Deferred<Value> value, final Deferred<MapView<Key, Value>> map) {
+    state = state.updated(key, value.get());
+    emitReduced();
+  }
+
+  private void emitReduced() {
+    final BTreeMap<Key, Value, Out> current = state;
+    emit(() -> current.reduced(seed, operation::apply, combiner::apply));
+  }
+
+  @Override
+  public void notifyRemoval(final Key key, final Deferred<MapView<Key, Value>> map) {
+    state = state.removed(key);
+    emitReduced();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ReduceFieldsConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ReduceFieldsConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import swim.collections.BTreeMap;
+import swim.util.Deferred;
 
 /**
  * Reduces the entries of a map to a sequence of values for each update/removal.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SamplingMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SamplingMapConduit.java
@@ -16,11 +16,12 @@ package swim.dataflow.connector;
 
 import java.time.Duration;
 import java.util.Map;
+import swim.concurrent.Recurring;
 import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
-import swim.dataflow.graph.impl.Recurring;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Map conduit that emits its outputs on a timer rather than on receipt of input. When the output triggers the entire

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SamplingMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SamplingMapConduit.java
@@ -1,0 +1,136 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.Map;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.impl.Recurring;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Map conduit that emits its outputs on a timer rather than on receipt of input. When the output triggers the entire
+ * contents of the map are reported downstream together with any keys that have been removed since the last trigger.
+ * The period can be controlled by an auxiliary input.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class SamplingMapConduit<K, V> extends AbstractMapJunction<K, V> implements MapJunction2<K, K, V, V, Duration> {
+
+  private MapView<K, V> oldView = null;
+  private Deferred<MapView<K, V>> nextView = null;
+  private final Schedule schedule;
+  private Recurring recurring = null;
+  private final ValuePersister<Duration> period;
+
+  /**
+   * @param schedule  Schedule for triggering outputs.
+   * @param persister Durable persistence for the period.
+   */
+  public SamplingMapConduit(final Schedule schedule,
+                            final ValuePersister<Duration> persister) {
+    Require.that(Duration.ZERO.compareTo(persister.get()) < 0, "The period must be positive.");
+    this.schedule = schedule;
+    this.period = persister;
+  }
+
+  /**
+   * @param schedule Schedule for triggering outputs.
+   * @param period   The period between output triggers.
+   */
+  public SamplingMapConduit(final Schedule schedule,
+                            final Duration period) {
+    this(schedule, new TrivialPersistenceProvider.TrivialValuePersister<>(period));
+  }
+
+  private void initTimer() {
+    recurring = new Recurring(schedule, period.get().toMillis()) {
+      @Override
+      protected void onTrigger() {
+        if (nextView != null) {
+          final MapView<K, V> nextMap = nextView.get();
+          final Deferred<MapView<K, V>> defMap = Deferred.value(nextMap);
+          if (oldView != null) {
+            for (final K key : oldView.keys()) {
+              if (!nextMap.containsKey(key)) {
+                emitRemoval(key, defMap);
+              }
+            }
+          }
+          for (final Map.Entry<K, Deferred<V>> entry : nextMap) {
+            emit(entry.getKey(), entry.getValue(), defMap);
+          }
+          oldView = nextMap;
+        }
+      }
+    };
+  }
+
+  /**
+   * Stop the periodic events.
+   */
+  public void stop() {
+    if (recurring != null) {
+      recurring.stop();
+    }
+  }
+
+  private final MapReceptacle<K, V> dataReceptacle = new MapReceptacle<K, V>() {
+
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      nextView = map;
+      if (recurring == null) {
+        initTimer();
+        recurring.start();
+      }
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+      nextView = map;
+      if (recurring == null) {
+        initTimer();
+        recurring.start();
+      }
+    }
+  };
+
+  @Override
+  public MapReceptacle<K, V> first() {
+    return dataReceptacle;
+  }
+
+  private final Receptacle<Duration> periodReceptacle = new Receptacle<Duration>() {
+    @Override
+    public void notifyChange(final Deferred<Duration> value) {
+      final Duration newPeriod = value.get();
+      if (Duration.ZERO.compareTo(newPeriod) < 0) {
+        period.set(newPeriod);
+        if (recurring != null) {
+          recurring.setPeriod(newPeriod.toMillis());
+        }
+      }
+    }
+  };
+
+  @Override
+  public Receptacle<Duration> second() {
+    return periodReceptacle;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SetView.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/SetView.java
@@ -1,0 +1,273 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Predicate;
+import swim.collections.HashTrieSet;
+
+/**
+ * An immutable view of the contents of a set.
+ *
+ * @param <T> The type of the elements.
+ */
+public interface SetView<T> extends Iterable<T> {
+
+  /**
+   * @return The size of the set.
+   */
+  int size();
+
+  /**
+   * @param value A value.
+   * @return Whether the set contains teh value.
+   */
+  boolean contains(T value);
+
+  /**
+   * Create a new set view that is the same as this one only with an additional value added.
+   *
+   * @param value The additional value.
+   * @return The new set view.
+   */
+  SetView<T> added(T value);
+
+  /**
+   * Create a new set view that is the same as this one only with a value removed.
+   *
+   * @param value The value to remove.
+   * @return The new set view.
+   */
+  SetView<T> removed(T value);
+
+  /**
+   * Create a new view based on this one but with some values filtered.
+   *
+   * @param p The predicate the filter the values.
+   * @return The filtered view.
+   */
+  SetView<T> filter(Predicate<T> p);
+
+  /**
+   * View a {@link HashTrieSet}.
+   *
+   * @param set The set to wrap.
+   * @param <T> The type of the elements.
+   * @return The view.
+   */
+  static <T> SetView<T> wrap(final HashTrieSet<T> set) {
+    return new SetWrapper<>(set);
+  }
+
+  /**
+   * View a Java set.
+   *
+   * @param set The set to wrap.
+   * @param <T> The type of the elements.
+   * @return The view.
+   */
+  static <T> SetView<T> wrap(final Set<T> set) {
+    return new JavaSetWrapper<>(set);
+  }
+}
+
+class FilteredIterator<T> implements Iterator<T> {
+  private final Iterator<T> inner;
+  private final Predicate<T> pred;
+  private T next;
+
+  FilteredIterator(final Iterator<T> inner, final Predicate<T> pred) {
+    this.inner = inner;
+    this.pred = pred;
+    next = null;
+    while (this.inner.hasNext()) {
+      final T value = inner.next();
+      if (pred.test(value)) {
+        next = value;
+        break;
+      }
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return next != null;
+  }
+
+  @Override
+  public T next() {
+    if (next == null) {
+      throw new NoSuchElementException();
+    }
+    final T current = next;
+    next = null;
+    while (this.inner.hasNext()) {
+      final T value = inner.next();
+      if (pred.test(value)) {
+        next = value;
+        break;
+      }
+    }
+    return current;
+  }
+}
+
+class FilteredSetView<T> implements SetView<T> {
+
+  private final SetView<T> wrapped;
+  private final Predicate<T> predicate;
+
+  FilteredSetView(final SetView<T> wrapped, final Predicate<T> prediate) {
+    this.wrapped = wrapped;
+    this.predicate = prediate;
+  }
+
+  private int size = -1;
+
+  @Override
+  public int size() {
+    if (size < 0) {
+      int n = 0;
+      for (final T val : wrapped) {
+        if (predicate.test(val)) {
+          ++n;
+        }
+      }
+      size = n;
+    }
+    return size;
+  }
+
+  @Override
+  public boolean contains(final T value) {
+    return predicate.test(value) && wrapped.contains(value);
+  }
+
+  @Override
+  public SetView<T> added(final T value) {
+    if (predicate.test(value) && !wrapped.contains(value)) {
+      return new FilteredSetView<>(wrapped.added(value), predicate);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public SetView<T> removed(final T value) {
+    if (!predicate.test(value) && wrapped.contains(value)) {
+      return new FilteredSetView<>(wrapped.removed(value), predicate);
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public SetView<T> filter(final Predicate<T> p) {
+    return new FilteredSetView<>(wrapped, predicate.and(p));
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return new FilteredIterator<>(wrapped.iterator(), predicate);
+  }
+}
+
+class SetWrapper<T> implements SetView<T> {
+
+  private final HashTrieSet<T> wrapped;
+
+  SetWrapper(final HashTrieSet<T> wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public int size() {
+    return wrapped.size();
+  }
+
+  @Override
+  public boolean contains(final T value) {
+    return wrapped.contains(value);
+  }
+
+  @Override
+  public SetView<T> added(final T value) {
+    return new SetWrapper<>(wrapped.added(value));
+  }
+
+  @Override
+  public SetView<T> removed(final T value) {
+    return new SetWrapper<>(wrapped.removed(value));
+  }
+
+  @Override
+  public SetView<T> filter(final Predicate<T> p) {
+    return new FilteredSetView<>(this, p);
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return wrapped.iterator();
+  }
+}
+
+class JavaSetWrapper<T> implements SetView<T> {
+
+  private final Set<T> wrapped;
+
+  JavaSetWrapper(final Set<T> wrapped) {
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public int size() {
+    return wrapped.size();
+  }
+
+  @Override
+  public boolean contains(final T value) {
+    return wrapped.contains(value);
+  }
+
+  @Override
+  public SetView<T> added(final T value) {
+    if (!wrapped.contains(value)) {
+      return new SetWrapper<>(HashTrieSet.from(wrapped).added(value));
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public SetView<T> removed(final T value) {
+    if (wrapped.contains(value)) {
+      return new SetWrapper<>(HashTrieSet.from(wrapped).removed(value));
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  public SetView<T> filter(final Predicate<T> p) {
+    return new FilteredSetView<>(this, p);
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return wrapped.iterator();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that maintains an external state.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduit.java
@@ -1,0 +1,47 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * {@link Conduit} that maintains an external state.
+ *
+ * @param <In>    The input type.
+ * @param <State> The state type.
+ */
+public class StatefulConduit<In, State> extends AbstractJunction<State> implements Conduit<In, State> {
+
+  private final ValuePersister<State> state;
+  private final BiFunction<State, In, State> update;
+
+  /**
+   * @param state  External persistence for the state.
+   * @param update Updates the state on new data.
+   */
+  public StatefulConduit(final ValuePersister<State> state,
+                         final BiFunction<State, In, State> update) {
+    this.state = state;
+    this.update = update;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<In> value) {
+    final State newState = update.apply(state.get(), value.get());
+    state.set(newState);
+    emit(newState);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduits.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduits.java
@@ -1,0 +1,321 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Utility methods to create common stateful conduits.
+ */
+public final class StatefulConduits {
+
+  private StatefulConduits() {
+  }
+
+  /**
+   * Create a conduit that performs a fold over it's inputs.
+   *
+   * @param initial The initial value of the state.
+   * @param foldOp  The fold operation.
+   * @param <In>    The input type.
+   * @param <State> The state/output type.
+   * @return The conduit.
+   */
+  public static <In, State> TransientStatefulConduit<In, State> fold(final State initial,
+                                                                     final BiFunction<State, In, State> foldOp) {
+    return new TransientStatefulConduit<>(Deferred.value(initial), (s, x) -> {
+      final State prev = s.get();
+      return x.andThen(in -> foldOp.apply(prev, in));
+    });
+  }
+
+  /**
+   * Create a conduit that performs a fold over it's inputs.
+   *
+   * @param foldOp  The fold operation.
+   * @param <In>    The input type.
+   * @param <State> The state/output type.
+   * @return The conduit.
+   */
+  public static <In, State> StatefulConduit<In, State> foldPersistent(final ValuePersister<State> persister,
+                                                                      final BiFunction<State, In, State> foldOp) {
+    return new StatefulConduit<>(persister, foldOp);
+  }
+
+  /**
+   * Create a conduit that performs a fold over the values for each key of its inputs.
+   *
+   * @param initial The initial value of the state.
+   * @param foldOp  The fold operation.
+   * @param <Key>   The type of the keys.
+   * @param <In>    The input type.
+   * @param <State> The state/output type.
+   * @return The conduit.
+   */
+  public static <Key, In, State> TransientStatefulMapConduit<Key, In, State> foldMap(final State initial,
+                                                                                     final BiFunction<State, In, State> foldOp) {
+    return new TransientStatefulMapConduit<>(Deferred.value(initial), (s, x) -> {
+      final State prev = s.get();
+      return x.andThen(in -> foldOp.apply(prev, in));
+    });
+  }
+
+  /**
+   * Create a conduit that performs a fold over the values for each key of its inputs.
+   *
+   * @param persister Persister for the map state.
+   * @param foldOp    The fold operation.
+   * @param <Key>     The type of the keys.
+   * @param <In>      The input type.
+   * @param <State>   The state/output type.
+   * @return The conduit.
+   */
+  public static <Key, In, State> StatefulMapConduit<Key, In, State> foldMapPersistent(final MapPersister<Key, State> persister,
+                                                                                      final BiFunction<State, In, State> foldOp) {
+    return new StatefulMapConduit<>(persister, foldOp);
+  }
+
+  /**
+   * Create a conduit that reduces its inputs with a binary operator.
+   *
+   * @param op  The operator.
+   * @param <T> The type of the inputs.
+   * @return The conduit.
+   */
+  public static <T> TransientStatefulConduit<T, T> reduce(final BinaryOperator<T> op) {
+    return new TransientStatefulConduit<>(Deferred.value(null), (s, x) -> {
+      final T prev = s.get();
+      return x.andThen(in -> prev == null ? in : op.apply(prev, in));
+    });
+  }
+
+  /**
+   * Create a conduit that reduces its inputs with a binary operator.
+   *
+   * @param op  The operator.
+   * @param <T> The type of the inputs.
+   * @return The conduit.
+   */
+  public static <T> StatefulConduit<T, T> reduce(final ValuePersister<T> persister,
+                                                 final BinaryOperator<T> op) {
+    return new StatefulConduit<>(persister, (s, x) -> s == null ? x : op.apply(s, x));
+  }
+
+  /**
+   * Create a conduit that reduces its inputs, for each key, with a binary operator.
+   *
+   * @param op    The operator.
+   * @param <Key> The type of the keys.
+   * @param <T>   The type of the inputs.
+   * @return The conduit.
+   */
+  public static <Key, T> TransientStatefulMapConduit<Key, T, T> reduceMap(final BinaryOperator<T> op) {
+    return new TransientStatefulMapConduit<>(Deferred.value(null), (s, x) -> {
+      final T prev = s.get();
+      return x.andThen(in -> prev == null ? in : op.apply(prev, in));
+    });
+  }
+
+  /**
+   * Create a conduit that reduces its inputs, for each key, with a binary operator.
+   *
+   * @param op    The operator.
+   * @param <Key> The type of the keys.
+   * @param <T>   The type of the inputs.
+   * @return The conduit.
+   */
+  public static <Key, T> StatefulMapConduit<Key, T, T> reduceMap(
+      final MapPersister<Key, T> persister,
+      final BinaryOperator<T> op) {
+    return new StatefulMapConduit<>(persister, (s, x) -> s == null ? x : op.apply(s, x));
+  }
+
+  /**
+   * Create a conduit that performs a fold over it's inputs. The fold operation can be modified by the value of an
+   * auxiliary input channel.
+   *
+   * @param initial  The initial value of the state.
+   * @param foldOp   The fold operation.
+   * @param initMode The initial value of the mode.
+   * @param <In>     The input type.
+   * @param <State>  The state/output type.
+   * @param <Mode>   The type of the control input.
+   * @return The conduit.
+   */
+  public static <In, State, Mode> TransientModalStatefulConduit<In, Mode, State> modalFold(
+      final Mode initMode,
+      final State initial,
+      final Function<Mode, BiFunction<State, In, State>> foldOp) {
+    return new TransientModalStatefulConduit<>(initMode, Deferred.value(initial), (Mode m) -> {
+      final BiFunction<State, In, State> op = foldOp.apply(m);
+      return (Deferred<State> s, Deferred<In> x) -> {
+        final State prev = s.get();
+        return x.andThen(in -> op.apply(prev, in));
+      };
+    });
+  }
+
+  /**
+   * Create a conduit that performs a fold over it's inputs. The fold operation can be modified by the value of an
+   * auxiliary input channel.
+   *
+   * @param modePersister  Persistence for the mode value.
+   * @param foldOp         The fold operation.
+   * @param statePersister Persistence for the state value.
+   * @param <In>           The input type.
+   * @param <State>        The state/output type.
+   * @param <Mode>         The type of the control input.
+   * @return The conduit.
+   */
+  public static <In, State, Mode> ModalStatefulConduit<In, Mode, State> modalFold(
+      final ValuePersister<Mode> modePersister,
+      final ValuePersister<State> statePersister,
+      final Function<Mode, BiFunction<State, In, State>> foldOp) {
+    return new ModalStatefulConduit<>(modePersister, statePersister, foldOp);
+  }
+
+  /**
+   * Create a conduit that reduces its inputs with a binary operator. The operator can be modified by the value of an
+   * auxiliary input channel.
+   *
+   * @param reduceOp The operator.
+   * @param initMode The initial value of the mode.
+   * @param <T>      The type of the inputs.
+   * @param <Mode>   The type of the control input.
+   * @return The conduit.
+   */
+  public static <T, Mode> TransientModalStatefulConduit<T, Mode, T> modalReduce(
+      final Mode initMode,
+      final Function<Mode, BinaryOperator<T>> reduceOp) {
+    return new TransientModalStatefulConduit<>(initMode, Deferred.value(null), (Mode m) -> {
+      final BinaryOperator<T> op = reduceOp.apply(m);
+      return (Deferred<T> s, Deferred<T> x) -> {
+        final T prev = s.get();
+        return x.andThen(in -> prev == null ? in : op.apply(prev, in));
+      };
+    });
+  }
+
+  /**
+   * Create a conduit that reduces its inputs with a binary operator. The operator can be modified by the value of an
+   * auxiliary input channel.
+   *
+   * @param reduceOp       The operator.
+   * @param modePersister  Persistence for the mode value.
+   * @param statePersister Persistence for the state value.
+   * @param <T>            The type of the inputs.
+   * @param <Mode>         The type of the control input.
+   * @return The conduit.
+   */
+  public static <T, Mode> ModalStatefulConduit<T, Mode, T> modalReduce(
+      final ValuePersister<Mode> modePersister,
+      final ValuePersister<T> statePersister,
+      final Function<Mode, BinaryOperator<T>> reduceOp) {
+    return new ModalStatefulConduit<>(modePersister, statePersister,
+        m -> (s, t) -> s == null ? t : reduceOp.apply(m).apply(s, t));
+  }
+
+  /**
+   * Create a conduit that performs a fold over the values for each key of its inputs. The fold operation can be
+   * modified by the value of an auxiliary input channel.
+   *
+   * @param initial  The initial value of the state.
+   * @param initMode The initial value of the mode.
+   * @param foldOp   The fold operation.
+   * @param <Key>    The type of the keys.
+   * @param <Val>    The input value type.
+   * @param <State>  The state/output type.
+   * @param <Mode>   The type of the control input.
+   * @return The conduit.
+   */
+  public static <Key, Val, State, Mode> TransientModalStatefulMapConduit<Key, Val, Mode, State> modalFoldMap(
+      final Mode initMode,
+      final State initial,
+      final Function<Mode, BiFunction<State, Val, State>> foldOp) {
+    return new TransientModalStatefulMapConduit<>(initMode, Deferred.value(initial), (Mode m) -> {
+      final BiFunction<State, Val, State> op = foldOp.apply(m);
+      return (Deferred<State> s, Deferred<Val> x) -> {
+        final State prev = s.get();
+        return x.andThen(in -> op.apply(prev, in));
+      };
+    });
+  }
+
+  /**
+   * Create a conduit that performs a fold over the values for each key of its inputs. The fold operation can be
+   * modified by the value of an auxiliary input channel.
+   *
+   * @param modePersister  Persistence for the mode value.
+   * @param statePersister Persistence for the state value.
+   * @param foldOp         The fold operation.
+   * @param <Key>          The type of the keys.
+   * @param <Val>          The input value type.
+   * @param <State>        The state/output type.
+   * @param <Mode>         The type of the control input.
+   * @return The conduit.
+   */
+  public static <Key, Val, State, Mode> ModalStatefulMapConduit<Key, Val, Mode, State> modalFoldMap(
+      final ValuePersister<Mode> modePersister,
+      final MapPersister<Key, State> statePersister,
+      final Function<Mode, BiFunction<State, Val, State>> foldOp) {
+    return new ModalStatefulMapConduit<>(modePersister, statePersister, foldOp);
+  }
+
+  /**
+   * Create a conduit that reduces its inputs, for each key, with a binary operator. The operator can be modified by
+   * the value of an auxiliary input channel.
+   *
+   * @param reduceOp The operator.
+   * @param initMode The initial value of the mode.
+   * @param <Key>    The type of the keys.
+   * @param <Val>    The input value type.
+   * @return The conduit.
+   */
+  public static <Key, Val, Mode> TransientModalStatefulMapConduit<Key, Val, Mode, Val> modalReduceMap(
+      final Mode initMode,
+      final Function<Mode, BinaryOperator<Val>> reduceOp) {
+    return new TransientModalStatefulMapConduit<>(initMode, Deferred.value(null), (Mode m) -> {
+      final BinaryOperator<Val> op = reduceOp.apply(m);
+      return (Deferred<Val> s, Deferred<Val> x) -> {
+        final Val prev = s.get();
+        return x.andThen(in -> prev == null ? in : op.apply(prev, in));
+      };
+    });
+  }
+
+  /**
+   * Create a conduit that reduces its inputs, for each key, with a binary operator. The operator can be modified by
+   * the value of an auxiliary input channel.
+   *
+   * @param reduceOp       The operator.
+   * @param modePersister  Persistence for the mode value.
+   * @param statePersister Persistence for the state value.
+   * @param <Key>          The type of the keys.
+   * @param <Val>          The input value type.
+   * @return The conduit.
+   */
+  public static <Key, Val, Mode> ModalStatefulMapConduit<Key, Val, Mode, Val> modalReduceMap(
+      final ValuePersister<Mode> modePersister,
+      final MapPersister<Key, Val> statePersister,
+      final Function<Mode, BinaryOperator<Val>> reduceOp) {
+    return new ModalStatefulMapConduit<>(modePersister, statePersister,
+        m -> (s, t) -> s == null ? t : reduceOp.apply(m).apply(s, t));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduits.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulConduits.java
@@ -19,6 +19,7 @@ import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import swim.dataflow.graph.persistence.MapPersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Utility methods to create common stateful conduits.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapCollector.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+import swim.dataflow.graph.persistence.MapPersister;
+
+/**
+ * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs. The current state
+ * of the map is stored persistently.
+ *
+ * @param <T> The type of the input values.
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+public class StatefulMapCollector<T, K, V> extends AbstractMapJunction<K, V> implements ValueToMapConduit<T, K, V> {
+
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+  private final MapPersister<K, V> persister;
+
+  /**
+   * @param toKey     Gets the map key for an input.
+   * @param toValue   Gets the map value for an input.
+   * @param persister Persistent store for the state of the map.
+   */
+  public StatefulMapCollector(final Function<T, K> toKey, final Function<T, V> toValue,
+                              final MapPersister<K, V> persister) {
+    this.toKey = toKey;
+    this.toValue = toValue;
+    this.persister = persister;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> el) {
+    final T element = el.get();
+    final K key = toKey.apply(element);
+    final V val = toValue.apply(element);
+    persister.put(key, val);
+    emit(key, val, Deferred.value(persister.get()));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapCollector.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.Function;
 import swim.dataflow.graph.persistence.MapPersister;
+import swim.util.Deferred;
 
 /**
  * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs. The current state

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
 import swim.dataflow.graph.persistence.MapPersister;
+import swim.util.Deferred;
 
 /**
  * {@link MapConduit} that maintains an internal state for each key.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/StatefulMapConduit.java
@@ -1,0 +1,52 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import swim.dataflow.graph.persistence.MapPersister;
+
+/**
+ * {@link MapConduit} that maintains an internal state for each key.
+ *
+ * @param <In>    The input type.
+ * @param <State> The state type.
+ */
+public class StatefulMapConduit<Key, In, State> extends AbstractMapJunction<Key, State> implements MapConduit<Key, Key, In, State> {
+
+  private final BiFunction<State, In, State> update;
+  private final MapPersister<Key, State> persister;
+
+  /**
+   * @param persister Persister for the state.
+   * @param update    Updates the state for new data.
+   */
+  public StatefulMapConduit(final MapPersister<Key, State> persister, final BiFunction<State, In, State> update) {
+    this.persister = persister;
+    this.update = update;
+  }
+
+  @Override
+  public void notifyChange(final Key key, final Deferred<In> value, final Deferred<MapView<Key, In>> map) {
+    final State updVal = update.apply(persister.getOrDefault(key), value.get());
+    persister.put(key, updVal);
+    emit(key, updVal, persister.get());
+  }
+
+  @Override
+  public void notifyRemoval(final Key key, final Deferred<MapView<Key, In>> map) {
+    persister.remove(key);
+    emitRemoval(key, persister.get());
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import java.util.function.Function;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that transforms the values of its input.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformConduit.java
@@ -1,0 +1,40 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+
+/**
+ * {@link Conduit} that transforms the values of its input.
+ *
+ * @param <In>  The input type.
+ * @param <Out> The transformed output type.
+ */
+public final class TransformConduit<In, Out> extends AbstractJunction<Out> implements Conduit<In, Out> {
+
+  private final Function<In, ? extends Out> f;
+
+  /**
+   * @param f The transformation function.
+   */
+  public TransformConduit(final Function<In, ? extends Out> f) {
+    this.f = f;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<In> value) {
+    emit(value.andThen(f));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformMapConduit.java
@@ -1,0 +1,46 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+
+/**
+ * {@link MapConduit} that transforms the map values with a function that depends on both the key and input value.
+ *
+ * @param <K>    The type of the keys.
+ * @param <VIn>  The type of the input values.
+ * @param <VOut> The type of the output values.
+ */
+public class TransformMapConduit<K, VIn, VOut> extends AbstractMapJunction<K, VOut> implements MapConduit<K, K, VIn, VOut> {
+
+  private final BiFunction<K, VIn, ? extends VOut> f;
+
+  /**
+   * @param f The transformation function.
+   */
+  public TransformMapConduit(final BiFunction<K, VIn, ? extends VOut> f) {
+    this.f = f;
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<VIn> value, final Deferred<MapView<K, VIn>> map) {
+    emit(key, value.andThen(v -> f.apply(key, v)), map.andThen(m -> m.map(f)));
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, VIn>> map) {
+    emitRemoval(key, map.andThen(m -> m.map(f)));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransformMapConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
+import swim.util.Deferred;
 
 /**
  * {@link MapConduit} that transforms the map values with a function that depends on both the key and input value.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientMapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientMapCollector.java
@@ -1,0 +1,50 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+
+/**
+ * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs.
+ *
+ * @param <T> The type of the input values.
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+public class TransientMapCollector<T, K, V> extends AbstractMapJunction<K, V> implements ValueToMapConduit<T, K, V> {
+
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+  private HashTrieMap<K, Deferred<V>> mapState = HashTrieMap.empty();
+
+  /**
+   * @param toKey   Gets the map key for an input.
+   * @param toValue Gets the map value for an input.
+   */
+  public TransientMapCollector(final Function<T, K> toKey, final Function<T, V> toValue) {
+    this.toKey = toKey;
+    this.toValue = toValue;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> el) {
+    final Deferred<T> memoized = el.memoize();
+    final K key = toKey.apply(memoized.get());
+    final Deferred<V> value = memoized.andThen(toValue);
+    mapState = mapState.updated(key, value);
+    emit(key, value, Deferred.value(MapView.wrap(mapState)));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientMapCollector.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientMapCollector.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.Function;
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * Collects values from a {@link Receptacle} and accumulates them into a map which it then outputs.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import swim.util.Deferred;
 
 /**
  * Conduit that maintains an internal state where the function that updates the state can be modified by an auxiliary

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulConduit.java
@@ -1,0 +1,58 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Conduit that maintains an internal state where the function that updates the state can be modified by an auxiliary
+ * control input.
+ *
+ * @param <In>    The input type.
+ * @param <Mode>  The type of the control values.
+ * @param <State> The type of the internal state.
+ */
+public final class TransientModalStatefulConduit<In, Mode, State>
+    extends ModalConduit<In, State, Mode, BiFunction<Deferred<State>, Deferred<In>, Deferred<State>>> {
+
+  private Deferred<State> state;
+  private final Function<Mode, BiFunction<Deferred<State>, Deferred<In>, Deferred<State>>> switcher;
+
+  /**
+   * @param initMode The initial value of the mode.
+   * @param init     The initial value of the state.
+   * @param switcher Controls the update function according to the mode.
+   */
+  public TransientModalStatefulConduit(final Mode initMode,
+                                       final Deferred<State> init,
+                                       final Function<Mode, BiFunction<Deferred<State>, Deferred<In>, Deferred<State>>> switcher) {
+    super(switcher.apply(initMode));
+    state = init;
+    this.switcher = switcher;
+  }
+
+  protected void notifyChange(final Deferred<BiFunction<Deferred<State>, Deferred<In>, Deferred<State>>> modal,
+                              final Deferred<In> value) {
+    final Deferred<State> current = state;
+    state = modal.andThen(upd -> upd.apply(current, value).get());
+    emit(state);
+  }
+
+  @Override
+  protected Deferred<BiFunction<Deferred<State>, Deferred<In>, Deferred<State>>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher).memoize();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulMapConduit.java
@@ -1,0 +1,74 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+
+/**
+ * Map conduit that maintains an internal state where the function that updates the state can be modified by an
+ * auxiliary control input.
+ *
+ * @param <Key>   The key type.
+ * @param <ValIn> The input value type.
+ * @param <Mode>  The type of the control values.
+ * @param <State> The type of the internal state.
+ */
+public class TransientModalStatefulMapConduit<Key, ValIn, Mode, State>
+    extends ModalMapConduit<Key, Key, ValIn, State, Mode, BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> {
+
+  private final Function<Mode, BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> switcher;
+  private HashTrieMap<Key, Deferred<State>> states = HashTrieMap.empty();
+  private final Deferred<State> seed;
+
+  @Override
+  protected Deferred<BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> changeMode(final Deferred<Mode> mode) {
+    return mode.andThen(switcher);
+  }
+
+  /**
+   * @param init     The initial value of the mode.
+   * @param seed     The initial value of the state.
+   * @param switcher Alters the update function based on the mode.
+   */
+  public TransientModalStatefulMapConduit(final Mode init,
+                                          final Deferred<State> seed,
+                                          final Function<Mode, BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> switcher) {
+    super(switcher.apply(init));
+    this.switcher = switcher;
+    this.seed = seed;
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> update,
+                              final Key key,
+                              final Deferred<ValIn> value,
+                              final Deferred<MapView<Key, ValIn>> map) {
+    final Deferred<State> existing = states.getOrDefault(key, seed);
+    final Deferred<State> newVal = update.get().apply(existing, value);
+    states = states.updated(key, newVal);
+    emit(key, newVal, Deferred.value(MapView.wrap(states)));
+  }
+
+  @Override
+  protected void notifyRemoval(final Deferred<BiFunction<Deferred<State>, Deferred<ValIn>, Deferred<State>>> state,
+                               final Key key,
+                               final Deferred<MapView<Key, ValIn>> map) {
+    states = states.removed(key);
+    emitRemoval(key, Deferred.value(MapView.wrap(states)));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientModalStatefulMapConduit.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * Map conduit that maintains an internal state where the function that updates the state can be modified by an

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulConduit.java
@@ -1,0 +1,46 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+
+/**
+ * {@link Conduit} that maintains an internal state.
+ *
+ * @param <In>    The input type.
+ * @param <State> The state type.
+ */
+public class TransientStatefulConduit<In, State> extends AbstractJunction<State> implements Conduit<In, State> {
+
+  private final BiFunction<Deferred<State>, Deferred<In>, Deferred<State>> update;
+  private Deferred<State> state;
+
+  /**
+   * @param init   Initial value of the state.
+   * @param update Updates the state on new data.
+   */
+  public TransientStatefulConduit(final Deferred<State> init,
+                                  final BiFunction<Deferred<State>, Deferred<In>, Deferred<State>> update) {
+    this.update = update;
+    state = init;
+  }
+
+  @Override
+  public void notifyChange(final Deferred<In> value) {
+    state = update.apply(state, value);
+    emit(state);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulConduit.java
@@ -15,6 +15,7 @@
 package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that maintains an internal state.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulMapConduit.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import java.util.function.BiFunction;
 import swim.collections.HashTrieMap;
+import swim.util.Deferred;
 
 /**
  * {@link MapConduit} that maintains an internal state for each key.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/TransientStatefulMapConduit.java
@@ -1,0 +1,55 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.function.BiFunction;
+import swim.collections.HashTrieMap;
+
+/**
+ * {@link MapConduit} that maintains an internal state for each key.
+ *
+ * @param <In>    The input type.
+ * @param <State> The state type.
+ */
+public class TransientStatefulMapConduit<Key, In, State> extends AbstractMapJunction<Key, State> implements MapConduit<Key, Key, In, State> {
+
+  private final BiFunction<Deferred<State>, Deferred<In>, Deferred<State>> update;
+  private HashTrieMap<Key, Deferred<State>> state = HashTrieMap.empty();
+  private final Deferred<State> seed;
+
+  /**
+   * @param seed   The initial value of the seed.
+   * @param update Updates the state for new data.
+   */
+  public TransientStatefulMapConduit(final Deferred<State> seed, final BiFunction<Deferred<State>, Deferred<In>, Deferred<State>> update) {
+    this.seed = seed;
+    this.update = update;
+  }
+
+  @Override
+  public void notifyChange(final Key key, final Deferred<In> value, final Deferred<MapView<Key, In>> map) {
+    final Deferred<State> updVal = update.apply(state.getOrDefault(key, seed), value);
+    state = state.updated(key, updVal);
+    emit(key, updVal, Deferred.value(MapView.wrap(state)));
+  }
+
+  @Override
+  public void notifyRemoval(final Key key, final Deferred<MapView<Key, In>> map) {
+    if (state.containsKey(key)) {
+      state = state.removed(key);
+      emitRemoval(key, Deferred.value(MapView.wrap(state)));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/UnionJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/UnionJunction.java
@@ -1,0 +1,50 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.Require;
+
+/**
+ * Junction that brings together any number of inputs, of the same type, and emits them all on a singel ouput.
+ *
+ * @param <T> The type of the values.
+ */
+public class UnionJunction<T> extends AbstractJunction<T> implements Bundle<T, T> {
+
+  private final FingerTrieSeq<Receptacle<T>> inputs;
+
+  /**
+   * @param numInputs The number of inputs to create.
+   */
+  public UnionJunction(final int numInputs) {
+    Require.that(numInputs > 1, "The number of inputs must be at least 2.");
+    FingerTrieSeq<Receptacle<T>> inputBuilder = FingerTrieSeq.empty();
+    for (int i = 0; i < numInputs; ++i) {
+      inputBuilder = inputBuilder.appended(this::emit);
+    }
+    inputs = inputBuilder;
+  }
+
+  public Receptacle<T> getInput(final int i) {
+    Require.that(i >= 0 && i < inputs.size(), "Input index must be in [0, %d).", inputs.size());
+    return inputs.get(i);
+  }
+
+  @Override
+  public Iterable<Receptacle<T>> inputs() {
+    return inputs;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ValueToMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/ValueToMapConduit.java
@@ -1,0 +1,25 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Conduit that consumes the values and outputs the values of a map.
+ *
+ * @param <KOut> The type of the output keys.
+ * @param <VOut> The type of the output values.
+ * @param <In> The type of the input.
+ */
+public interface ValueToMapConduit<In, KOut, VOut> extends Receptacle<In>, MapJunction<KOut, VOut> {
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayJunction.java
@@ -1,0 +1,70 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Junction that buffers the values it receives and emits the values a variable number of samples previous to the
+ * most recently received value.
+ *
+ * @param <T> The type of the values.
+ */
+public class VariableDelayJunction<T> extends AbstractJunction2<T, Integer, T> {
+
+  private final ListPersister<T> persister;
+  private final ValuePersister<Integer> step;
+
+  /**
+   * Store the buffer and number of delay samples persistently.
+   * @param persister Persistence for the buffer.
+   * @param step Persistence for the sample offset.
+   */
+  public VariableDelayJunction(final ListPersister<T> persister, final ValuePersister<Integer> step) {
+    Require.that(step.get() != null && step.get() >= 1, "Delay must be at least 1.");
+    this.persister = persister;
+    this.step = step;
+  }
+
+  /**
+   * Store the buffer and number of delay samples transiently.
+   * @param init The initial value of the sample offset.
+   */
+  public VariableDelayJunction(final int init) {
+    this(new TrivialListPersister<>(), new TrivialValuePersister<>(init));
+  }
+
+  @Override
+  protected void notifyChangeFirst(final Deferred<T> value) {
+    persister.append(value.get());
+    final int bufferSize = step.get() + 1;
+    persister.takeEnd(bufferSize);
+    if (persister.size() == bufferSize) {
+      emit(persister.get(0));
+    }
+  }
+
+  @Override
+  protected void notifyChangeSecond(final Deferred<Integer> value) {
+    final int newStep = value.get();
+    if (newStep >= 1) {
+      step.set(newStep);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayJunction.java
@@ -19,6 +19,7 @@ import swim.dataflow.graph.persistence.ListPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Junction that buffers the values it receives and emits the values a variable number of samples previous to the

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayMapJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayMapJunction.java
@@ -1,0 +1,121 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.Map;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Junction that buffers the values it receives and emits the values a variable number of samples previous to the
+ * most recently received value, for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class VariableDelayMapJunction<K, V> extends AbstractMapJunction2<K, K, V, V, Integer> {
+  private HashTrieMap<K, ListPersister<V>> buffers;
+  private final Function<K, ListPersister<V>> bufferPersisters;
+  private final SetPersister<K> keys;
+  private final ValuePersister<Integer> step;
+
+  /**
+   * Store the buffers persistently.
+   *
+   * @param bufferPersisters Factory for persistent buffers.
+   * @param keys             Persistence for the active keys.
+   * @param step             Number of samples of delay.
+   */
+  public VariableDelayMapJunction(final Function<K, ListPersister<V>> bufferPersisters,
+                                  final SetPersister<K> keys,
+                                  final ValuePersister<Integer> step) {
+    Require.that(step.get() != null && step.get() >= 1, "Delay must be at least 1.");
+    this.buffers = HashTrieMap.empty();
+    for (final K key : keys.get()) {
+      buffers = buffers.updated(key, bufferPersisters.apply(key));
+    }
+    this.bufferPersisters = bufferPersisters;
+    this.keys = keys;
+    this.step = step;
+  }
+
+  /**
+   * Store the buffers transiently.
+   *
+   * @param step Number of samples of delay.
+   */
+  public VariableDelayMapJunction(final int step) {
+    this(k -> new TrivialListPersister<>(), new TrivialSetPersisiter<>(), new TrivialValuePersister<>(step));
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+    ListPersister<V> buf = buffers.get(key);
+    if (buf == null) {
+      buf = bufferPersisters.apply(key);
+      buffers = buffers.updated(key, buf);
+      keys.add(key);
+    }
+    final int bufferSize = step.get() + 1;
+    buf.append(value.get());
+    buf.takeEnd(bufferSize);
+    if (buf.size() == bufferSize) {
+      final MapView<K, V> view = createView(bufferSize);
+      final V current = buf.get(0);
+      emit(key, current, view);
+    }
+  }
+
+  private MapView<K, V> createView(final int bufferSize) {
+    HashTrieMap<K, V> snapshot = HashTrieMap.empty();
+    for (final Map.Entry<K, ListPersister<V>> entry : buffers.entrySet()) {
+      final ListPersister<V> buf = entry.getValue();
+      if (buf.size() >= bufferSize) {
+        snapshot = snapshot.updated(entry.getKey(), buf.get(0));
+      }
+    }
+    return MapView.wrap(snapshot);
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    final ListPersister<V> buf = buffers.get(key);
+    if (buf != null) {
+      try {
+        buffers = buffers.removed(key);
+        keys.remove(key);
+      } finally {
+        buf.close();
+      }
+      final MapView<K, V> view = createView(step.get() + 1);
+      emitRemoval(key, view);
+    }
+  }
+
+  @Override
+  protected void notifyChange(final Deferred<Integer> value) {
+    final int newStep = value.get();
+    if (newStep >= 1) {
+      step.set(newStep);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayMapJunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableDelayMapJunction.java
@@ -24,6 +24,7 @@ import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPer
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Junction that buffers the values it receives and emits the values a variable number of samples previous to the

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableFlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableFlatMapConduit.java
@@ -22,6 +22,7 @@ import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * {@link Conduit} that, for each values of its input, emits a sequence of output values on a period that can be

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableFlatMapConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariableFlatMapConduit.java
@@ -1,0 +1,97 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.function.Function;
+import swim.collections.FingerTrieSeq;
+import swim.concurrent.AbstractTimer;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * {@link Conduit} that, for each values of its input, emits a sequence of output values on a period that can be
+ * controlled by an auxiliary input.
+ *
+ * @param <In>  The type of the inputs.
+ * @param <Out> The type of the outputs.
+ */
+public class VariableFlatMapConduit<In, Out> extends AbstractJunction2<In, Duration, Out> {
+
+  private FingerTrieSeq<Out> queue = FingerTrieSeq.empty();
+  private final Function<In, Iterable<Out>> flatMapFun;
+  private final AbstractTimer timer;
+  private final ValuePersister<Duration> period;
+
+  /**
+   * @param flatMapFun Function to transform the inputs to the outputs.
+   * @param schedule   Used to schedule the output emission.
+   * @param periodPersister Durable persistence for the period.
+   */
+  public VariableFlatMapConduit(final Function<In, Iterable<Out>> flatMapFun,
+                                final Schedule schedule,
+                                final ValuePersister<Duration> periodPersister) {
+    Require.that(periodPersister.get() != null && Duration.ZERO.compareTo(periodPersister.get()) < 0,
+        "The period between outputs must be positive.");
+    this.flatMapFun = flatMapFun;
+    this.period = periodPersister;
+    timer = new AbstractTimer() {
+      @Override
+      public void runTimer() {
+        final FingerTrieSeq<Out> q = queue;
+        final Out toEmit = q.head();
+        queue = q.tail();
+        emit(toEmit);
+        if (!queue.isEmpty()) {
+          timerContext.reschedule(period.get().toMillis());
+        }
+      }
+    };
+    schedule.timer(timer);
+  }
+
+  /**
+   * @param flatMapFun Function to transform the inputs to the outputs.
+   * @param schedule   Used to schedule the output emission.
+   * @param period The initial period between output emit events.
+   */
+  public VariableFlatMapConduit(final Function<In, Iterable<Out>> flatMapFun,
+                                final Schedule schedule,
+                                final Duration period) {
+    this(flatMapFun, schedule, new TrivialPersistenceProvider.TrivialValuePersister<>(period));
+  }
+
+  @Override
+  protected void notifyChangeFirst(final Deferred<In> value) {
+    final boolean wasEmpty = queue.isEmpty();
+    for (final Out val : flatMapFun.apply(value.get())) {
+      queue = queue.appended(val);
+    }
+    if (wasEmpty) {
+      timer.runTimer();
+    }
+  }
+
+  @Override
+  protected void notifyChangeSecond(final Deferred<Duration> value) {
+    final Duration delay = value.get();
+    if (Duration.ZERO.compareTo(delay) < 0) {
+      period.set(delay);
+    }
+
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariablePeriodicConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariablePeriodicConduit.java
@@ -1,0 +1,102 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.impl.Recurring;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Conduit that emits its outputs on a timer rather than on receipt of input. The period of the timer can be
+ * controlled by an auxiliary input.
+ *
+ * @param <T> The type of the data.
+ */
+public class VariablePeriodicConduit<T> extends AbstractJunction2<T, Duration, T> {
+
+  private Deferred<T> current = null;
+  private final Schedule schedule;
+  private Recurring recurring = null;
+  private final ValuePersister<Duration> period;
+  private final StreamInterpretation interp;
+
+  /**
+   * @param schedule      Scheduler for triggering the output.
+   * @param periodPersister Durable persistence for the period.
+   * @param interp        The semantic interpretation of the stream.
+   */
+  public VariablePeriodicConduit(final Schedule schedule,
+                                 final ValuePersister<Duration> periodPersister,
+                                 final StreamInterpretation interp) {
+    Require.that(periodPersister.get() != null && Duration.ZERO.compareTo(periodPersister.get()) < 0,
+        "The period between outputs must be positive.");
+    this.schedule = schedule;
+    this.period = periodPersister;
+    this.interp = interp;
+  }
+
+  /**
+   * @param schedule      Scheduler for triggering the output.
+   * @param initialPeriod The initial period between output emit events.
+   * @param interp        The semantic interpretation of the stream.
+   */
+  public VariablePeriodicConduit(final Schedule schedule,
+                                 final Duration initialPeriod,
+                                 final StreamInterpretation interp) {
+    this(schedule, new TrivialValuePersister<>(initialPeriod), interp);
+  }
+
+  @Override
+  protected void notifyChangeFirst(final Deferred<T> value) {
+    current = value;
+    if (recurring == null) {
+      recurring = new Recurring(schedule, period.get().toMillis()) {
+        @Override
+        protected void onTrigger() {
+          final Deferred<T> toEmit = current;
+          if (toEmit != null) {
+            if (interp == StreamInterpretation.DISCRETE) {
+              current = null;
+            }
+            emit(toEmit);
+          }
+        }
+      };
+      recurring.start();
+    }
+  }
+
+  @Override
+  protected void notifyChangeSecond(final Deferred<Duration> value) {
+    final Duration newPeriod = value.get();
+    if (Duration.ZERO.compareTo(newPeriod) < 0) {
+      period.set(newPeriod);
+      if (recurring != null) {
+        recurring.setPeriod(newPeriod.toMillis());
+      }
+    }
+  }
+
+
+  public void stop() {
+    if (recurring != null) {
+      recurring.stop();
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariablePeriodicConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/VariablePeriodicConduit.java
@@ -15,12 +15,13 @@
 package swim.dataflow.connector;
 
 import java.time.Duration;
+import swim.concurrent.Recurring;
 import swim.concurrent.Schedule;
 import swim.dataflow.graph.Require;
 import swim.dataflow.graph.StreamInterpretation;
-import swim.dataflow.graph.impl.Recurring;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
 import swim.dataflow.graph.persistence.ValuePersister;
+import swim.util.Deferred;
 
 /**
  * Conduit that emits its outputs on a timer rather than on receipt of input. The period of the timer can be

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/WithSideOutput.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector/WithSideOutput.java
@@ -1,0 +1,24 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+/**
+ * Interface for junctions that have an additional output.
+ *
+ * @param <T> The type of the output.
+ */
+public interface WithSideOutput<T> {
+  Junction<T> sideOutput();
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/BindingContext.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/BindingContext.java
@@ -1,0 +1,23 @@
+package swim.dataflow.graph;
+
+/**
+ * Context passed through {@link SwimStream} and {@link MapSwimStream} instances.
+ */
+public interface BindingContext {
+
+  <T> SinkHandle<Unit, T> bindSink(SwimStream<T> in, Sink<T> out);
+
+  <K, V> SinkHandle<K, V> bindSink(MapSwimStream<K, V> in, MapSink<K, V> out);
+
+  /**
+   * Create a unique ID for a stream.
+   * @return The ID.
+   */
+  String createId();
+
+  /**
+   * Cleam a unique ID for a stream.
+   * @param id The ID.
+   */
+  void claimId(String id);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/CollectionSwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/CollectionSwimStream.java
@@ -1,0 +1,67 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.structure.Form;
+
+/**
+ * Specialization of {@link SwimStream} for collections.
+ *
+ * @param <T> The type of the elements.
+ * @param <C> The collection type.
+ */
+public interface CollectionSwimStream<T, C extends Collection<T>> extends SwimStream<C> {
+
+  /**
+   * Convert this stream to a map stream where elements in the map are derived from elements of
+   * the collections.
+   *
+   * @param toKey     Function from stream values to map keys.
+   * @param toValue   Function from stream values to map values.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <K>       The type of the keys.
+   * @param <V>       The type of the values.
+   * @return The map stream.
+   */
+  <K, V> MapSwimStream<K, V> toMapStream(Function<T, K> toKey, Function<T, V> toValue,
+                                         Form<K> keyForm, Form<V> valueForm,
+                                         boolean isTransient);
+
+  /**
+   * Convert this stream to a map stream where elements in the map are derived from elements of
+   * the collections.
+   *
+   * @param toKey     Function from stream values to map keys.
+   * @param toValue   Function from stream values to map values.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param <K>       The type of the keys.
+   * @param <V>       The type of the values.
+   * @return The map stream.
+   */
+  default <K, V> MapSwimStream<K, V> toMapStream(final Function<T, K> toKey, final Function<T, V> toValue,
+                                                 final Form<K> keyForm, final Form<V> valueForm) {
+    return toMapStream(toKey, toValue, keyForm, valueForm, false);
+  }
+
+  @Override
+  CollectionSwimStream<T, C> updateTimestamps(ToLongFunction<C> datation);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Either.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Either.java
@@ -1,0 +1,292 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.Optional;
+import java.util.function.Function;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Kind;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Java representation of the co-product of two types.
+ *
+ * @param <L> The left hand type.
+ * @param <R> The right hand type.
+ */
+public interface Either<L, R> {
+
+  /**
+   * @return Whether this is a left value.
+   */
+  boolean isLeft();
+
+  /**
+   * @return Whether this is a right value.
+   */
+  boolean isRight();
+
+  /**
+   * Distinguish between left and right values.
+   *
+   * @param leftFun  Function to apply to left values.
+   * @param rightFun Function to apply to right values.
+   * @param <U>      Result type.
+   * @return The result value.
+   */
+  <U> U match(Function<L, U> leftFun, Function<R, U> rightFun);
+
+  /**
+   * @return A defined optional value if and only if this is a left value.
+   */
+  Optional<L> left();
+
+  /**
+   * @return A defined optional value if and only if this is a right value.
+   */
+  Optional<R> right();
+
+  /**
+   * @return A left value or a {@link IllegalArgumentException} if this is a right value.
+   */
+  L getLeft();
+
+  /**
+   * @return A right value or a {@link IllegalArgumentException} if this is a left value.
+   */
+  R getRight();
+
+  /**
+   * Create a left value.
+   *
+   * @param val The value.
+   * @param <S> The left type.
+   * @param <T> The right type.
+   * @return The left value.
+   */
+  static <S, T> Either<S, T> left(final S val) {
+    return new Left<>(val);
+  }
+
+  /**
+   * Create a right value.
+   *
+   * @param val The value.
+   * @param <S> The left type.
+   * @param <T> The right type.
+   * @return The left value.
+   */
+  static <S, T> Either<S, T> right(final T val) {
+    return new Right<>(val);
+  }
+
+  /**
+   * Create a {@link Form} for an {@link Either} value.
+   *
+   * @param leftForm  The form of the left type.
+   * @param rightForm The form of the right type.
+   * @param <S>       The left type.
+   * @param <T>       The right type.
+   * @return The form.
+   */
+  @Kind
+  static <S, T> Form<Either<S, T>> form(final Form<S> leftForm, final Form<T> rightForm) {
+    return new EitherForm<>(leftForm, rightForm);
+  }
+
+}
+
+class EitherForm<S, T> extends Form<Either<S, T>> {
+
+  private final Form<S> leftForm;
+  private final Form<T> rightForm;
+
+  EitherForm(final Form<S> leftForm, final Form<T> rightForm) {
+    this.leftForm = leftForm;
+    this.rightForm = rightForm;
+  }
+
+  @Override
+  public Class<?> type() {
+    return Either.class;
+  }
+
+  @Override
+  public Item mold(final Either<S, T> object) {
+    if (object != null) {
+      return object.match(left -> Record.create(1).attr("left", Record.create(1).item(leftForm.mold(left))),
+          right -> Record.create(1).attr("right", Record.create(1).item(rightForm.mold(right))));
+    } else {
+      return Item.absent();
+    }
+  }
+
+  @Override
+  public Either<S, T> cast(final Item item) {
+    final Value asValue = item.toValue();
+    final Value left = asValue.header("left");
+    if (left.isDefined()) {
+      final S leftVal = leftForm.cast(left.getItem(0));
+      return new Left<>(leftVal);
+    } else {
+      final Value right = asValue.header("right");
+      if (right.isDefined()) {
+        final T rightVal = rightForm.cast(right.getItem(0));
+        return new Right<>(rightVal);
+      } else {
+        return null;
+      }
+    }
+  }
+}
+
+/**
+ * Type of left values.
+ *
+ * @param <L> The left type.
+ * @param <R> The right type.
+ */
+class Left<L, R> implements Either<L, R> {
+
+  private final L value;
+
+  Left(final L val) {
+    Require.that(val != null, "Value must be non-null.");
+    value = val;
+  }
+
+  @Override
+  public boolean isLeft() {
+    return true;
+  }
+
+  @Override
+  public boolean isRight() {
+    return false;
+  }
+
+  @Override
+  public <U> U match(final Function<L, U> leftFun, final Function<R, U> rightFun) {
+    return leftFun.apply(value);
+  }
+
+  @Override
+  public Optional<L> left() {
+    return Optional.of(value);
+  }
+
+  @Override
+  public Optional<R> right() {
+    return Optional.empty();
+  }
+
+  @Override
+  public L getLeft() {
+    return value;
+  }
+
+  @Override
+  public R getRight() {
+    throw new IllegalArgumentException("Get right called on left value.");
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof Left) {
+      final Left<?, ?> other = (Left<?, ?>) obj;
+      return value.equals(other.value);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+
+}
+
+/**
+ * Type of right values.
+ *
+ * @param <L> The left type.
+ * @param <R> The right type.
+ */
+class Right<L, R> implements Either<L, R> {
+
+  private final R value;
+
+  Right(final R val) {
+    Require.that(val != null, "Value must be non-null.");
+    value = val;
+  }
+
+  @Override
+  public boolean isLeft() {
+    return false;
+  }
+
+  @Override
+  public boolean isRight() {
+    return true;
+  }
+
+  @Override
+  public <U> U match(final Function<L, U> leftFun, final Function<R, U> rightFun) {
+    return rightFun.apply(value);
+  }
+
+  @Override
+  public Optional<L> left() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<R> right() {
+    return Optional.of(value);
+  }
+
+  @Override
+  public L getLeft() {
+    throw new IllegalArgumentException("Get left called on right value.");
+  }
+
+  @Override
+  public R getRight() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof Right) {
+      final Right<?, ?> other = (Right<?, ?>) obj;
+      return value.equals(other.value);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Iterables.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Iterables.java
@@ -1,0 +1,136 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+/**
+ * Utility methods for manipulating {@link Iterable} instances.
+ */
+public final class Iterables {
+
+  private Iterables() {
+  }
+
+  /**
+   * Map a function across an {@link Iterable}.
+   *
+   * @param it  The iterable.
+   * @param f   The function.
+   * @param <S> The input type.
+   * @param <T> The output type.
+   * @return The mapped iterable.
+   */
+  public static <S, T> Iterable<T> mapIterable(final Iterable<? extends S> it, final Function<S, ? extends T> f) {
+
+    return () -> StreamSupport.stream(it.spliterator(), false).<T>map(f).iterator();
+  }
+
+  /**
+   * Filter the values of an iterable.
+   *
+   * @param it        The iterable.
+   * @param predicate Predicate on the values.
+   * @param <T>       The type of the values.
+   * @return The filtered iterable.
+   */
+  public static <T> Iterable<T> filterIterable(final Iterable<T> it, final Predicate<T> predicate) {
+    return () -> StreamSupport.stream(it.spliterator(), false).filter(predicate).iterator();
+  }
+
+  /**
+   * Flat-map a function across an {@link Iterable}.
+   *
+   * @param it  The iterable.
+   * @param f   The function.
+   * @param <S> The input type.
+   * @param <T> The output type.
+   * @return The mapped iterable.
+   */
+  public static <S, T> Iterable<T> flatMapIterable(final Iterable<? extends S> it, final Function<S, Iterable<T>> f) {
+
+    return () -> StreamSupport.stream(it.spliterator(), false)
+            .flatMap(v -> StreamSupport.stream(f.apply(v).spliterator(), false)).iterator();
+  }
+
+  /**
+   * Find the index of the first element of an iterable satisfying a predicate.
+   *
+   * @param iter The iterable.
+   * @param pred The predicate.
+   * @param <T>  The type of the elements.
+   * @return The index of the first element satisfying the predicate or -1 otherwise.
+   */
+  public static <T> int findFirstIndex(final Iterable<T> iter, final Predicate<T> pred) {
+    final Iterator<T> it = iter.iterator();
+    return findFirstIndex(it, pred);
+  }
+
+  /**
+   * Find the index of the first element of an iterator satisfying a predicate.
+   *
+   * @param it   The iterator.
+   * @param pred The predicate.
+   * @param <T>  The type of the elements.
+   * @return The index of the first element satisfying the predicate or -1 otherwise.
+   */
+  public static <T> int findFirstIndex(final Iterator<T> it, final Predicate<T> pred) {
+    int i = 0;
+    while (it.hasNext()) {
+      final T next = it.next();
+      if (pred.test(next)) {
+        return i;
+      } else {
+        ++i;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Find the index of the first element of an iterable satisfying a predicate.
+   *
+   * @param iter The iterable.
+   * @param pred The predicate.
+   * @param <T>  The type of the elements.
+   * @return The index of the first element satisfying the predicate or -1 otherwise.
+   */
+  public static <T> Optional<T> findFirst(final Iterable<T> iter, final Predicate<T> pred) {
+    final Iterator<T> it = iter.iterator();
+    return findFirst(it, pred);
+  }
+
+  /**
+   * Find the index of the first element of an iterator satisfying a predicate.
+   *
+   * @param it   The iterator.
+   * @param pred The predicate.
+   * @param <T>  The type of the elements.
+   * @return The index of the first element satisfying the predicate or -1 otherwise.
+   */
+  public static <T> Optional<T> findFirst(final Iterator<T> it, final Predicate<T> pred) {
+    while (it.hasNext()) {
+      final T next = it.next();
+      if (pred.test(next)) {
+        return Optional.of(next);
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/JoinKind.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/JoinKind.java
@@ -1,0 +1,26 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+/**
+ * Enumeration of supported join types.
+ */
+public enum JoinKind {
+  INNER,
+  LEFT,
+  RIGHT,
+  FULL
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapSink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapSink.java
@@ -1,0 +1,23 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import swim.dataflow.connector.MapReceptacle;
+
+public interface MapSink<K, V> {
+
+  MapReceptacle<K, V> instantiateReceptacle(SwimStreamContext.InitContext context);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapSwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapSwimStream.java
@@ -1,0 +1,1112 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.KeyedWindowSpec;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.streamlet.Inlet;
+import swim.streamlet.Outlet;
+import swim.structure.Form;
+
+/**
+ * An abstract stream of mappings from keys to values. In combination with {@link SwimStream} this is used to construct
+ * a directed graph of combinators which pump data from sources to sinks. The graph can then be instantiated against a
+ * set of source {@link Outlet}s and sink {@link Inlet}s to create an executable data-flow that can run inside a Swim
+ * agent.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public interface MapSwimStream<K, V> {
+
+  /**
+   * @return The unique identifier of this stream.
+   */
+  String id();
+
+  /**
+   * Set the unique identifier of this stream.
+   *
+   * @param id The new identifier.
+   * @return This stream.
+   */
+  MapSwimStream<K, V> setId(String id);
+
+  /**
+   * @return The form of the key type of the stream.
+   */
+  Form<K> keyForm();
+
+  /**
+   * @return The form of the value type of the stream.
+   */
+  Form<V> valueForm();
+
+  /**
+   * @return Timestamp assigner for the stream.
+   */
+  ToLongFunction<V> getTimestamps();
+
+  /**
+   * Replace the timestamps on the values in this stream.
+   *
+   * @param datation The timestamp assignment function.
+   * @return A copy of this stream with different timestamps.
+   */
+  MapSwimStream<K, V> updateTimestamps(ToLongFunction<V> datation);
+
+  /**
+   * @return A stream containing just the keys of this stream.
+   */
+  CollectionSwimStream<K, Set<K>> keys();
+
+  /**
+   * Transform the keys of this stream.
+   *
+   * @param f     The function to transform the keys.
+   * @param form  The from of the new key type.
+   * @param onRem Mapping from key removals.
+   * @param <K2>  The type of the new keys.
+   * @return A new stream with the keys transformed.
+   */
+  <K2> MapSwimStream<K2, V> mapKeys(BiFunction<K, V, ? extends K2> f, Function<K, Set<K2>> onRem, Form<K2> form);
+
+  /**
+   * Transform the keys of this stream.
+   *
+   * @param f     The function to transform the keys.
+   * @param onRem Mapping from key removals.
+   * @return A new stream with the keys transformed.
+   */
+  default MapSwimStream<K, V> mapKeys(final BiFunction<K, V, ? extends K> f, final Function<K, Set<K>> onRem) {
+    return mapKeys(f, onRem, keyForm());
+  }
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f       The function to transform the values.
+   * @param form    The form of the new value type.
+   * @param memoize Memoize the computed values.
+   * @param <V2>    The type of the new values.
+   * @return A new stream with the values transformed.
+   */
+  <V2> MapSwimStream<K, V2> mapValues(BiFunction<K, V, ? extends V2> f, boolean memoize, Form<V2> form);
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f    The function to transform the values.
+   * @param form The form of the new value type.
+   * @param <V2> The type of the new values.
+   * @return A new stream with the values transformed.
+   */
+  default <V2> MapSwimStream<K, V2> mapValues(final BiFunction<K, V, ? extends V2> f, final Form<V2> form) {
+    return mapValues(f, false, form);
+  }
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f The function to transform the values.
+   * @return A new stream with the values transformed.
+   */
+  default MapSwimStream<K, V> mapValues(final BiFunction<K, V, ? extends V> f) {
+    return mapValues(f, false, valueForm());
+  }
+
+  /**
+   * Transform both the keys and values of this stream.
+   *
+   * @param f     The function to transform the keys and values.
+   * @param onRem Mapping for key removals.
+   * @param kform The form of the new key type.
+   * @param vform The form of the new value type.
+   * @param <K2>  The type of the new keys.
+   * @param <V2>  The type of the new values.
+   * @return A new stream with the keys and values transformed.
+   */
+  <K2, V2> MapSwimStream<K2, V2> map(BiFunction<K, V, Pair<K2, V2>> f, Function<K, Set<K2>> onRem,
+                                     Form<K2> kform, Form<V2> vform);
+
+  /**
+   * Transform both the keys and values of this stream.
+   *
+   * @param f     The function to transform the keys and values.
+   * @param onRem Mapping for key removals.
+   * @return A new stream with the keys and values transformed.
+   */
+  default MapSwimStream<K, V> map(final BiFunction<K, V, Pair<K, V>> f, final Function<K, Set<K>> onRem) {
+    return map(f, onRem, keyForm(), valueForm());
+  }
+
+  /**
+   * Flat-map over the keys and values of this stream. For each key-value pair a sequence of new key-value pairs
+   * is generated, each of which becomes a new record in the transformed stream.
+   *
+   * @param f     The function to transform the key-value pairs.
+   * @param onRem Mapping for key removals.
+   * @param kform The form of the new key type.
+   * @param vform The form of the new value type.
+   * @param <K2>  The type of the new keys.
+   * @param <V2>  The type of the new values.
+   * @return A new stream with both the keys and values transformed.
+   */
+  <K2, V2> MapSwimStream<K2, V2> flatMap(BiFunction<K, V, Iterable<Pair<K2, V2>>> f,
+                                         Function<K, Set<K2>> onRem, Form<K2> kform, Form<V2> vform);
+
+  /**
+   * Flat-map over the keys and values of this stream. For each key-value pair a sequence of new key-value pairs
+   * is generated, each of which becomes a new record in the transformed stream.
+   *
+   * @param f     The function to transform the key-value pairs.
+   * @param onRem Mapping for key removals.
+   * @return A new stream with both the keys and values transformed.
+   */
+  default MapSwimStream<K, V> flatMap(final BiFunction<K, V, Iterable<Pair<K, V>>> f,
+                                      final Function<K, Set<K>> onRem) {
+    return flatMap(f, onRem, keyForm(), valueForm());
+  }
+
+  default SwimStream<V> get(final K key) {
+    return get(key, Sampling.eager());
+  }
+
+  /**
+   * Get the stream of values associated with a specific key.
+   *
+   * @param key      The key.
+   * @param sampling The sampling strategy for the link.
+   * @return The value stream.
+   */
+  SwimStream<V> get(K key, Sampling sampling);
+
+  /**
+   * Get the stream of values associated with a dynamically changing key.
+   *
+   * @param keys        The stream of keys.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return The value stream.
+   */
+  default SwimStream<V> get(final SwimStream<K> keys, final boolean isTransient) {
+    return get(keys, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Get the stream of values associated with a dynamically changing key.
+   *
+   * @param keys The stream of keys.
+   * @return The value stream.
+   */
+  default SwimStream<V> get(final SwimStream<K> keys) {
+    return get(keys, Sampling.eager());
+  }
+
+  /**
+   * Get the stream of values associated with a dynamically changing key.
+   *
+   * @param keys        The stream of keys.
+   * @param sampling    The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return The value stream.
+   */
+  SwimStream<V> get(SwimStream<K> keys, Sampling sampling, boolean isTransient);
+
+  /**
+   * Get the stream of values associated with a dynamically changing key.
+   *
+   * @param keys     The stream of keys.
+   * @param sampling The sampling strategy for the link.
+   * @return The value stream.
+   */
+  default SwimStream<V> get(final SwimStream<K> keys, final Sampling sampling) {
+    return get(keys, sampling, false);
+  }
+
+  /**
+   * Interpret this as a {@link SwimStream} of collections of {@link Pair}s of keys and values.
+   *
+   * @return The Key-Value stream.
+   */
+  SwimStream<Map<K, V>> stream();
+
+  /**
+   * Apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulations as computed by the operator.
+   *
+   * @param op       The operator.
+   * @param sampling Sampling strategy for the link (this will control which values the operator is applied to).
+   * @return A stream of running accumulations.
+   */
+  MapSwimStream<K, V> reduce(BinaryOperator<V> op, Sampling sampling, boolean isTransient);
+
+  /**
+   * Apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulations as computed by the operator.
+   *
+   * @param op       The operator.
+   * @param sampling Sampling strategy for the link (this will control which values the operator is applied to).
+   * @return A stream of running accumulations.
+   */
+  default MapSwimStream<K, V> reduce(final BinaryOperator<V> op, final Sampling sampling) {
+    return reduce(op, sampling, false);
+  }
+
+  /**
+   * Apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulations as computed by the operator.
+   *
+   * @param op The operator.
+   * @return A stream of running accumulations.
+   */
+  default MapSwimStream<K, V> reduce(final BinaryOperator<V> op, final boolean isTransient) {
+    return reduce(op, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulations as computed by the operator.
+   *
+   * @param op The operator.
+   * @return A stream of running accumulations.
+   */
+  default MapSwimStream<K, V> reduce(final BinaryOperator<V> op) {
+    return reduce(op, Sampling.eager());
+  }
+
+  /**
+   * Fold across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed     The seed value for the computation.
+   * @param op       The function to combine the values of this stream with the previously computed value.
+   * @param form     The form of the new values.
+   * @param sampling The sampling strategy for the link (this will control which values the function is applied to).
+   * @param isTransient Whether the stream stores its state.
+   * @param <U>      The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  <U> MapSwimStream<K, U> fold(U seed, BiFunction<U, V, U> op, Form<U> form, Sampling sampling, boolean isTransient);
+
+  /**
+   * Fold across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed     The seed value for the computation.
+   * @param op       The function to combine the values of this stream with the previously computed value.
+   * @param form     The form of the new values.
+   * @param sampling The sampling strategy for the link (this will control which values the function is applied to).
+   * @param <U>      The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> MapSwimStream<K, U> fold(final U seed, final BiFunction<U, V, U> op,
+                                       final Form<U> form, final Sampling sampling) {
+    return fold(seed, op, form, sampling, false);
+  }
+
+  /**
+   * Folded across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed The seed value for the computation.
+   * @param op   The function to combine the values of this stream with the previously computed value.
+   * @param form The form of the new values.
+   * @param isTransient Whether the stream stores its state.
+   * @param <U>  The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> MapSwimStream<K, U> fold(final U seed, final BiFunction<U, V, U> op,
+                                       final Form<U> form, final boolean isTransient) {
+    return fold(seed, op, form, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Folded across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed The seed value for the computation.
+   * @param op   The function to combine the values of this stream with the previously computed value.
+   * @param form The form of the new values.
+   * @param <U>  The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> MapSwimStream<K, U> fold(final U seed, final BiFunction<U, V, U> op, final Form<U> form) {
+    return fold(seed, op, form, Sampling.eager(), false);
+  }
+
+  /**
+   * Folded across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed        The seed value for the computation.
+   * @param op          The function to combine the values of this stream with the previously computed value.
+   * @param isTransient Whether the stream stores its state.
+   * @return A new stream of the applications of the function.
+   */
+  default MapSwimStream<K, V> fold(final V seed, final BiFunction<V, V, V> op, final boolean isTransient) {
+    return fold(seed, op, valueForm(), Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Folded across the values of the stream for a each key to produce a new stream. For each key and each sample taken
+   * from this stream apply the provided function to it and the previously computed value (starting with the specified
+   * seed). The output of the function is the new value of the stream for the key.
+   *
+   * @param seed The seed value for the computation.
+   * @param op   The function to combine the values of this stream with the previously computed value.
+   * @return A new stream of the applications of the function.
+   */
+  default MapSwimStream<K, V> fold(final V seed, final BiFunction<V, V, V> op) {
+    return fold(seed, op, valueForm(), Sampling.eager());
+  }
+
+  /**
+   * Modally apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulating as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param op            The modal operator.
+   * @param sampling      Sampling strategy for the link (this will control which values the operator is applied to).
+   * @param controlStream The control stream of the operator.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return A stream of running accumulations.
+   */
+  <M> MapSwimStream<K, V> reduceModal(M initialMode, Function<M, BinaryOperator<V>> op, Sampling sampling,
+                                      SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulating as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param op            The modal operator.
+   * @param sampling      Sampling strategy for the link (this will control which values the operator is applied to).
+   * @param controlStream The control stream of the operator.
+   * @return A stream of running accumulations.
+   */
+  default <M> MapSwimStream<K, V> reduceModal(final M initialMode, final Function<M, BinaryOperator<V>> op,
+                                              final Sampling sampling,
+                                              final SwimStream<M> controlStream) {
+    return reduceModal(initialMode, op, sampling, controlStream, false);
+  }
+
+  /**
+   * Modally apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulating as computed by the operator. The difference between this and {@link #reduce(BinaryOperator)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param op            The modal operator.
+   * @param controlStream The control stream of the operator.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return A stream of running accumulations.
+   */
+  default <M> MapSwimStream<K, V> reduceModal(final M initialMode,
+                                              final Function<M, BinaryOperator<V>> op, final SwimStream<M> controlStream,
+                                              final boolean isTransient) {
+    return reduceModal(initialMode, op, Sampling.eager(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally apply a binary operator across the values for each key of this stream. The new stream will maintain running
+   * accumulating as computed by the operator. The difference between this and {@link #reduce(BinaryOperator)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param op            The modal operator.
+   * @param controlStream The control stream of the operator.
+   * @return A stream of running accumulations.
+   */
+  default <M> MapSwimStream<K, V> reduceModal(final M initialMode,
+                                              final Function<M, BinaryOperator<V>> op, final SwimStream<M> controlStream) {
+    return reduceModal(initialMode, op, Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param sampling      The sampling strategy for the link (this will control which values the function is applied to).
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  <U, M> MapSwimStream<K, U> foldModal(M initialMode, U seed, Function<M, BiFunction<U, V, U>> op,
+                                       Form<U> form, Sampling sampling, SwimStream<M> controlStream,
+                                       boolean isTransient);
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param sampling      The sampling strategy for the link (this will control which values the function is applied to).
+   * @param controlStream The control stream of the update operation.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> MapSwimStream<K, U> foldModal(final M initialMode, final U seed,
+                                               final Function<M, BiFunction<U, V, U>> op,
+                                               final Form<U> form, final Sampling sampling,
+                                               final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, form, sampling, controlStream, false);
+  }
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> MapSwimStream<K, U> foldModal(final M initialMode, final U seed, final Function<M, BiFunction<U, V, U>> op,
+                                               final Form<U> form, final SwimStream<M> controlStream,
+                                               final boolean isTransient) {
+    return foldModal(initialMode, seed, op, form, Sampling.eager(), controlStream, isTransient);
+  }
+
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param controlStream The control stream of the update operation.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> MapSwimStream<K, U> foldModal(final M initialMode, final U seed, final Function<M, BiFunction<U, V, U>> op,
+                                               final Form<U> form, final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, form, Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A new stream of the applications of the function.
+   */
+  default <M> MapSwimStream<K, V> foldModal(final M initialMode, final V seed, final Function<M, BiFunction<V, V, V>> op,
+                                            final SwimStream<M> controlStream, final boolean isTransient) {
+    return foldModal(initialMode, seed, op, valueForm(), Sampling.eager(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally fold across the values of the stream for a each key to produce a new stream. For each key and each sample
+   * taken from this stream apply the provided function to it and the previously computed value (starting with the
+   * specified seed). The output of the function is the new value of the stream for the key. The difference between
+   * this and {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the
+   * behaviour of the update function.
+   *
+   * @param initialMode   The initial value of the mode.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param controlStream The control stream of the update operation.
+   * @return A new stream of the applications of the function.
+   */
+  default <M> MapSwimStream<K, V> foldModal(final M initialMode, final V seed, final Function<M, BiFunction<V, V, V>> op,
+                                            final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, valueForm(), Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Filter out elements from this stream.
+   *
+   * @param predicate Predicate to apply to the key-value pairs.
+   * @return The filtered stream.
+   */
+  MapSwimStream<K, V> filter(BiPredicate<K, V> predicate);
+
+  /**
+   * Modally filter out elements from this stream.
+   *
+   * @param initialMode    The initial value of the mode.
+   * @param modalPredicate Function to switch the predicate according to the mode.
+   * @param controlStream  Stream of modes.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <M>            The type of the modes.
+   * @return The filtered stream.
+   */
+  <M> MapSwimStream<K, V> filterModal(M initialMode, Function<M, BiPredicate<K, V>> modalPredicate,
+                                      SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally filter out elements from this stream.
+   *
+   * @param initialMode    The initial value of the mode.
+   * @param modalPredicate Function to switch the predicate according to the mode.
+   * @param controlStream  Stream of modes.
+   * @param <M>            The type of the modes.
+   * @return The filtered stream.
+   */
+  default <M> MapSwimStream<K, V> filterModal(final M initialMode, final Function<M, BiPredicate<K, V>> modalPredicate,
+                                              final SwimStream<M> controlStream) {
+    return filterModal(initialMode, modalPredicate, controlStream, false);
+  }
+
+  /**
+   * Filter out elements from this stream by key.
+   *
+   * @param predicate The key predicate.
+   * @return The filtered stream.
+   */
+  default MapSwimStream<K, V> filterKeys(final Predicate<K> predicate) {
+    return filter((k, v) -> predicate.test(k));
+  }
+
+  /**
+   * Modally filter out elements from this stream by key.
+   *
+   * @param initialMode    The initial value of the mode.
+   * @param modalPredicate Function to switch the predicate according to the mode.
+   * @param controlStream  Stream of modes.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <M>            The type of the modes.
+   * @return The filtered stream.
+   */
+  <M> MapSwimStream<K, V> filterKeysModal(M initialMode, Function<M, Predicate<K>> modalPredicate,
+                                          SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally filter out elements from this stream by key.
+   *
+   * @param initialMode    The initial value of the mode.
+   * @param modalPredicate Function to switch the predicate according to the mode.
+   * @param controlStream  Stream of modes.
+   * @param <M>            The type of the modes.
+   * @return The filtered stream.
+   */
+  default <M> MapSwimStream<K, V> filterKeysModal(final M initialMode, final Function<M, Predicate<K>> modalPredicate,
+                                                  final SwimStream<M> controlStream) {
+    return filterKeysModal(initialMode, modalPredicate, controlStream, false);
+  }
+
+  /**
+   * Apply a reduction over the keys and values of the instantaneous state of this stream.
+   *
+   * @param seed     The initial seed value.
+   * @param op       Operation to add a value to the aggregate value.
+   * @param combine  Combines together intermediate results.
+   * @param form     The form of the type of the result.
+   * @param sampling The sampling strategy of the link.
+   * @param <U>      The type of the results.
+   * @return The reduced stream.
+   */
+  <U> SwimStream<U> reduceKeyed(U seed, BiFunction<U, ? super V, U> op, BinaryOperator<U> combine, Form<U> form, Sampling sampling);
+
+  /**
+   * Apply a reduction over the keys and values of the instantaneous state of this stream.
+   *
+   * @param seed    The initial seed value.
+   * @param op      Operation to add a value to the aggregate value.
+   * @param combine Combines together intermediate results.
+   * @param form    The form of the type of the result.
+   * @param <U>     The type of the results.
+   * @return The reduced stream.
+   */
+  default <U> SwimStream<U> reduceKeyed(final U seed, final BiFunction<U, ? super V, U> op, final BinaryOperator<U> combine, final Form<U> form) {
+    return reduceKeyed(seed, op, combine, form, Sampling.eager());
+  }
+
+  /**
+   * Apply a reduction over the keys and values of the instantaneous state of this stream.
+   *
+   * @param seed    The initial seed value.
+   * @param op      Operation to add a value to the aggregate value.
+   * @param combine Combines together intermediate results.
+   * @return The reduced stream.
+   */
+  default SwimStream<V> reduceKeyed(final V seed, final BiFunction<V, ? super V, V> op, final BinaryOperator<V> combine) {
+    return reduceKeyed(seed, op, combine, valueForm(), Sampling.eager());
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+                                                                         Form<W> windowForm,
+                                                                         Sampling sampling,
+                                                                         boolean isTransient);
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+                                                                                 final Form<W> windowForm,
+                                                                                 final Sampling sampling) {
+    return window(assigner, windowForm, sampling, false);
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final TemporalWindowAssigner<V, W, S> assigner,
+                                                                                 final Form<W> windowForm,
+                                                                                 final Sampling sampling,
+                                                                                 final boolean isTransient) {
+    return window(k -> assigner, windowForm, sampling, isTransient);
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final TemporalWindowAssigner<V, W, S> assigner,
+                                                                                 final Form<W> windowForm,
+                                                                                 final Sampling sampling) {
+    return window(k -> assigner, windowForm, sampling);
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(
+      final Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+      final Form<W> windowForm,
+      final boolean isTransient) {
+    return window(assigner, windowForm, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(
+      final Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+      final Form<W> windowForm) {
+    return window(assigner, windowForm, Sampling.eager());
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(
+      final TemporalWindowAssigner<V, W, S> assigner,
+      final Form<W> windowForm,
+      final boolean isTransient) {
+    return window(k -> assigner, windowForm, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * For each key, divide the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(
+      final TemporalWindowAssigner<V, W, S> assigner,
+      final Form<W> windowForm) {
+    return window(k -> assigner, windowForm, Sampling.eager());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec     The specification of the windows.
+   * @param sampling The sampling strategy for the link.
+   * @param <W>      The type of the windows.
+   * @param <S>      The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final KeyedWindowSpec<K, V, W, S> spec,
+                                                                                 final Sampling sampling) {
+    return window(spec.getAssigner(), spec.getWindowForm(), sampling)
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setIsTransient(spec.isTransient());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec The specification of the windows.
+   * @param <W>  The type of the windows.
+   * @param <S>  The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final KeyedWindowSpec<K, V, W, S> spec) {
+    return window(spec.getAssigner(), spec.getWindowForm())
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setIsTransient(spec.isTransient());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec     The specification of the windows.
+   * @param sampling The sampling strategy for the link.
+   * @param <W>      The type of the windows.
+   * @param <S>      The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final WindowSpec<V, W, S> spec,
+                                                                                 final Sampling sampling) {
+    return window(spec.getAssigner(), spec.getWindowForm(), sampling)
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setIsTransient(spec.isTransient());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec The specification of the windows.
+   * @param <W>  The type of the windows.
+   * @param <S>  The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(final WindowSpec<V, W, S> spec) {
+    return window(spec.getAssigner(), spec.getWindowForm())
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setIsTransient(spec.isTransient());
+  }
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in on of the streams
+   * it will not occur in the new stream.
+   *
+   * @param other    The other stream.
+   * @param combiner Function used to combine the values.
+   * @param form     The form of the new value type.
+   * @param sampling The sampling strategy for the link.
+   * @param <V2>     The value type of the other stream.
+   * @param <U>      The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  <V2, U> MapSwimStream<K, U> join(MapSwimStream<K, V2> other, BiFunction<V, V2, U> combiner, Form<U> form, Sampling sampling);
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in one of the streams
+   * it will not occur in the new stream.
+   *
+   * @param other    The other stream.
+   * @param combiner Function used to combine the values.
+   * @param form     The form of the new value type.
+   * @param <V2>     The value type of the other stream.
+   * @param <U>      The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  default <V2, U> MapSwimStream<K, U> join(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner, final Form<U> form) {
+    return join(other, combiner, form, Sampling.eager());
+  }
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in this stream a
+   * value will be substituted. If a key is missing in other stream the value will be missing.
+   *
+   * @param other    The other stream.
+   * @param combiner Function used to combine the values.
+   * @param leftOnly Provides the substitute values on the left.
+   * @param form     The form of the new value type.
+   * @param sampling The sampling strategy for the link.
+   * @param <V2>     The value type of the other stream.
+   * @param <U>      The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  <V2, U> MapSwimStream<K, U> leftJoin(MapSwimStream<K, V2> other, BiFunction<V, V2, U> combiner,
+                                       Function<V, U> leftOnly, Form<U> form, Sampling sampling);
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in this stream a
+   * value will be substituted. If a key is missing in other stream the value will be missing.
+   *
+   * @param other    The other stream.
+   * @param combiner Function used to combine the values.
+   * @param leftOnly Provides the substitute values on the left.
+   * @param form     The form of the new value type.
+   * @param <V2>     The value type of the other stream.
+   * @param <U>      The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  default <V2, U> MapSwimStream<K, U> leftJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                               final Function<V, U> leftOnly, final Form<U> form) {
+    return leftJoin(other, combiner, leftOnly, form, Sampling.eager());
+  }
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in this stream a
+   * the value will be missing. If a key is missing in other stream a value will be substituted.
+   *
+   * @param other     The other stream.
+   * @param combiner  Function used to combine the values.
+   * @param rightOnly Provides the substitute values on the right.
+   * @param form      The form of the new value type.
+   * @param sampling  The sampling strategy for the link.
+   * @param <V2>      The value type of the other stream.
+   * @param <U>       The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  <V2, U> MapSwimStream<K, U> rightJoin(MapSwimStream<K, V2> other, BiFunction<V, V2, U> combiner,
+                                        Function<V2, U> rightOnly, Form<U> form, Sampling sampling);
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in this stream a
+   * the value will be missing. If a key is missing in other stream a value will be substituted.
+   *
+   * @param other     The other stream.
+   * @param combiner  Function used to combine the values.
+   * @param rightOnly Provides the substitute values on the right.
+   * @param form      The form of the new value type.
+   * @param <V2>      The value type of the other stream.
+   * @param <U>       The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  default <V2, U> MapSwimStream<K, U> rightJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                                final Function<V2, U> rightOnly, final Form<U> form) {
+    return rightJoin(other, combiner, rightOnly, form, Sampling.eager());
+  }
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in either stream a value
+   * will be substituted.
+   *
+   * @param other     The other stream.
+   * @param combiner  Function used to combine the values.
+   * @param leftOnly  Provides the substitute values on the left.
+   * @param rightOnly Provides the substitute values on the right.
+   * @param form      The form of the new value type.
+   * @param sampling  The sampling strategy for the link.
+   * @param <V2>      The value type of the other stream.
+   * @param <U>       The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  <V2, U> MapSwimStream<K, U> fullJoin(MapSwimStream<K, V2> other, BiFunction<V, V2, U> combiner,
+                                       Function<V, U> leftOnly, Function<V2, U> rightOnly,
+                                       Form<U> form, Sampling sampling);
+
+  /**
+   * Join this stream with another keyed streams. The values for each key in the new stream are computed from the
+   * currently sampled values for that key in the contributing streams. If a key is missing in either stream a value
+   * will be substituted.
+   *
+   * @param other     The other stream.
+   * @param combiner  Function used to combine the values.
+   * @param leftOnly  Provides the substitute values on the left.
+   * @param rightOnly Provides the substitute values on the right.
+   * @param form      The form of the new value type.
+   * @param <V2>      The value type of the other stream.
+   * @param <U>       The type of the combined values.
+   * @return A new stream containing the joined values.
+   */
+  default <V2, U> MapSwimStream<K, U> fullJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                               final Function<V, U> leftOnly, final Function<V2, U> rightOnly,
+                                               final Form<U> form) {
+    return fullJoin(other, combiner, leftOnly, rightOnly, form, Sampling.eager());
+  }
+
+  /**
+   * Create a stream that will always hold the first value received by this stream for each key.
+   *
+   * @param isTransient Whether to store the first values persistently.
+   * @param resetOnRemoval Whether the first value resets of key removal.
+   * @return The first value stream.
+   */
+  MapSwimStream<K, V> first(boolean resetOnRemoval, boolean isTransient);
+
+  /**
+   * Create a stream that will always hold the first value received by this stream for each key.
+   *
+   * @return The first value stream.
+   */
+  default MapSwimStream<K, V> first() {
+    return first(true, false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value, for each key.
+   *
+   * @param n           The number of steps back (must be at least 1).
+   * @param isTransient Whether to store the history persistently.
+   * @return The delayed stream.
+   */
+  MapSwimStream<K, V> delayed(int n, boolean isTransient);
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value, for each key.
+   *
+   * @param ns          Stream of the number of steps back (must be at least 1).
+   * @param isTransient Whether to store the history persistently.
+   * @param init        Initial delay.
+   * @return The delayed stream.
+   */
+  MapSwimStream<K, V> delayed(SwimStream<Integer> ns, int init, boolean isTransient);
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value, for each key.
+   *
+   * @param n The number of steps back (must be at least 1).
+   * @return The delayed stream.
+   */
+  default MapSwimStream<K, V> delayed(final int n) {
+    return delayed(n, false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value, for each key.
+   *
+   * @param ns   Stream of the number of steps back (must be at least 1).
+   * @param init Initial delay.
+   * @return The delayed stream.
+   */
+  default MapSwimStream<K, V> delayed(final SwimStream<Integer> ns, final int init) {
+    return delayed(ns, init, false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the previous value of
+   * this stream, for each key.
+   *
+   * @param isTransient Whether to store the history persistently.
+   * @return The delayed stream.
+   */
+  default MapSwimStream<K, V> previous(final boolean isTransient) {
+    return delayed(1, isTransient);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the previous value of
+   * this stream, for each key.
+   *
+   * @return The delayed stream.
+   */
+  default MapSwimStream<K, V> previous() {
+    return delayed(1, false);
+  }
+
+  /**
+   * Attach this stream to a sink.
+   *
+   * @param sink Descriptor of the sink.
+   * @return Handle for the graph leaf represented by this sink.
+   */
+  SinkHandle<K, V> bind(MapSink<K, V> sink);
+
+  /**
+   * Instantiate this stream as a node in a flow graph.
+   *
+   * @param context Initialization context to keep track of nodes in the graph.
+   * @return The outlet corresponding to this node.
+   */
+  MapJunction<K, V> instantiate(SwimStreamContext.InitContext context);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapWindowedSwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/MapWindowedSwimStream.java
@@ -1,0 +1,305 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import swim.dataflow.graph.windows.Group;
+import swim.dataflow.graph.windows.InvertibleFolder;
+import swim.dataflow.graph.windows.KeyedWindowBinOp;
+import swim.dataflow.graph.windows.KeyedWindowFoldFunction;
+import swim.dataflow.graph.windows.KeyedWindowFunction;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+/**
+ * A {@link MapSwimStream} that has been partitioned into (possibly overlapping) windows.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <W> The type of the windows.
+ */
+public interface MapWindowedSwimStream<K, V, W> {
+
+  /**
+   * @return The form of the key type.
+   */
+  Form<K> keyForm();
+
+  /**
+   * @return The form of the value type.
+   */
+  Form<V> valueForm();
+
+  /**
+   * @return The form of the window type.
+   */
+  Form<W> windowForm();
+
+  /**
+   * Collapse each window into a single value in a new stream.
+   *
+   * @param winFun Function to transform the window contents.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  <U> MapSwimStream<K, U> mapWindow(KeyedWindowFunction<K, V, W, U> winFun, Form<U> form);
+
+  /**
+   * Collapse each window into a single value in a new stream.
+   *
+   * @param winFun Function to transform the window contents.
+   * @return A stream containing the results.
+   */
+  default MapSwimStream<K, V> mapWindow(final KeyedWindowFunction<K, V, W, V> winFun) {
+    return mapWindow(winFun, valueForm());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded).
+   *
+   * @param seed     The initial value for the fold operation.
+   * @param winFun   The fold operation.
+   * @param combiner Combines intermediate results.
+   * @param form     The form of the result type.
+   * @param <U>      The result type.
+   * @return A stream containing the results.
+   */
+  <U> MapSwimStream<K, U> fold(U seed, KeyedWindowFoldFunction<K, V, W, U> winFun, BinaryOperator<U> combiner, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link V} is bounded).
+   *
+   * @param seed     The initial value for the fold operation.
+   * @param winFun   The fold operation.
+   * @param combiner Combines intermediate results.
+   * @return A stream containing the results.
+   */
+  default MapSwimStream<K, V> fold(final V seed, final KeyedWindowFoldFunction<K, V, W, V> winFun, final BinaryOperator<V> combiner) {
+    return fold(seed, winFun, combiner, valueForm());
+  }
+
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded).
+   *
+   * @param seed   The initial value for the fold operation.
+   * @param winFun The fold operation.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  default <U> MapSwimStream<K, U> fold(final U seed, final KeyedWindowFoldFunction<K, V, W, U> winFun, final Form<U> form) {
+    return fold(seed, winFun, null, form);
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link V} is bounded).
+   *
+   * @param seed   The initial value for the fold operation.
+   * @param winFun The fold operation.
+   * @return A stream containing the results.
+   */
+  default MapSwimStream<K, V> fold(final V seed, final KeyedWindowFoldFunction<K, V, W, V> winFun) {
+    return fold(seed, winFun, null, valueForm());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed     The seed initialization function.
+   * @param winFun   The fold operation.
+   * @param combiner Combines intermediate results.
+   * @param form     The form of the result type.
+   * @param <U>      The result type.
+   * @return A stream containing the results.
+   */
+  <U> MapSwimStream<K, U> foldByKeyWithCombiner(BiFunction<K, W, U> seed, KeyedWindowFoldFunction<K, V, W, U> winFun,
+                                                KeyedWindowBinOp<K, U, W> combiner, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link V} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed     The seed initialization function.
+   * @param winFun   The fold operation.
+   * @param combiner Combines intermediate results.
+   * @return A stream containing the results.
+   */
+  default MapSwimStream<K, V> foldByKeyWithCombiner(final BiFunction<K, W, V> seed,
+                                                    final KeyedWindowFoldFunction<K, V, W, V> winFun,
+                                                    final KeyedWindowBinOp<K, V, W> combiner) {
+    return foldByKeyWithCombiner(seed, winFun, combiner, valueForm());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed   The seed initialization function.
+   * @param winFun The fold operation.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  default <U> MapSwimStream<K, U> foldByKey(final BiFunction<K, W, U> seed,
+                                            final KeyedWindowFoldFunction<K, V, W, U> winFun, final Form<U> form) {
+    return foldByKeyWithCombiner(seed, winFun, null, form);
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(KeyedWindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link V} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed   The seed initialization function.
+   * @param winFun The fold operation.
+   * @return A stream containing the results.
+   */
+  default MapSwimStream<K, V> foldByKey(final BiFunction<K, W, V> seed,
+                                        final KeyedWindowFoldFunction<K, V, W, V> winFun) {
+    return foldByKeyWithCombiner(seed, winFun, null, valueForm());
+  }
+
+  /**
+   * Reduce each window into a single value in a new stream.
+   *
+   * @param op The binary operation on the values.
+   * @return A stream containing the results.
+   */
+  MapSwimStream<K, V> reduceByKey(KeyedWindowBinOp<K, V, W> op);
+
+  /**
+   * Reduce by key using a group operation.
+   *
+   * @param group The group.
+   * @return The reduced stream.
+   */
+  default MapSwimStream<K, V> groupReduce(final Group<V> group) {
+    return groupReduce((k, w) -> group);
+  }
+
+  /**
+   * Reduce by key using a group operation.
+   *
+   * @param group The group operation by key.
+   * @return The reduced stream.
+   */
+  default MapSwimStream<K, V> groupReduce(final BiFunction<K, W, Group<V>> group) {
+    return reduceByKey((k, w, t1, t2) -> group.apply(k, w).add(t1, t2));
+  }
+
+  /**
+   * Fold the streams using an invertible fold operation.
+   *
+   * @param folder The fold operation.
+   * @param form   The form of the output.
+   * @param <U>    The type of the output.
+   * @return The folded stream
+   */
+  default <U> MapSwimStream<K, U> fold(final InvertibleFolder<V, U> folder, final Form<U> form) {
+    return fold((k, w) -> folder, form);
+  }
+
+  /**
+   * Fold the streams using an invertible fold operation.
+   *
+   * @param folder The fold operation.
+   * @return The folded stream
+   */
+  default MapSwimStream<K, V> fold(final InvertibleFolder<V, V> folder) {
+    return fold((k, w) -> folder, valueForm());
+  }
+
+  /**
+   * Fold the streams using an invertible fold operation.
+   *
+   * @param folder The fold operation by key.
+   * @param form   The form of the output.
+   * @param <U>    The type of the output.
+   * @return The folded stream
+   */
+  default <U> MapSwimStream<K, U> fold(final BiFunction<K, W, InvertibleFolder<V, U>> folder, final Form<U> form) {
+    final BiFunction<K, W, U> seed = folder.andThen(InvertibleFolder::zero);
+    final KeyedWindowFoldFunction<K, V, W, U> foldOp = (k, w, t1, t2) -> folder.apply(k, w).add(t1, t2);
+    return foldByKeyWithCombiner(seed, foldOp, null, form);
+  }
+
+  /**
+   * Fold the streams using an invertible fold operation.
+   *
+   * @param folder The fold operation by key.
+   * @return The folded stream
+   */
+  default MapSwimStream<K, V> fold(final BiFunction<K, W, InvertibleFolder<V, V>> folder) {
+    return fold(folder, valueForm());
+  }
+
+  /**
+   * Change the trigger for the windowing on this stream.
+   *
+   * @param trigger The window trigger.
+   * @return Copy of this stream with a new trigger.
+   */
+  MapWindowedSwimStream<K, V, W> withTrigger(Function<K, Trigger<V, W>> trigger);
+
+  /**
+   * Change the trigger for the windowing on this stream.
+   *
+   * @param trigger The window trigger.
+   * @return Copy of this stream with a new trigger.
+   */
+  default MapWindowedSwimStream<K, V, W> withTrigger(final Trigger<V, W> trigger) {
+    return withTrigger(k -> trigger);
+  }
+
+  /**
+   * Change the eviction strategy for the windowing on this stream.
+   *
+   * @param eviction The eviction strategy.
+   * @return Copy of this stream with a new eviction strategy.
+   */
+  MapWindowedSwimStream<K, V, W> withEviction(Function<K, EvictionStrategy<V, W>> eviction);
+
+  /**
+   * Set whether the stream state is transient.
+   *
+   * @param isTransient Whether the stream is transient.
+   * @return Copy of this stream with the flag altered.
+   */
+  MapWindowedSwimStream<K, V, W> setIsTransient(boolean isTransient);
+
+  /**
+   * Change the eviction for the windowing on this stream.
+   *
+   * @param eviction The eviction strategy.
+   * @return Copy of this stream with a new eviction strategy.
+   */
+  default MapWindowedSwimStream<K, V, W> withEviction(final EvictionStrategy<V, W> eviction) {
+    return withEviction(k -> eviction);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Pair.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Pair.java
@@ -1,0 +1,149 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.ArrayList;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+import swim.util.Murmur3;
+
+/**
+ * A simple generic pair type.
+ *
+ * @param <S> The left type.
+ * @param <T> The right type.
+ */
+public class Pair<S, T> {
+
+  /**
+   * The left value.
+   */
+  private final S first;
+
+  /**
+   * The right value.
+   */
+  private final T second;
+
+  public Pair(final S fst, final T snd) {
+    Require.that(fst != null && snd != null, "Both components must be non-null.");
+    first = fst;
+    second = snd;
+  }
+
+  public final S getFirst() {
+    return first;
+  }
+
+  public final T getSecond() {
+    return second;
+  }
+
+  /**
+   * Create an instance.
+   *
+   * @param first  The left hand value.
+   * @param second The right hand value.
+   * @param <S>    The first type.
+   * @param <T>    The seond type.
+   * @return The pair.
+   */
+  public static <S, T> Pair<S, T> pair(final S first, final T second) {
+    return new Pair<>(first, second);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof Pair<?, ?>)) {
+      return false;
+    } else {
+      final Pair<?, ?> other = (Pair<?, ?>) obj;
+      return first.equals(other.first) && second.equals(other.second);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashSeed == 0) {
+      hashSeed = Murmur3.seed(Pair.class);
+    }
+    return Murmur3.mash(Murmur3.mix(Murmur3.mix(hashSeed, first.hashCode()), second.hashCode()));
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(%s, %s)", first, second);
+  }
+
+  private static int hashSeed;
+
+  /**
+   * Create a form for a pair type.
+   *
+   * @param left  The form for the left hand type.
+   * @param right The form for the right hand type.
+   * @param <S>   The left hand type.
+   * @param <T>   The right hand type.
+   * @return The pair form.
+   */
+  public static <S, T> Form<Pair<S, T>> form(final Form<S> left, final Form<T> right) {
+    return new PairForm<>(left, right);
+  }
+
+  private static final class PairForm<S, T> extends Form<Pair<S, T>> {
+
+    private final Form<S> left;
+    private final Form<T> right;
+
+    PairForm(final Form<S> l, final Form<T> r) {
+      left = l;
+      right = r;
+    }
+
+    @Override
+    public Class<?> type() {
+      return Pair.class;
+    }
+
+    @Override
+    public Item mold(final Pair<S, T> object) {
+      if (object != null) {
+        return Record.of(left.mold(object.getFirst()), right.mold(object.getSecond()));
+      } else {
+        return Item.extant();
+      }
+    }
+
+    @Override
+    public Pair<S, T> cast(final Item item) {
+      final Value val = item.toValue();
+      final ArrayList<Item> children = new ArrayList<>(2);
+      for (final Item child : val) {
+        children.add(child);
+      }
+      if (children.size() == 2) {
+        return new Pair<>(left.cast(children.get(0)), right.cast(children.get(1)));
+      } else {
+        return null;
+      }
+    }
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Require.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Require.java
@@ -1,0 +1,37 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+/**
+ * Convenient exception throwing assertions to check preconditions.
+ */
+public final class Require {
+
+  private Require() {
+  }
+
+  public static void that(final boolean condition, final String message) {
+    if (!condition) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  public static void that(final boolean condition, final String format, final Object... params) {
+    if (!condition) {
+      throw new IllegalArgumentException(String.format(format, params));
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Sink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Sink.java
@@ -1,0 +1,23 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import swim.dataflow.connector.Receptacle;
+
+public interface Sink<T> {
+
+  Receptacle<T> instantiate(SwimStreamContext.InitContext context);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SinkHandle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SinkHandle.java
@@ -1,0 +1,18 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+public interface SinkHandle<K, V> {
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/StreamInterpretation.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/StreamInterpretation.java
@@ -1,0 +1,22 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+public enum StreamInterpretation {
+
+  DISCRETE,
+  CONTINUOUS
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SwimStream.java
@@ -1,0 +1,1136 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.sampling.DelaySpecifier;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.CombinedState;
+import swim.dataflow.graph.windows.CombinedWindowAssigner;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.dataflow.graph.windows.PartitionState;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.streamlet.Inlet;
+import swim.streamlet.Outlet;
+import swim.structure.Form;
+
+/**
+ * An abstract stream of values. In combination with {@link MapSwimStream} this is used to construct a directed
+ * graph of combinators which pump data from sources to sinks. The graph can then be instantiated against a set of
+ * source {@link Outlet}s and sink {@link Inlet}s to create an executable data-flow that can run inside a Swim
+ * agent.
+ *
+ * @param <T> The type of the values.
+ */
+public interface SwimStream<T> {
+
+  /**
+   * @return The unique identifier of this stream.
+   */
+  String id();
+
+  /**
+   * Set the unique identifier of this stream.
+   *
+   * @param id The new identifier.
+   * @return This stream.
+   */
+  SwimStream<T> setId(String id);
+
+  /**
+   * @return The form of the stream value type.
+   */
+  Form<T> form();
+
+  /**
+   * @return Timestamp assigner for the stream.
+   */
+  ToLongFunction<T> getTimestamps();
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f       The function to transform the values.
+   * @param memoize Whether to memoize the result.
+   * @param form    The from of the new value type.
+   * @param <U>     The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  <U> SwimStream<U> map(Function<T, ? extends U> f, boolean memoize, Form<U> form);
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f    The function to transform the values.
+   * @param form The from of the new value type.
+   * @param <U>  The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  default <U> SwimStream<U> map(final Function<T, ? extends U> f, final Form<U> form) {
+    return map(f, false, form);
+  }
+
+  /**
+   * Transform the values of this stream.
+   *
+   * @param f The function to transform the values.
+   * @return A new stream with the values transformed.
+   */
+  default SwimStream<T> map(final Function<T, ? extends T> f) {
+    return map(f, false, form());
+  }
+
+  /**
+   * Transform the values of this stream into a collection of another type.
+   *
+   * @param f    The transformation function.
+   * @param form The form of the collection type.
+   * @param <U>  The element type.
+   * @param <C>  The collection type.
+   * @return The collection stream.
+   */
+  default <U, C extends Collection<U>> CollectionSwimStream<U, C> mapToCollection(final Function<T, C> f,
+                                                                                  final Form<C> form) {
+    return mapToCollection(f, false, form);
+  }
+
+  /**
+   * Transform the values of this stream into a collection of another type.
+   *
+   * @param f       The transformation function.
+   * @param memoize Whether to memoize the result.
+   * @param form    The form of the collection type.
+   * @param <U>     The element type.
+   * @param <C>     The collection type.
+   * @return The collection stream.
+   */
+  <U, C extends Collection<U>> CollectionSwimStream<U, C> mapToCollection(Function<T, C> f, boolean memoize, Form<C> form);
+
+  /**
+   * Consider only values of the state of the stream satisfying a predicate.
+   *
+   * @param predicate The predicate.
+   * @return The filtered stream.
+   */
+  SwimStream<T> filter(Predicate<T> predicate);
+
+  /**
+   * Consider only values of the state of the stream satisfying a predicate.
+   *
+   * @param intialMode    The initial value of the mode.
+   * @param predicate     The predicate.
+   * @param controlStream The stream of modes.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return The filtered stream.
+   */
+  <M> SwimStream<T> filterModal(M intialMode, Function<M, Predicate<T>> predicate,
+                                SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Consider only values of the state of the stream satisfying a predicate.
+   *
+   * @param intialMode    The initial value of the mode.
+   * @param predicate     The predicate.
+   * @param controlStream The stream of modes.
+   * @return The filtered stream.
+   */
+  default <M> SwimStream<T> filterModal(final M intialMode, final Function<M, Predicate<T>> predicate,
+                                        final SwimStream<M> controlStream) {
+    return filterModal(intialMode, predicate, controlStream, false);
+  }
+
+  /**
+   * Split the states of the stream by a predicate.
+   *
+   * @param predicate The predicate.
+   * @return Pair of stream the first containing the states that satisfy the predicate and the second those that
+   * do not.
+   */
+  Pair<SwimStream<T>, SwimStream<T>> split(Predicate<T> predicate);
+
+  /**
+   * Categorize the states of the stream by an enumeration.
+   *
+   * @param categories Function to assign the categories.
+   * @param enumType   The type of the enumeration.
+   * @param <E>        The type of the enumeration.
+   * @return Map from categories to streams.
+   */
+  <E extends Enum<E>> Map<E, SwimStream<T>> categorize(Function<T, E> categories, Class<E> enumType);
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param memoize       Whether to memoize the result.
+   * @param form          The from of the new value type.
+   * @param controlStream The control stream.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  <U, M> SwimStream<U> mapModal(M initialMode, Function<M, Function<T, ? extends U>> f, boolean memoize,
+                                Form<U> form, SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param memoize       Whether to memoize the result.
+   * @param form          The from of the new value type.
+   * @param controlStream The control stream.
+   * @param <U>           The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  default <U, M> SwimStream<U> mapModal(final M initialMode, final Function<M, Function<T, ? extends U>> f,
+                                        final boolean memoize, final Form<U> form,
+                                        final SwimStream<M> controlStream) {
+    return mapModal(initialMode, f, memoize, form, controlStream, false);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param form          The from of the new value type.
+   * @param controlStream The control stream.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  default <U, M> SwimStream<U> mapModal(final M initialMode, final Function<M, Function<T, ? extends U>> f,
+                                        final Form<U> form, final SwimStream<M> controlStream,
+                                        final boolean isTransient) {
+    return mapModal(initialMode, f, false, form, controlStream, isTransient);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param form          The from of the new value type.
+   * @param controlStream The control stream.
+   * @param <U>           The type of the new value.
+   * @return A new stream with the values transformed.
+   */
+  default <U, M> SwimStream<U> mapModal(final M initialMode, final Function<M, Function<T, ? extends U>> f,
+                                        final Form<U> form, final SwimStream<M> controlStream) {
+    return mapModal(initialMode, f, false, form, controlStream);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param controlStream The control stream.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A new stream with the values transformed.
+   */
+  default <M> SwimStream<T> mapModal(final M initialMode,
+                                     final Function<M, Function<T, ? extends T>> f,
+                                     final SwimStream<M> controlStream,
+                                     final boolean isTransient) {
+    return mapModal(initialMode, f, form(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param controlStream The control stream.
+   * @return A new stream with the values transformed.
+   */
+  default <M> SwimStream<T> mapModal(final M initialMode,
+                                     final Function<M, Function<T, ? extends T>> f,
+                                     final SwimStream<M> controlStream) {
+    return mapModal(initialMode, f, form(), controlStream);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param memoize       Whether to memoize the result.
+   * @param controlStream The control stream.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A new stream with the values transformed.
+   */
+  default <M> SwimStream<T> mapModal(final M initialMode,
+                                     final Function<M, Function<T, ? extends T>> f,
+                                     final boolean memoize,
+                                     final SwimStream<M> controlStream,
+                                     final boolean isTransient) {
+    return mapModal(initialMode, f, memoize, form(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally transform the values of this stream. This differs from {@link #map} in there being an additional
+   * control scheme that modifies the behaviour of the mapping function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param f             The modal function to transform the values.
+   * @param memoize       Whether to memoize the result.
+   * @param controlStream The control stream.
+   * @return A new stream with the values transformed.
+   */
+  default <M> SwimStream<T> mapModal(final M initialMode,
+                                     final Function<M, Function<T, ? extends T>> f,
+                                     final boolean memoize,
+                                     final SwimStream<M> controlStream) {
+    return mapModal(initialMode, f, memoize, form(), controlStream);
+  }
+
+  /**
+   * Flat-map over the values of this stream. Each value in this stream will become 0 or more values in the new stream.
+   *
+   * @param f     The function to apply.
+   * @param form  The form of the new value type.
+   * @param delay Delay strategy for the outputs.
+   * @param <U>   The new value type.
+   * @return A new stream with the transformed values.
+   */
+  <U> SwimStream<U> flatMap(Function<T, Iterable<U>> f, Form<U> form, DelaySpecifier delay);
+
+  /**
+   * Flat-map over the values of this stream. Each value in this stream will become 0 or more values in the new stream.
+   *
+   * @param f     The function to apply.
+   * @param delay Delay strategy for the outputs.
+   * @return A new stream with the transformed values.
+   */
+  default SwimStream<T> flatMap(final Function<T, Iterable<T>> f, final DelaySpecifier delay) {
+    return flatMap(f, form(), delay);
+  }
+
+  /**
+   * Modally flat-map over the values of this stream. Each value in this stream will become 0 or more values in the
+   * new stream. This differs from {@link #flatMap} in there being an additional control scheme that modifies the
+   * behaviour of the mapping function.
+   *
+   * @param initialMode The initial value of the mode.
+   * @param f           The function to apply.
+   * @param form        The form of the new value type.
+   * @param delay       Delay strategy for the outputs.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <U>         The new value type.
+   * @return A new stream with the transformed values.
+   */
+  <U, M> SwimStream<U> flatMapModal(M initialMode, Function<M, Function<T, Iterable<U>>> f,
+                                    Form<U> form, DelaySpecifier delay, SwimStream<M> controlStream,
+                                    boolean isTransient);
+
+  /**
+   * Modally flat-map over the values of this stream. Each value in this stream will become 0 or more values in the
+   * new stream. This differs from {@link #flatMap} in there being an additional control scheme that modifies the
+   * behaviour of the mapping function.
+   *
+   * @param initialMode The initial value of the mode.
+   * @param f           The function to apply.
+   * @param form        The form of the new value type.
+   * @param delay       Delay strategy for the outputs.
+   * @param <U>         The new value type.
+   * @return A new stream with the transformed values.
+   */
+  default <U, M> SwimStream<U> flatMapModal(final M initialMode, final Function<M, Function<T, Iterable<U>>> f,
+                                            final Form<U> form, final DelaySpecifier delay,
+                                            final SwimStream<M> controlStream) {
+    return flatMapModal(initialMode, f, form, delay, controlStream, false);
+  }
+
+  /**
+   * Modally flat-map over the values of this stream. Each value in this stream will become 0 or more values in the
+   * new stream. This differs from {@link #flatMap} in there being an additional control scheme that modifies the
+   * behaviour of the mapping function.
+   *
+   * @param initialMode The initial value of the mode.
+   * @param f           The function to apply.
+   * @param delay       Delay strategy for the outputs.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return A new stream with the transformed values.
+   */
+  default <M> SwimStream<T> flatMapModal(final M initialMode, final Function<M, Function<T, Iterable<T>>> f,
+                                         final DelaySpecifier delay, final SwimStream<M> controlStream,
+                                         final boolean isTransient) {
+    return flatMapModal(initialMode, f, form(), delay, controlStream, isTransient);
+  }
+
+  /**
+   * Modally flat-map over the values of this stream. Each value in this stream will become 0 or more values in the
+   * new stream. This differs from {@link #flatMap} in there being an additional control scheme that modifies the
+   * behaviour of the mapping function.
+   *
+   * @param initialMode The initial value of the mode.
+   * @param f           The function to apply.
+   * @param delay       Delay strategy for the outputs.
+   * @return A new stream with the transformed values.
+   */
+  default <M> SwimStream<T> flatMapModal(final M initialMode, final Function<M, Function<T, Iterable<T>>> f,
+                                         final DelaySpecifier delay, final SwimStream<M> controlStream) {
+    return flatMapModal(initialMode, f, form(), delay, controlStream);
+  }
+
+  /**
+   * Replace the timestamps on the values in this stream.
+   *
+   * @param datation The timestamp assignment function.
+   * @return A copy of this stream with different timestamps.
+   */
+  SwimStream<T> updateTimestamps(ToLongFunction<T> datation);
+
+  /**
+   * Apply a binary operator across the values of this stream. The new stream will maintain a running accumulation
+   * as computed by the operator.
+   *
+   * @param op       The operator.
+   * @param sampling Sampling strategy for the link (this will control which values the operator is applied to).
+   * @return A stream of running accumulations.
+   */
+  SwimStream<T> reduce(BinaryOperator<T> op, Sampling sampling, boolean isTransient);
+
+  /**
+   * Apply a binary operator across the values of this stream. The new stream will maintain a running accumulation
+   * as computed by the operator.
+   *
+   * @param op       The operator.
+   * @param sampling Sampling strategy for the link (this will control which values the operator is applied to).
+   * @return A stream of running accumulations.
+   */
+  default SwimStream<T> reduce(final BinaryOperator<T> op, final Sampling sampling) {
+    return reduce(op, sampling, false);
+  }
+
+  /**
+   * Apply a binary operator across the values of this stream. The new stream will maintain a running accumulation
+   * as computed by the operator.
+   *
+   * @param op The operator.
+   * @return A stream of running accumulations.
+   */
+  default SwimStream<T> reduce(final BinaryOperator<T> op, final boolean isTransient) {
+    return reduce(op, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Apply a binary operator across the values of this stream. The new stream will maintain a running accumulation
+   * as computed by the operator.
+   *
+   * @param op The operator.
+   * @return A stream of running accumulations.
+   */
+  default SwimStream<T> reduce(final BinaryOperator<T> op) {
+    return reduce(op, Sampling.eager());
+  }
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed        The seed value for the computation.
+   * @param op          The function to combine the values of this stream with the previously computed value.
+   * @param form        The form of the new values.
+   * @param sampling    The sampling strategy for the link (this will control which values the function is applied to).
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <U>         The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  <U> SwimStream<U> fold(U seed, BiFunction<U, T, U> op, Form<U> form, Sampling sampling, boolean isTransient);
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed     The seed value for the computation.
+   * @param op       The function to combine the values of this stream with the previously computed value.
+   * @param form     The form of the new values.
+   * @param sampling The sampling strategy for the link (this will control which values the function is applied to).
+   * @param <U>      The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> SwimStream<U> fold(final U seed, final BiFunction<U, T, U> op,
+                                 final Form<U> form, final Sampling sampling) {
+    return fold(seed, op, form, sampling, false);
+  }
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed The seed value for the computation.
+   * @param op   The function to combine the values of this stream with the previously computed value.
+   * @param form The form of the new values.
+   * @param <U>  The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> SwimStream<U> fold(final U seed, final BiFunction<U, T, U> op, final Form<U> form) {
+    return fold(seed, op, form, Sampling.eager());
+  }
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed        The seed value for the computation.
+   * @param op          The function to combine the values of this stream with the previously computed value.
+   * @param form        The form of the new values.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <U>         The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U> SwimStream<U> fold(final U seed, final BiFunction<U, T, U> op,
+                                 final Form<U> form, final boolean isTransient) {
+    return fold(seed, op, form, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed The seed value for the computation.
+   * @param op   The function to combine the values of this stream with the previously computed value.
+   * @return A new stream of the applications of the function.
+   */
+  default SwimStream<T> fold(final T seed, final BiFunction<T, T, T> op) {
+    return fold(seed, op, form(), Sampling.eager());
+  }
+
+  /**
+   * Fold across the values of the stream to produce a new stream. For each sample taken from this stream apply the
+   * provided function to it and the previously computed value (starting with the specified seed). The output of the
+   * function is the new value of the stream.
+   *
+   * @param seed        The seed value for the computation.
+   * @param op          The function to combine the values of this stream with the previously computed value.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @return A new stream of the applications of the function.
+   */
+  default SwimStream<T> fold(final T seed, final BiFunction<T, T, T> op, final boolean isTransient) {
+    return fold(seed, op, form(), Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Modally apply a binary operator across the values of this stream. The new stream will maintain a running
+   * accumulation as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param op            The modal operator.
+   * @param sampling      Sampling strategy for the link (this will control which values the operator is applied to).
+   * @param controlStream The control stream of the operator.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A stream of running accumulations.
+   */
+  <M> SwimStream<T> reduceModal(M initialMode, Function<M, BinaryOperator<T>> op, Sampling sampling,
+                                SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally apply a binary operator across the values of this stream. The new stream will maintain a running
+   * accumulation as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param op            The modal operator.
+   * @param sampling      Sampling strategy for the link (this will control which values the operator is applied to).
+   * @param controlStream The control stream of the operator.
+   * @return A stream of running accumulations.
+   */
+  default <M> SwimStream<T> reduceModal(final M initialMode, final Function<M, BinaryOperator<T>> op,
+                                        final Sampling sampling, final SwimStream<M> controlStream) {
+    return reduceModal(initialMode, op, sampling, controlStream, false);
+  }
+
+  /**
+   * Modally apply a binary operator across the values of this stream. The new stream will maintain a running
+   * accumulation as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param op            The modal operator.
+   * @param controlStream The control stream of the operator.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A stream of running accumulations.
+   */
+  default <M> SwimStream<T> reduceModal(final M initialMode, final Function<M, BinaryOperator<T>> op,
+                                        final SwimStream<M> controlStream, final boolean isTransient) {
+    return reduceModal(initialMode, op, Sampling.eager(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally apply a binary operator across the values of this stream. The new stream will maintain a running
+   * accumulation as computed by the operator. The difference between this and {@link #reduce(BinaryOperator, Sampling)}
+   * is that an auxiliary control stream modifies the behaviour of the operator.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param op            The modal operator.
+   * @param controlStream The control stream of the operator.
+   * @return A stream of running accumulations.
+   */
+  default <M> SwimStream<T> reduceModal(final M initialMode, final Function<M, BinaryOperator<T>> op,
+                                        final SwimStream<M> controlStream) {
+    return reduceModal(initialMode, op, Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param sampling      The sampling strategy for the link (this will control which values the function is applied to).
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  <U, M> SwimStream<U> foldModal(M initialMode, U seed, Function<M, BiFunction<U, T, U>> op, Form<U> form,
+                                 Sampling sampling, SwimStream<M> controlStream, boolean isTransient);
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param sampling      The sampling strategy for the link (this will control which values the function is applied to).
+   * @param controlStream The control stream of the update operation.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> SwimStream<U> foldModal(final M initialMode, final U seed,
+                                         final Function<M, BiFunction<U, T, U>> op, final Form<U> form,
+                                         final Sampling sampling, final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, form, sampling, controlStream, false);
+  }
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> SwimStream<U> foldModal(final M initialMode,
+                                         final U seed, final Function<M, BiFunction<U, T, U>> op,
+                                         final Form<U> form,
+                                         final SwimStream<M> controlStream, final boolean isTransient) {
+    return foldModal(initialMode, seed, op, form, Sampling.eager(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param form          The form of the new values.
+   * @param controlStream The control stream of the update operation.
+   * @param <U>           The type of the new values.
+   * @return A new stream of the applications of the function.
+   */
+  default <U, M> SwimStream<U> foldModal(final M initialMode,
+                                         final U seed, final Function<M, BiFunction<U, T, U>> op,
+                                         final Form<U> form,
+                                         final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, form, Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param controlStream The control stream of the update operation.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @return A new stream of the applications of the function.
+   */
+  default <M> SwimStream<T> foldModal(final M initialMode,
+                                      final T seed, final Function<M, BiFunction<T, T, T>> op,
+                                      final SwimStream<M> controlStream, final boolean isTransient) {
+    return foldModal(initialMode, seed, op, form(), Sampling.eager(), controlStream, isTransient);
+  }
+
+  /**
+   * Modally fold across the values of the stream to produce a new stream. For each sample taken from this stream
+   * apply the provided function to it and the previously computed value (starting with the specified seed). The
+   * output of the function is the new value of the stream for the key. The difference between this and
+   * {@link #fold(Object, BiFunction, Form, Sampling)} is that an auxiliary control stream modifies the behaviour
+   * of the update function.
+   *
+   * @param initialMode   The initial mode of the stream.
+   * @param seed          The seed value for the computation.
+   * @param op            The  modal function to combine the values of this stream with the previously computed value.
+   * @param controlStream The control stream of the update operation.
+   * @return A new stream of the applications of the function.
+   */
+  default <M> SwimStream<T> foldModal(final M initialMode,
+                                      final T seed, final Function<M, BiFunction<T, T, T>> op,
+                                      final SwimStream<M> controlStream) {
+    return foldModal(initialMode, seed, op, form(), Sampling.eager(), controlStream);
+  }
+
+  /**
+   * Partitions the stream into a map stream.
+   *
+   * @param assigner    Assigns partitions (keys in the map) to values.
+   * @param partForm    The form of the partitions.
+   * @param sampling    The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <P>         The type of the partitions.
+   * @param <S>         The type of the state tracking open windows.
+   * @return The partitioned stream.
+   */
+  <P, S extends PartitionState<P, S>> MapSwimStream<P, T> partition(PartitionAssigner<T, P, S> assigner,
+                                                                    Form<P> partForm,
+                                                                    Sampling sampling,
+                                                                    boolean isTransient);
+
+  /**
+   * Partitions the stream into a map stream.
+   *
+   * @param assigner Assigns partitions (keys in the map) to values.
+   * @param partForm The form of the partitions.
+   * @param sampling The sampling strategy for the link.
+   * @param <P>      The type of the partitions.
+   * @param <S>      The type of the state tracking open windows.
+   * @return The partitioned stream.
+   */
+  default <P, S extends PartitionState<P, S>> MapSwimStream<P, T> partition(final PartitionAssigner<T, P, S> assigner,
+                                                                            final Form<P> partForm,
+                                                                            final Sampling sampling) {
+    return partition(assigner, partForm, sampling, false);
+  }
+
+  /**
+   * Partitions the stream into a map stream.
+   *
+   * @param assigner    Assigns partitions (keys in the map) to values.
+   * @param partForm    The form of the partitions.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <P>         The type of the partitions.
+   * @param <S>         The type of the state tracking open windows.
+   * @return The partitioned stream.
+   */
+  default <P, S extends PartitionState<P, S>> MapSwimStream<P, T> partition(final PartitionAssigner<T, P, S> assigner,
+                                                                            final Form<P> partForm,
+                                                                            final boolean isTransient) {
+    return partition(assigner, partForm, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Partitions the stream into a map stream.
+   *
+   * @param assigner Assigns partitions (keys in the map) to values.
+   * @param partForm The form of the partitions.
+   * @param <P>      The type of the partitions.
+   * @param <S>      The type of the state tracking open windows.
+   * @return The partitioned stream.
+   */
+  default <P, S extends PartitionState<P, S>> MapSwimStream<P, T> partition(final PartitionAssigner<T, P, S> assigner,
+                                                                            final Form<P> partForm) {
+    return partition(assigner, partForm, Sampling.eager());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner    Assigns each value to one or more windows.
+   * @param windowForm  The form of the windows.
+   * @param sampling    The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <W>         The type of the windows.
+   * @return A windowed stream.
+   */
+  <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(TemporalWindowAssigner<T, W, S> assigner,
+                                                                   Form<W> windowForm,
+                                                                   Sampling sampling,
+                                                                   boolean isTransient);
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(final TemporalWindowAssigner<T, W, S> assigner,
+                                                                           final Form<W> windowForm,
+                                                                           final Sampling sampling) {
+    return window(assigner, windowForm, sampling, false);
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner    Assigns each value to one or more windows.
+   * @param windowForm  The form of the windows.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <W>         The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(
+      final TemporalWindowAssigner<T, W, S> assigner,
+      final Form<W> windowForm,
+      final boolean isTransient) {
+    return window(assigner, windowForm, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more windows.
+   * @param windowForm The form of the windows.
+   * @param <W>        The type of the windows.
+   * @return A windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(
+      final TemporalWindowAssigner<T, W, S> assigner,
+      final Form<W> windowForm) {
+    return window(assigner, windowForm, Sampling.eager());
+  }
+
+  /**
+   * Divides the values by partition and temporal window simultaneously using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more partitions and windows.
+   * @param partForm   The form of the partitions.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <P>        The type of the partitions.
+   * @param <W>        The type of the windows.
+   * @param <S>        The type of the state managing the open partitions and windows.
+   * @return The partitioned and windowed stream.
+   */
+  <P, W, S extends CombinedState<P, W, S>> MapWindowedSwimStream<P, T, W> window(
+      CombinedWindowAssigner<T, P, W, S> assigner,
+      Form<P> partForm,
+      Form<W> windowForm,
+      Sampling sampling,
+      boolean isTransient);
+
+  /**
+   * Divides the values by partition and temporal window simultaneously using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more partitions and windows.
+   * @param partForm   The form of the partitions.
+   * @param windowForm The form of the windows.
+   * @param sampling   The sampling strategy for the link.
+   * @param <P>        The type of the partitions.
+   * @param <W>        The type of the windows.
+   * @param <S>        The type of the state managing the open partitions and windows.
+   * @return The partitioned and windowed stream.
+   */
+  default <P, W, S extends CombinedState<P, W, S>> MapWindowedSwimStream<P, T, W> window(
+      final CombinedWindowAssigner<T, P, W, S> assigner,
+      final Form<P> partForm,
+      final Form<W> windowForm,
+      final Sampling sampling) {
+    return window(assigner, partForm, windowForm, sampling, false);
+  }
+
+  /**
+   * Divides the values by partition and temporal window simultaneously using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more partitions and windows.
+   * @param partForm   The form of the partitions.
+   * @param windowForm The form of the windows.
+   * @param <P>        The type of the partitions.
+   * @param <W>        The type of the windows.
+   * @param <S>        The type of the state managing the open partitions and windows.
+   * @return The partitioned and windowed stream.
+   */
+  default <P, W, S extends CombinedState<P, W, S>> MapWindowedSwimStream<P, T, W> window(
+      final CombinedWindowAssigner<T, P, W, S> assigner,
+      final Form<P> partForm,
+      final Form<W> windowForm,
+      final boolean isTransient) {
+    return window(assigner, partForm, windowForm, Sampling.eager(), isTransient);
+  }
+
+  /**
+   * Divides the values by partition and temporal window simultaneously using a configurable strategy.
+   *
+   * @param assigner   Assigns each value to one or more partitions and windows.
+   * @param partForm   The form of the partitions.
+   * @param windowForm The form of the windows.
+   * @param <P>        The type of the partitions.
+   * @param <W>        The type of the windows.
+   * @param <S>        The type of the state managing the open partitions and windows.
+   * @return The partitioned and windowed stream.
+   */
+  default <P, W, S extends CombinedState<P, W, S>> MapWindowedSwimStream<P, T, W> window(
+      final CombinedWindowAssigner<T, P, W, S> assigner,
+      final Form<P> partForm,
+      final Form<W> windowForm) {
+    return window(assigner, partForm, windowForm, Sampling.eager());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec The specification of the windows.
+   * @param <W>  The type of the windows.
+   * @param <S>  The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(final WindowSpec<T, W, S> spec) {
+    return window(spec.getAssigner(), spec.getWindowForm())
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setTransient(spec.isTransient());
+  }
+
+  /**
+   * Divides the values into (possibly overlapping) windows, using a configurable strategy.
+   *
+   * @param spec     The specification of the windows.
+   * @param sampling The sampling strategy for the link.
+   * @param <W>      The type of the windows.
+   * @param <S>      The type of the state tracking open windows.
+   * @return The windowed stream.
+   */
+  default <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(final WindowSpec<T, W, S> spec,
+                                                                           final Sampling sampling) {
+    return window(spec.getAssigner(), spec.getWindowForm(), sampling)
+        .withTrigger(spec.getTrigger())
+        .withEviction(spec.getEvictionStrategy())
+        .setTransient(spec.isTransient());
+  }
+
+  /**
+   * Join together two streams using a common windowing strategy. If there are duplicate values for a key in a
+   * window the value that is chosen is not defined.
+   *
+   * @param other       The other stream.
+   * @param assigner    Assigns items in both streams to one or more windows.
+   * @param trigger     Determines when a window is complete.
+   * @param kform       The form of the type of the join keys.
+   * @param vform       The form of the type of the joined values.
+   * @param windowForm  The form of the type of the windows.
+   * @param sampling    The sampling strategy for the links.
+   * @param firstToKey  Gets the keys for the first type.
+   * @param secondToKey Gets the keys for the second type.
+   * @param combine     Combines pairs of records to for a single output.
+   * @param <W>         The type of the windows.
+   * @param <K>         The type of the keys.
+   * @param <T2>        The type of the values in the other stream.
+   * @param <U>         The type of the combined values.
+   * @return The joined stream.
+   */
+  <W, K, T2, U, S extends WindowState<W, S>> MapSwimStream<K, U> windowJoin(SwimStream<T2> other,
+                                                                            TemporalWindowAssigner<Either<T, T2>, W, S> assigner,
+                                                                            Trigger<Either<T, T2>, W> trigger,
+                                                                            Form<K> kform, Form<U> vform,
+                                                                            Form<W> windowForm,
+                                                                            Sampling sampling,
+                                                                            Function<T, K> firstToKey,
+                                                                            Function<T2, K> secondToKey,
+                                                                            BiFunction<T, T2, U> combine);
+
+  /**
+   * Combine together stream of the same type.
+   *
+   * @param others The other streams.
+   * @return The combined stream.
+   */
+  SwimStream<T> union(Iterable<SwimStream<? extends T>> others);
+
+  /**
+   * Combine this stream with another of the same type.
+   *
+   * @param other The other stream.
+   * @return The combined stream.
+   */
+  SwimStream<T> union(SwimStream<? extends T> other);
+
+  /**
+   * Create a stream that will always hold the first value received by this stream.
+   *
+   * @param isTransient Whether to store the first value persistently.
+   * @return The first value stream.
+   */
+  SwimStream<T> first(boolean isTransient);
+
+  /**
+   * Create a stream that will always hold the first value received by this stream.
+   *
+   * @return The first value stream.
+   */
+  default SwimStream<T> first() {
+    return first(false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value.
+   *
+   * @param n           The number of steps back (must be at least 1).
+   * @param isTransient Whether to store the history persistently.
+   * @return The delayed stream.
+   */
+  SwimStream<T> delayed(int n, boolean isTransient);
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value.
+   *
+   * @param ns          Stream of the number of steps back (must be at least 1).
+   * @param isTransient Whether to store the history persistently.
+   * @param init        Initial delay.
+   * @return The delayed stream.
+   */
+  SwimStream<T> delayed(SwimStream<Integer> ns, int init, boolean isTransient);
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value.
+   *
+   * @param n The number of steps back (must be at least 1).
+   * @return The delayed stream.
+   */
+  default SwimStream<T> delayed(final int n) {
+    return delayed(n, false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the value
+   * received by this stream {@code n} steps before the current value.
+   *
+   * @param ns   Stream of the number of steps back (must be at least 1).
+   * @param init Initial delay.
+   * @return The delayed stream.
+   */
+  default SwimStream<T> delayed(final SwimStream<Integer> ns, final int init) {
+    return delayed(ns, init, false);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the previous value of
+   * this stream.
+   *
+   * @param isTransient Whether to store the history persistently.
+   * @return The delayed stream.
+   */
+  default SwimStream<T> previous(final boolean isTransient) {
+    return delayed(1, isTransient);
+  }
+
+  /**
+   * Interpreting this stream as a sequence of discrete samples, create a stream which contains the previous value of
+   * this stream.
+   *
+   * @return The delayed stream.
+   */
+  default SwimStream<T> previous() {
+    return delayed(1, false);
+  }
+
+  /**
+   * Key this stream.
+   *
+   * @param keys        Function to extract the keys.
+   * @param kform       The form of the key type.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <K>         The type of the keys.
+   * @return A copy of this stream with keys.
+   */
+  <K> MapSwimStream<K, T> keyBy(Function<T, K> keys, Form<K> kform, boolean isTransient);
+
+  /**
+   * Key this stream.
+   *
+   * @param keys  Function to extract the keys.
+   * @param kform The form of the key type.
+   * @param <K>   The type of the keys.
+   * @return A copy of this stream with keys.
+   */
+  default <K> MapSwimStream<K, T> keyBy(final Function<T, K> keys, final Form<K> kform) {
+    return keyBy(keys, kform, false);
+  }
+
+  /**
+   * Attach this stream to a sink.
+   *
+   * @param sink Descriptor of the sink.
+   * @return Handle for the graph leaf represented by this sink.
+   */
+  SinkHandle<Unit, T> bind(Sink<T> sink);
+
+  /**
+   * Instantiate this stream as a node in a flow graph as a {@link Junction}.
+   *
+   * @param context Initialization context to keep track of nodes in the graph.
+   * @return The junction corresponding to this node.
+   */
+  Junction<T> instantiate(SwimStreamContext.InitContext context);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SwimStreamContext.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/SwimStreamContext.java
@@ -1,0 +1,282 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import swim.concurrent.Schedule;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.connector.Receptacle;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.structure.Form;
+
+/**
+ * Interface for contexts used to create flow graphs.
+ */
+public interface SwimStreamContext {
+
+  /**
+   * Create a stream from an external {@link Junction} (which could be a value lane or downlink).
+   *
+   * @param junction   The external junction.
+   * @param form       The form of the type of the junction.
+   * @param timestamps Assigns timestamps to the values.
+   * @param <T>        The type of the values.
+   * @return The stream based on the junction.
+   */
+  <T> SwimStream<T> fromJunction(Supplier<Junction<T>> junction, Form<T> form, ToLongFunction<T> timestamps);
+
+  /**
+   * Create a stream from an external junction (which could be a value lane or downlink).
+   *
+   * @param junction The external junction.
+   * @param form     The form of the type of the junction.
+   * @param <T>      The type of the values.
+   * @return The stream based on the junction.
+   */
+  default <T> SwimStream<T> fromJunction(final Supplier<Junction<T>> junction, final Form<T> form) {
+    return fromJunction(junction, form, null);
+  }
+
+  /**
+   * Create a stream from an external inlet (which could be a value lane or downlink).
+   *
+   * @param outlet The external outlet.
+   * @param form   The form of the type of the outlet.
+   * @param <T>    The type of the values.
+   * @return The stream based on the outlet.
+   */
+  default <T> SwimStream<T> fromJunction(final Junction<T> outlet, final Form<T> form) {
+    return fromJunction(() -> outlet, form);
+  }
+
+  /**
+   * Create a stream from an external junction (which could be a value lane or downlink).
+   *
+   * @param junction   The external junction.
+   * @param form       The form of the type of the junction.
+   * @param timestamps Assigns timestamps to the values.
+   * @param <T>        The type of the values.
+   * @return The stream based on the junction.
+   */
+  default <T> SwimStream<T> fromJunction(final Junction<T> junction,
+                                         final Form<T> form,
+                                         final ToLongFunction<T> timestamps) {
+    return fromJunction(() -> junction, form, timestamps);
+  }
+
+  /**
+   * Create a stream from an external map junction (which could be a map lane or downlink).
+   *
+   * @param junction   The external junction.
+   * @param keyForm    The form of the type of the keys.
+   * @param valueForm  The form of the type of the values.
+   * @param timestamps Assigns timestamps to the values.
+   * @param <K>        The type of the keys.
+   * @param <V>        The type of the values.
+   * @return The stream based on the junction.
+   */
+  <K, V> MapSwimStream<K, V> fromMapJunction(Supplier<MapJunction<K, V>> junction,
+                                             Form<K> keyForm, Form<V> valueForm,
+                                             ToLongFunction<V> timestamps);
+
+  /**
+   * Create a stream from an external map junction (which could be a map lane or downlink).
+   *
+   * @param junction  The external junction.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param <K>       The type of the keys.
+   * @param <V>       The type of the values.
+   * @return The stream based on the junction.
+   */
+  default <K, V> MapSwimStream<K, V> fromMapJunction(final Supplier<MapJunction<K, V>> junction,
+                                                     final Form<K> keyForm, final Form<V> valueForm) {
+    return fromMapJunction(junction, keyForm, valueForm, null);
+  }
+
+  /**
+   * Create a stream from an external map junction (which could be a map lane or downlink).
+   *
+   * @param junction  The external junction.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param <K>       The type of the keys.
+   * @param <V>       The type of the values.
+   * @return The stream based on the junction.
+   */
+  default <K, V> MapSwimStream<K, V> fromMapJunction(final MapJunction<K, V> junction,
+                                                     final Form<K> keyForm, final Form<V> valueForm) {
+    return fromMapJunction(() -> junction, keyForm, valueForm);
+  }
+
+  /**
+   * Create a stream from an external map junction (which could be a map lane or downlink).
+   *
+   * @param junction   The external junction.
+   * @param keyForm    The form of the type of the keys.
+   * @param valueForm  The form of the type of the values.
+   * @param timestamps Assigns timestamps to the values.
+   * @param <K>        The type of the keys.
+   * @param <V>        The type of the values.
+   * @return The stream based on the junction.
+   */
+  default <K, V> MapSwimStream<K, V> fromMapJunction(final MapJunction<K, V> junction,
+                                                     final Form<K> keyForm, final Form<V> valueForm,
+                                                     final ToLongFunction<V> timestamps) {
+    return fromMapJunction(() -> junction, keyForm, valueForm, timestamps);
+  }
+
+  /**
+   * Construct a flow graph based on all of the sinks connected by this context.
+   *
+   * @return Instantiation context for the flow graph.
+   */
+  InitContext constructGraph();
+
+  /**
+   * Context used to instantiate the flow graph.
+   */
+  interface InitContext {
+
+    /**
+     * @return The graph persistence provider.
+     */
+    PersistenceProvider getPersistenceProvider();
+
+    /**
+     * Instantiate a stream and provide the terminal junction.
+     *
+     * @param stream The stream.
+     * @param <S>    The type of the stream.
+     * @return The terminal junction.
+     */
+    <S> Junction<S> createFor(SwimStream<S> stream);
+
+    /**
+     * Instantiate a stream and provide the terminal junction.
+     *
+     * @param stream The stream.
+     * @param <K>    The type of the keys.
+     * @param <V>    The type of the values.
+     * @return The terminal junction.
+     */
+    <K, V> MapJunction<K, V> createFor(MapSwimStream<K, V> stream);
+
+    /**
+     * Instantiate a sink.
+     *
+     * @param sink The sink.
+     * @param <S>  The type accepted by the sink.
+     * @return The inlet for the sink.
+     */
+    <S> Receptacle<S> createFrom(Sink<S> sink);
+
+    /**
+     * Instantiate a map sink.
+     *
+     * @param sink The sink.
+     * @param <K>  The type of the keys accepted by the sink.
+     * @param <V>  The type of the values accepted by the sink.
+     * @return The inlet for the sink.
+     */
+    <K, V> MapReceptacle<K, V> createFromMap(MapSink<K, V> sink);
+
+    /**
+     * Get a junction that already exists in the context for a stream.
+     *
+     * @param stream The stream.
+     * @param <S>    The type of the stream values.
+     * @return The junction.
+     */
+    <S> Junction<S> getExisting(SwimStream<S> stream);
+
+    /**
+     * Inject a junction into the context for a stream.
+     *
+     * @param stream   The stream.
+     * @param junction The junction.
+     * @param <S>      The type of the stream values.
+     */
+    <S> void inject(SwimStream<S> stream, Junction<S> junction);
+
+    /**
+     * Get a junction that already exists in the context for a stream.
+     *
+     * @param stream The stream.
+     * @param <K>    The type of the keys.
+     * @param <V>    The type of the values.
+     * @return The junction.
+     */
+    <K, V> MapJunction<K, V> getExistingMap(MapSwimStream<K, V> stream);
+
+    /**
+     * Inject a junction into the context for a stream.
+     *
+     * @param stream   The stream.
+     * @param junction The junction.
+     * @param <K>      The type of the keys.
+     * @param <V>      The type of the values.
+     */
+    <K, V> void inject(MapSwimStream<K, V> stream, MapJunction<K, V> junction);
+
+    /**
+     * Get a receptacle that already exists in the context for a sink.
+     *
+     * @param sink The stream.
+     * @param <S>  The type of the stream values.
+     * @return The receptacle.
+     */
+    <S> Receptacle<S> getExisting(Sink<S> sink);
+
+    /**
+     * Inject a receptacle into the context for a sink.
+     *
+     * @param sink       The sink.
+     * @param receptacle The receptacle.
+     * @param <S>        The type of the stream values.
+     */
+    <S> void inject(Sink<S> sink, Receptacle<S> receptacle);
+
+    /**
+     * Get a receptacle that already exists in the context for a sink.
+     *
+     * @param sink The sink.
+     * @param <K>  The type of the keys accepted by the sink.
+     * @param <V>  The type of the values accepted by the sink.
+     * @return The receptacle.
+     */
+    <K, V> MapReceptacle<K, V> getExistingMap(MapSink<K, V> sink);
+
+    /**
+     * Inject a receptacle into the context for a sink.
+     *
+     * @param sink       The sink.
+     * @param receptacle The receptacle.
+     * @param <K>        The type of the keys accepted by the sink.
+     * @param <V>        The type of the values accepted by the sink.
+     */
+    <K, V> void injectMap(MapSink<K, V> sink, MapReceptacle<K, V> receptacle);
+
+    /**
+     * @return Schedule for events.
+     */
+    Schedule getSchedule();
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Unit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/Unit.java
@@ -1,0 +1,62 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.util.Murmur3;
+
+/**
+ * Canonical type with a single member.
+ */
+public final class Unit {
+
+  private Unit() {
+  }
+
+  public static final Unit INSTANCE = new Unit();
+
+  @Override
+  public boolean equals(final Object obj) {
+    return obj == this;
+  }
+
+  private static final int HASH = Murmur3.seed(Unit.class);
+
+  @Override
+  public int hashCode() {
+    return HASH;
+  }
+
+  public static final Form<Unit> FORM = new Form<Unit>() {
+
+    @Override
+    public Class<?> type() {
+      return Unit.class;
+    }
+
+    @Override
+    public Item mold(final Unit object) {
+      return Record.of();
+    }
+
+    @Override
+    public Unit cast(final Item item) {
+      return INSTANCE;
+    }
+  };
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/WindowedSwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/WindowedSwimStream.java
@@ -1,0 +1,209 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph;
+
+import java.util.function.Function;
+import swim.dataflow.graph.windows.Group;
+import swim.dataflow.graph.windows.InvertibleFolder;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowFunction;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+/**
+ * A {@link SwimStream} that has been partitioned into (possibly overlapping) windows.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+public interface WindowedSwimStream<T, W> {
+
+  /**
+   * @return Form of the type of the values.
+   */
+  Form<T> form();
+
+  /**
+   * @return Form of the type of the windows.
+   */
+  Form<W> windowForm();
+
+  /**
+   * Collapse each window into a single value in a new stream.
+   *
+   * @param winFun Function to transform the window contents.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  <U> SwimStream<U> mapWindow(WindowFunction<T, W, U> winFun, Form<U> form);
+
+  /**
+   * Collapse each window into a single value in a new stream.
+   *
+   * @param winFun Function to transform the window contents.
+   * @return A stream containing the results.
+   */
+  default SwimStream<T> mapWindow(final WindowFunction<T, W, T> winFun) {
+    return mapWindow(winFun, form());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded).
+   *
+   * @param seed   The initial value for the fold operation.
+   * @param winFun The fold operation.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  <U> SwimStream<U> fold(U seed, WindowFoldFunction<T, W, U> winFun, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link T} is bounded).
+   *
+   * @param seed   The initial value for the fold operation.
+   * @param winFun The fold operation.
+   * @return A stream containing the results.
+   */
+  default SwimStream<T> fold(final T seed, final WindowFoldFunction<T, W, T> winFun) {
+    return fold(seed, winFun, form());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded).
+   *
+   * @param seed     The initial value for the fold operation.
+   * @param winFun   The fold operation.
+   * @param combiner Combiner for intermediate results.
+   * @param form     The form of the result type.
+   * @param <U>      The result type.
+   * @return A stream containing the results.
+   */
+  <U> SwimStream<U> fold(U seed, WindowFoldFunction<T, W, U> winFun, WindowBinOp<U, W> combiner, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link T} is bounded).
+   *
+   * @param seed     The initial value for the fold operation.
+   * @param winFun   The fold operation.
+   * @param combiner Combiner for intermediate results.
+   * @return A stream containing the results.
+   */
+  default SwimStream<T> fold(final T seed, final WindowFoldFunction<T, W, T> winFun, final WindowBinOp<T, W> combiner) {
+    return fold(seed, winFun, combiner, form());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed   The seed initialization function.
+   * @param winFun The fold operation.
+   * @param form   The form of the result type.
+   * @param <U>    The result type.
+   * @return A stream containing the results.
+   */
+  <U> SwimStream<U> foldBy(Function<W, U> seed, WindowFoldFunction<T, W, U> winFun, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link T} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed   The seed initialization function.
+   * @param winFun The fold operation.
+   * @return A stream containing the results.
+   */
+  default SwimStream<T> foldBy(final Function<W, T> seed, final WindowFoldFunction<T, W, T> winFun) {
+    return foldBy(seed, winFun, form());
+  }
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link U} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed     The seed initialization function.
+   * @param winFun   The fold operation.
+   * @param combiner Combiner for intermediate results.
+   * @param form     The form of the result type.
+   * @param <U>      The result type.
+   * @return A stream containing the results.
+   */
+  <U> SwimStream<U> foldWithCombiner(Function<W, U> seed, WindowFoldFunction<T, W, U> winFun, WindowBinOp<U, W> combiner, Form<U> form);
+
+  /**
+   * Fold each window into a single value in a new stream. This differs from {@link #mapWindow(WindowFunction, Form)}
+   * in that it only requires bounded state (if the size of {@link T} is bounded). The seed value is computed from
+   * the key and the window.
+   *
+   * @param seed     The seed initialization function.
+   * @param winFun   The fold operation.
+   * @param combiner Combiner for intermediate results.
+   * @return A stream containing the results.
+   */
+  default SwimStream<T> foldWithCombiner(final Function<W, T> seed, final WindowFoldFunction<T, W, T> winFun,
+                                         final WindowBinOp<T, W> combiner) {
+    return foldWithCombiner(seed, winFun, combiner, form());
+  }
+
+  /**
+   * Reduce each window into a single value in a new stream.
+   *
+   * @param op The binary operation on the values.
+   * @return A stream containing the results.
+   */
+  SwimStream<T> reduce(WindowBinOp<T, W> op);
+
+  default SwimStream<T> groupReduce(final Group<T> group) {
+    return groupReduce(w -> group);
+  }
+
+  default SwimStream<T> groupReduce(final Function<W, Group<T>> group) {
+    return reduce((w, t1, t2) -> group.apply(w).add(t1, t2));
+  }
+
+  default <U> SwimStream<U> fold(final InvertibleFolder<T, U> folder, final Form<U> form) {
+    return fold(w -> folder, form);
+  }
+
+  default SwimStream<T> fold(final InvertibleFolder<T, T> folder) {
+    return fold(w -> folder, form());
+  }
+
+  default <U> SwimStream<U> fold(final Function<W, InvertibleFolder<T, U>> folder, final Form<U> form) {
+    final Function<W, U> seed = folder.andThen(InvertibleFolder::zero);
+    final WindowFoldFunction<T, W, U> foldOp = (w, t1, t2) -> folder.apply(w).add(t1, t2);
+    return foldBy(seed, foldOp, form);
+  }
+
+  default SwimStream<T> fold(final Function<W, InvertibleFolder<T, T>> folder) {
+    return fold(folder, form());
+  }
+
+  WindowedSwimStream<T, W> withTrigger(Trigger<T, W> trigger);
+
+  WindowedSwimStream<T, W> withEviction(EvictionStrategy<T, W> strategy);
+
+  WindowedSwimStream<T, W> setTransient(boolean isTransient);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractCollectionStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractCollectionStream.java
@@ -1,0 +1,49 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.CollectionSwimStream;
+import swim.dataflow.graph.MapSwimStream;
+import swim.structure.Form;
+
+/**
+ * Base implementation of streams of collections.
+ *
+ * @param <T> The type of the elements.
+ * @param <C> The type of the collections.
+ */
+abstract class AbstractCollectionStream<T, C extends Collection<T>> extends AbstractSwimStream<C>
+        implements CollectionSwimStream<T, C> {
+
+  AbstractCollectionStream(final Form<C> valForm, final BindingContext con) {
+    super(valForm, con);
+  }
+
+  AbstractCollectionStream(final Form<C> valForm, final BindingContext con, final ToLongFunction<C> ts) {
+    super(valForm, con, ts);
+  }
+
+  @Override
+  public <K, V> MapSwimStream<K, V> toMapStream(final Function<T, K> toKey, final Function<T, V> toValue,
+                                                final Form<K> keyForm, final Form<V> valueForm,
+                                                final boolean isTransient) {
+    return new CollectionToMapStream<>(this, getContext(), toKey, toValue, keyForm, valueForm, isTransient);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractMapStream.java
@@ -1,0 +1,265 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.CollectionSwimStream;
+import swim.dataflow.graph.MapSink;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.MapWindowedSwimStream;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.SinkHandle;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowState;
+import swim.structure.Form;
+
+/**
+ * Provides standard implementations of combinator builder methods.
+ *
+ * @param <K> The key type of the stream.
+ * @param <V> The value type of the stream.
+ */
+public abstract class AbstractMapStream<K, V> implements MapSwimStream<K, V> {
+
+  private final Form<K> keyForm;
+  private final Form<V> valForm;
+  private final ToLongFunction<V> timestamps;
+  private final BindingContext context;
+
+  private String id;
+
+  @Override
+  public final String id() {
+    return id;
+  }
+
+  @Override
+  public final AbstractMapStream<K, V> setId(final String id) {
+    context.claimId(id);
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * @return Context use to instantiate the graph.
+   */
+  protected BindingContext getContext() {
+    return context;
+  }
+
+  /**
+   * @param kform Form of the type of the keys.
+   * @param vform Form of the type of the values.
+   * @param con   Context used to instantiate the graph.
+   */
+  protected AbstractMapStream(final Form<K> kform, final Form<V> vform,
+                    final BindingContext con) {
+
+    this(kform, vform, con, null);
+  }
+
+  /**
+   * @param kform Form of the type of the keys.
+   * @param vform Form of the type of the values.
+   * @param con   Context used to instantiate the graph.
+   * @param ts    Timestamp assignment for the values.
+   */
+  protected AbstractMapStream(final Form<K> kform, final Form<V> vform,
+                    final BindingContext con, final ToLongFunction<V> ts) {
+
+    keyForm = kform;
+    valForm = vform;
+    context = con;
+    timestamps = ts;
+    id = con.createId();
+  }
+
+
+  @Override
+  public final ToLongFunction<V> getTimestamps() {
+    return timestamps;
+  }
+
+  @Override
+  public final Form<K> keyForm() {
+    return keyForm;
+  }
+
+  @Override
+  public final Form<V> valueForm() {
+    return valForm;
+  }
+
+  @Override
+  public CollectionSwimStream<K, Set<K>> keys() {
+    return new KeyStream<>(this, context);
+  }
+
+  @Override
+  public MapSwimStream<K, V> filter(final BiPredicate<K, V> predicate) {
+    return new FilteredMapStream<>(this, context, predicate);
+  }
+
+  @Override
+  public <M> MapSwimStream<K, V> filterModal(final M initialMode, final Function<M, BiPredicate<K, V>> modalPredicate,
+                                             final SwimStream<M> controlStream, final boolean isTransient) {
+    return new ModalFilteredMapStream<>(this, context, initialMode, modalPredicate, controlStream, isTransient);
+  }
+
+  @Override
+  public <M> MapSwimStream<K, V> filterKeysModal(final M initialMode,
+                                                 final Function<M, Predicate<K>> modalPredicate,
+                                                 final SwimStream<M> controlStream,
+                                                 final boolean isTransient) {
+    return new ModalFilteredKeysMapStream<>(this, context, initialMode, modalPredicate, controlStream, isTransient);
+  }
+
+  @Override
+  public <U> SwimStream<U> reduceKeyed(final U seed, final BiFunction<U, ? super V, U> op,
+                                       final BinaryOperator<U> combine, final Form<U> form, final Sampling sampling) {
+    return new ReducedByEntriesMapStream<>(this, context, seed, op, combine, form, sampling);
+  }
+
+  @Override
+  public <K2> MapSwimStream<K2, V> mapKeys(final BiFunction<K, V, ? extends K2> f,
+                                           final Function<K, Set<K2>> onRem, final Form<K2> kform) {
+    final BiFunction<K, V, Pair<K2, V>> toPair = (k, v) -> new Pair<>(f.apply(k, v), v);
+    return new TransformedMapStream<>(this, context, toPair, onRem, kform, valForm);
+  }
+
+  @Override
+  public <V2> MapSwimStream<K, V2> mapValues(final BiFunction<K, V, ? extends V2> f, final boolean memoize, final Form<V2> vform) {
+    return new TransformedValuesMapStream<>(this, context, f, memoize, vform);
+  }
+
+  @Override
+  public <K2, V2> MapSwimStream<K2, V2> map(final BiFunction<K, V, Pair<K2, V2>> f,
+                                            final Function<K, Set<K2>> onRem, final Form<K2> kform, final Form<V2> vform) {
+    return new TransformedMapStream<>(this, context, f, onRem, kform, vform);
+  }
+
+  @Override
+  public <K2, V2> MapSwimStream<K2, V2> flatMap(final BiFunction<K, V, Iterable<Pair<K2, V2>>> f,
+                                                final Function<K, Set<K2>> onRem,
+                                                final Form<K2> kform, final Form<V2> vform) {
+    return new FlatMappedMapStream<>(this, context, f, onRem, kform, vform);
+  }
+
+  @Override
+  public SwimStream<V> get(final K key, final Sampling sampling) {
+    return new KeyFetch<>(this, context, key, sampling);
+  }
+
+  @Override
+  public SwimStream<V> get(final SwimStream<K> keys, final Sampling sampling, final boolean isTransient) {
+    return new ModalKeyFetch<>(this, context, keys, sampling, isTransient);
+  }
+
+  @Override
+  public SwimStream<Map<K, V>> stream() {
+    return new KeyValueStream<>(this, getContext());
+  }
+
+  @Override
+  public <U> MapSwimStream<K, U> fold(final U seed, final BiFunction<U, V, U> op, final Form<U> form,
+                                      final Sampling sampling, final boolean isTransient) {
+    return new FoldedMapStream<>(this, context, form, seed, op, sampling, isTransient);
+  }
+
+  @Override
+  public <U, M> MapSwimStream<K, U> foldModal(final M initialMode, final U seed, final Function<M, BiFunction<U, V, U>> op,
+                                              final Form<U> form, final Sampling sampling,
+                                              final SwimStream<M> controlStream, final boolean isTransient) {
+    return new ModalFoldedMapStream<>(this, context, form, seed, initialMode, op, controlStream, sampling, isTransient);
+  }
+
+  @Override
+  public MapSwimStream<K, V> reduce(final BinaryOperator<V> op, final Sampling sampling, final boolean isTransient) {
+    return new ReducedMapStream<>(this, context, op, sampling, isTransient);
+  }
+
+  @Override
+  public <M> MapSwimStream<K, V> reduceModal(final M initialMode,
+                                             final Function<M, BinaryOperator<V>> op, final Sampling sampling,
+                                             final SwimStream<M> controlStream, final boolean isTransient) {
+    return new ModalReducedMapStream<>(this, context, op, initialMode, controlStream, sampling, isTransient);
+  }
+
+  @Override
+  public <W, S extends WindowState<W, S>> MapWindowedSwimStream<K, V, W> window(
+      final Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+      final Form<W> windowForm,
+      final Sampling sampling,
+      final boolean isTransient) {
+    return new MapWindowedStream<>(this, context, windowForm, assigner, null, null,
+        sampling, isTransient);
+  }
+
+  @Override
+  public <V2, U> MapSwimStream<K, U> join(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                          final Form<U> form, final Sampling sampling) {
+    return new JoinedStream<>(this, other, context, form, combiner, null, null, sampling);
+  }
+
+  @Override
+  public <V2, U> MapSwimStream<K, U> leftJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner, final Function<V, U> leftOnly,
+                                              final Form<U> form, final Sampling sampling) {
+    return new JoinedStream<>(this, other, context, form, combiner, leftOnly, null, sampling);
+  }
+
+  @Override
+  public <V2, U> MapSwimStream<K, U> rightJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                               final Function<V2, U> rightOnly, final Form<U> form, final Sampling sampling) {
+    return new JoinedStream<>(this, other, context, form, combiner, null, rightOnly, sampling);
+  }
+
+  @Override
+  public <V2, U> MapSwimStream<K, U> fullJoin(final MapSwimStream<K, V2> other, final BiFunction<V, V2, U> combiner,
+                                              final Function<V, U> leftOnly, final Function<V2, U> rightOnly,
+                                              final Form<U> form, final Sampling sampling) {
+    return new JoinedStream<>(this, other, context, form, combiner, leftOnly, rightOnly, sampling);
+  }
+
+  @Override
+  public MapSwimStream<K, V> first(final boolean resetOnRemoval, final boolean isTransient) {
+    return new FirstMapStream<>(this, context, resetOnRemoval, isTransient);
+  }
+
+  @Override
+  public MapSwimStream<K, V> delayed(final int n, final boolean isTransient) {
+    return new DelayedMapStream<>(this, context, n, isTransient);
+  }
+
+  @Override
+  public MapSwimStream<K, V> delayed(final SwimStream<Integer> ns, final int init, final boolean isTransient) {
+    return new VariableDelayedMapStream<>(this, context, ns, init, isTransient);
+  }
+
+  public SinkHandle<K, V> bind(final MapSink<K, V> sink) {
+    return context.bindSink(this, sink);
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractSwimStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/AbstractSwimStream.java
@@ -1,0 +1,300 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.CollectionSwimStream;
+import swim.dataflow.graph.Either;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.MapWindowedSwimStream;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SinkHandle;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.Unit;
+import swim.dataflow.graph.WindowedSwimStream;
+import swim.dataflow.graph.sampling.DelaySpecifier;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.CombinedState;
+import swim.dataflow.graph.windows.CombinedWindowAssigner;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.dataflow.graph.windows.PartitionState;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+import swim.util.Builder;
+
+/**
+ * Provides standard implementations of combinator builder methods.
+ *
+ * @param <T> The type of the values.
+ */
+public abstract class AbstractSwimStream<T> implements SwimStream<T> {
+
+  private final Form<T> form;
+  private final ToLongFunction<T> timestamps;
+  private final BindingContext context;
+  private String id;
+
+  @Override
+  public final String id() {
+    return id;
+  }
+
+  @Override
+  public final AbstractSwimStream<T> setId(final String id) {
+    context.claimId(id);
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * @return Context use to instantiate the graph.
+   */
+  protected BindingContext getContext() {
+    return context;
+  }
+
+  /**
+   * @param valForm The form of the type of the values.
+   * @param con     Context used to instantiate the graph.
+   */
+  protected AbstractSwimStream(final Form<T> valForm, final BindingContext con) {
+    this.id = con.createId();
+    form = valForm;
+    timestamps = null;
+    context = con;
+  }
+
+  /**
+   * @param valForm The form of the type of the values.
+   * @param con     Context used to instantiate the graph.
+   * @param ts      Assigns timestamps.
+   */
+  protected AbstractSwimStream(final Form<T> valForm, final BindingContext con, final ToLongFunction<T> ts) {
+    this.id = con.createId();
+    form = valForm;
+    timestamps = ts;
+    context = con;
+  }
+
+  @Override
+  public ToLongFunction<T> getTimestamps() {
+    return timestamps;
+  }
+
+  @Override
+  public final Form<T> form() {
+    return form;
+  }
+
+  @Override
+  public <U> SwimStream<U> map(final Function<T, ? extends U> f, final boolean memoize, final Form<U> form) {
+    return new TransformedStream<>(this, context, f, memoize, form);
+  }
+
+  @Override
+  public <U, C extends Collection<U>> CollectionSwimStream<U, C> mapToCollection(final Function<T, C> f,
+                                                                                 final boolean memoize,
+                                                                                 final Form<C> form) {
+    return new TransformedColStream<>(this, context, f, memoize, form);
+  }
+
+  @Override
+  public SwimStream<T> filter(final Predicate<T> predicate) {
+    return new FilteredStream<>(this, context, predicate);
+  }
+
+
+  @Override
+  public <M> SwimStream<T> filterModal(final M initialMode,
+                                       final Function<M, Predicate<T>> predicate, final SwimStream<M> controlStream,
+                                       final boolean isTransient) {
+    return new ModalFilteredStream<>(this, context, initialMode, predicate, controlStream, isTransient);
+  }
+
+  @Override
+  public Pair<SwimStream<T>, SwimStream<T>> split(final Predicate<T> predicate) {
+    return new Pair<>(filter(predicate), filter(predicate.negate()));
+  }
+
+  @Override
+  public <E extends Enum<E>> Map<E, SwimStream<T>> categorize(final Function<T, E> categories, final Class<E> enumType) {
+    final EnumMap<E, SwimStream<T>> streamMap = new EnumMap<>(enumType);
+    for (final E enumConst : enumType.getEnumConstants()) {
+      streamMap.put(enumConst, filter(x -> categories.apply(x) == enumConst));
+    }
+    return streamMap;
+  }
+
+  @Override
+  public <U> SwimStream<U> flatMap(final Function<T, Iterable<U>> f, final Form<U> form, final DelaySpecifier delay) {
+
+    return new FlatMapStream<>(this, context, form, f, delay);
+  }
+
+  @Override
+  public <U, M2> SwimStream<U> mapModal(final M2 initialMode,
+                                        final Function<M2, Function<T, ? extends U>> f,
+                                        final boolean memoize,
+                                        final Form<U> form,
+                                        final SwimStream<M2> controlStream,
+                                        final boolean isTransient) {
+    return new ModalTransformedStream<>(this, context, initialMode, f, memoize, controlStream, form, isTransient);
+  }
+
+  @Override
+  public <U, M> SwimStream<U> flatMapModal(final M initialMode, final Function<M, Function<T, Iterable<U>>> f,
+                                           final Form<U> form, final DelaySpecifier delay,
+                                           final SwimStream<M> controlStream, final boolean isTransient) {
+    return new ModalFlatMapStream<>(this, context, form, initialMode, f, delay, controlStream, isTransient);
+  }
+
+  @Override
+  public <U> SwimStream<U> fold(final U seed, final BiFunction<U, T, U> op, final Form<U> form,
+                                final Sampling sampling, final boolean isTransient) {
+    return new FoldedStream<>(this, context, form, seed, op, sampling, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> reduce(final BinaryOperator<T> op, final Sampling sampling, final boolean isTransient) {
+    return new ReducedStream<>(this, context, op, sampling, isTransient);
+  }
+
+  @Override
+  public <U, M> SwimStream<U> foldModal(final M initialMode, final U seed, final Function<M, BiFunction<U, T, U>> op,
+                                        final Form<U> form, final Sampling sampling, final SwimStream<M> controlStream,
+                                        final boolean isTransient) {
+    return new ModalFoldedStream<>(this, context, initialMode, form, seed, op,
+        sampling, controlStream, isTransient);
+  }
+
+  @Override
+  public <M> SwimStream<T> reduceModal(final M initialMode, final Function<M, BinaryOperator<T>> op,
+                                       final Sampling sampling, final SwimStream<M> controlStream,
+                                       final boolean isTransient) {
+    return new ModalReducedStream<>(this, context, initialMode, op, sampling, controlStream, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> union(final Iterable<SwimStream<? extends T>> others) {
+    final Builder<SwimStream<? extends T>, FingerTrieSeq<SwimStream<? extends T>>> builder = FingerTrieSeq.builder();
+    builder.add(this);
+    for (final SwimStream<? extends T> other : others) {
+      builder.add(other);
+    }
+    final FingerTrieSeq<SwimStream<? extends T>> seq = builder.bind();
+    if (seq.isEmpty()) {
+      return this;
+    } else {
+      return new UnionStream<>(form(), seq, context);
+    }
+  }
+
+  @Override
+  public SwimStream<T> union(final SwimStream<? extends T> other) {
+    final Builder<SwimStream<? extends T>, FingerTrieSeq<SwimStream<? extends T>>> builder = FingerTrieSeq.builder();
+    builder.add(this);
+    builder.add(other);
+    return new UnionStream<>(form(), builder.bind(), context);
+  }
+
+
+  @Override
+  public <W, K, T2, U, S extends WindowState<W, S>> MapSwimStream<K, U> windowJoin(
+      final SwimStream<T2> other,
+      final TemporalWindowAssigner<Either<T, T2>, W, S> assigner,
+      final Trigger<Either<T, T2>, W> trigger,
+      final Form<K> kform, final Form<U> vform, final Form<W> windowForm,
+      final Sampling sampling,
+      final Function<T, K> firstToKey,
+      final Function<T2, K> secondToKey,
+      final BiFunction<T, T2, U> combine) {
+    final Form<Either<T, T2>> eitherForm = Either.form(form, other.form());
+    final SwimStream<Either<T, T2>> combined = map(Either::left, eitherForm)
+            .union(other.map(Either::right, eitherForm));
+    final WindowedSwimStream<Either<T, T2>, W> windowed = combined.window(assigner, windowForm, sampling)
+            .withTrigger(trigger);
+    final WindowJoinFunction<T, T2, K, U, W> joinFunction = new WindowJoinFunction<>(firstToKey, secondToKey, combine);
+
+    final Form<List<Pair<K, U>>> listForm = Form.forCollection(List.class, Pair.form(kform, vform));
+    return windowed.mapWindow(joinFunction, listForm)
+            .mapToCollection(c -> c, listForm)
+            .toMapStream(Pair::getFirst, Pair::getSecond, kform, vform);
+
+  }
+
+  public final <K> MapSwimStream<K, T> keyBy(final Function<T, K> keys, final Form<K> kform, final boolean isTransient) {
+
+    return new WrappedMapStream<>(this, context, keys, kform, isTransient);
+  }
+
+  @Override
+  public <W, S extends WindowState<W, S>> WindowedSwimStream<T, W> window(final TemporalWindowAssigner<T, W, S> assigner,
+                                                                          final Form<W> windowForm,
+                                                                          final Sampling sampling,
+                                                                          final boolean isTransient) {
+    return new WindowedStream<>(this, context, windowForm, assigner,
+        null, null, sampling, isTransient);
+  }
+
+  @Override
+  public <P, S extends PartitionState<P, S>> MapSwimStream<P, T> partition(final PartitionAssigner<T, P, S> assigner,
+                                                                           final Form<P> partForm,
+                                                                           final Sampling sampling,
+                                                                           final boolean isTransient) {
+    return new PartitionedStream<>(this, context, assigner, partForm, sampling, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> first(final boolean isTransient) {
+    return new FirstStream<>(this, context, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> delayed(final int n, final boolean isTransient) {
+    return new DelayedStream<>(this, context, n, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> delayed(final SwimStream<Integer> ns, final int init, final boolean isTransient) {
+    return new VariableDelayedStream<>(this, context, ns, init, isTransient);
+  }
+
+  @Override
+  public <P, W, S extends CombinedState<P, W, S>> MapWindowedSwimStream<P, T, W> window(
+      final CombinedWindowAssigner<T, P, W, S> assigner,
+      final Form<P> partForm,
+      final Form<W> windowForm, final Sampling sampling, final boolean isTransient) {
+    return new PartAndWinStream<>(this, context, assigner, null, null,
+        partForm, windowForm, sampling, isTransient);
+  }
+
+  public SinkHandle<Unit, T> bind(final Sink<T> sink) {
+    return context.bindSink(this, sink);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/CollectionToMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/CollectionToMapStream.java
@@ -1,0 +1,112 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.CollectionToMapConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.structure.Form;
+
+/**
+ * Map stream derived from a stream of collections, the elements of which induce the key value pairs of the map.
+ *
+ * @param <T> The type of the incoming stream elements.
+ * @param <C> The type of the incoming stream collections.
+ * @param <K> The type of the output keys.
+ * @param <V> The type of the output values.
+ */
+class CollectionToMapStream<T, C extends Collection<T>, K, V> extends AbstractMapStream<K, V> {
+
+  private final SwimStream<C> in;
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+  private final boolean isTransient;
+
+  /**
+   * @param input     The source stream.
+   * @param context   The initialization context.
+   * @param keys      Function from input data to keys.
+   * @param values    Function from input data to values.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  CollectionToMapStream(final SwimStream<C> input,
+                        final BindingContext context,
+                        final Function<T, K> keys,
+                        final Function<T, V> values,
+                        final Form<K> keyForm,
+                        final Form<V> valueForm,
+                        final boolean isTransient) {
+    super(keyForm, valueForm, context);
+    in = input;
+    toKey = keys;
+    toValue = values;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param input     The source stream.
+   * @param context   The initialization context.
+   * @param keys      Function from input data to keys.
+   * @param values    Function from input data to values.
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param ts        Timestamp assignment for the values.
+   */
+  CollectionToMapStream(final SwimStream<C> input,
+                        final BindingContext context,
+                        final Function<T, K> keys,
+                        final Function<T, V> values,
+                        final Form<K> keyForm,
+                        final Form<V> valueForm,
+                        final boolean isTransient,
+                        final ToLongFunction<V> ts) {
+    super(keyForm, valueForm, context, ts);
+    in = input;
+    toKey = keys;
+    toValue = values;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new CollectionToMapStream<>(in, getContext(), toKey, toValue, keyForm(), valueForm(), isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<C> source = context.createFor(in);
+    final CollectionToMapConduit<T, Collection<T>, K, V> conduit;
+    if (isTransient) {
+      conduit = new CollectionToMapConduit<>(toKey, toValue, valueForm());
+    } else {
+      final MapPersister<K, V> persister = context.getPersistenceProvider().forMap(
+          StateTags.stateTag(id()), keyForm(), valueForm());
+      conduit = new CollectionToMapConduit<>(toKey, toValue, persister);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/CollectionToMapTransform.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/CollectionToMapTransform.java
@@ -1,0 +1,140 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.streamlet.AbstractMapOutlet;
+import swim.streamlet.Inlet;
+import swim.streamlet.KeyEffect;
+import swim.streamlet.Outlet;
+
+/**
+ * Consumes a stream of collections and outputs a map stream based on the instantaneous values of the collection.
+ * @param <T> The type of the members of the collection.
+ * @param <C> The type of the collection.
+ * @param <K> The type of the map keys.
+ * @param <V> The type of the map values.
+ */
+final class CollectionToMapTransform<T, C extends Collection<T>, K, V> extends AbstractMapOutlet<K, V, Map<K, V>> implements Inlet<C> {
+
+  private Outlet<? extends C> input;
+  private int version;
+  private HashTrieMap<K, V> state = HashTrieMap.empty();
+  private final Function<T, K> toKey;
+  private final Function<T, V> toValue;
+
+  /**
+   * @param toKey Extract keys from the members of the collection.
+   * @param toValue Extract values from the members of the collection.
+   */
+  CollectionToMapTransform(final Function<T, K> toKey, final Function<T, V> toValue) {
+    this.toKey = toKey;
+    this.toValue = toValue;
+  }
+
+
+  @Override
+  public Outlet<? extends C> input() {
+    return this.input;
+  }
+
+  @Override
+  public void bindInput(final Outlet<? extends C> input) {
+    if (this.input != null) {
+      this.input.unbindOutput(this);
+    }
+    this.input = input;
+    if (this.input != null) {
+      this.input.bindOutput(this);
+    }
+  }
+
+  @Override
+  public void unbindInput() {
+    if (this.input != null) {
+      this.input.unbindOutput(this);
+    }
+    this.input = null;
+  }
+
+  @Override
+  public void disconnectInputs() {
+    final Outlet<? extends C> input = this.input;
+    if (input != null) {
+      input.unbindOutput(this);
+      this.input = null;
+      input.disconnectInputs();
+    }
+  }
+
+
+  @Override
+  public void invalidateOutput() {
+    if (this.version >= 0) {
+      this.version = -1;
+      invalidateInput();
+    }
+  }
+
+  @Override
+  public void reconcileOutput(final int version) {
+    if (this.version < 0) {
+      this.version = version;
+      if (this.input != null) {
+        this.input.reconcileInput(version);
+        final C col = input.get();
+        HashTrieSet<K> toRemove = HashTrieSet.from(state.keySet());
+        for (final T entry : col) {
+          final K key = toKey.apply(entry);
+          final V value = toValue.apply(entry);
+          state = state.updated(key, value);
+          toRemove = toRemove.removed(key);
+          invalidateInputKey(key, KeyEffect.UPDATE);
+        }
+        for (final K key : toRemove) {
+          state = state.removed(key);
+          invalidateInputKey(key, KeyEffect.REMOVE);
+        }
+      }
+      reconcileInput(version);
+    }
+  }
+
+  @Override
+  public boolean containsKey(final K key) {
+    return state.containsKey(key);
+  }
+
+  @Override
+  public V get(final K key) {
+    return state.get(key);
+  }
+
+  @Override
+  public Map<K, V> get() {
+    return state;
+  }
+
+  @Override
+  public Iterator<K> keyIterator() {
+    return state.keyIterator();
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ContextImpl.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ContextImpl.java
@@ -1,0 +1,264 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.IdentityHashMap;
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieSet;
+import swim.concurrent.Schedule;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.connector.Receptacle;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSink;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SinkHandle;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.Unit;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.structure.Form;
+
+/**
+ * Standard implementation of {@link SwimStreamContext}.
+ */
+class ContextImpl implements SwimStreamContext, BindingContext {
+
+  private final Schedule schedule;
+
+  /**
+   * Collects all sinks that have been attached to the graph. These terminal nodes are used to instantiate
+   * the graph from sink to source.
+   */
+  private FingerTrieSeq<InternalSinkHandle<?, ?>> sinkHandles = FingerTrieSeq.empty();
+
+  private final PersistenceProvider persistence;
+
+  ContextImpl(final Schedule schedule, final PersistenceProvider persistence) {
+    this.schedule = schedule;
+    this.persistence = persistence;
+  }
+
+  /**
+   * Add a new sink handle.
+   *
+   * @param handle The handle.
+   */
+  void addSinkHandle(final InternalSinkHandle<?, ?> handle) {
+    sinkHandles = sinkHandles.appended(handle);
+  }
+
+  @Override
+  public <T> SwimStream<T> fromJunction(final Supplier<Junction<T>> junction,
+                                        final Form<T> form,
+                                        final ToLongFunction<T> timestamps) {
+    return new ExternalOutletStream<>(form, this, junction, timestamps);
+  }
+
+  @Override
+  public <K, V> MapSwimStream<K, V> fromMapJunction(final Supplier<MapJunction<K, V>> junction,
+                                                    final Form<K> keyForm,
+                                                    final Form<V> valueForm,
+                                                    final ToLongFunction<V> timestamps) {
+    return new ExternalMapOutletStream<>(keyForm, valueForm, this, junction);
+  }
+
+  @Override
+  public InitContext constructGraph() {
+    final FingerTrieSeq<InternalSinkHandle<?, ?>> handles = sinkHandles;
+    final InitContextImpl initContext = new InitContextImpl(schedule, persistence);
+    for (final InternalSinkHandle<?, ?> handle : handles) {
+      handle.bindConnector(initContext);
+    }
+    return initContext;
+  }
+
+  @Override
+  public <T> SinkHandle<Unit, T> bindSink(final SwimStream<T> in, final Sink<T> sink) {
+    final SinkBinding<T> binding = new SinkBinding<>(in, sink);
+    addSinkHandle(binding);
+    return binding;
+  }
+
+  @Override
+  public <K, V> SinkHandle<K, V> bindSink(final MapSwimStream<K, V> in, final MapSink<K, V> sink) {
+    final MapSinkBinding<K, V> binding = new MapSinkBinding<>(in, sink);
+    addSinkHandle(binding);
+    return binding;
+  }
+
+  private int count = 0;
+
+  private HashTrieSet<String> names = HashTrieSet.empty();
+
+  @Override
+  public final String createId() {
+    String id;
+    do {
+      id = String.format("StreamElement%d", count);
+      ++count;
+    } while (names.contains(id));
+    names = names.added(id);
+    return id;
+  }
+
+  @Override
+  public void claimId(final String id) {
+    Require.that(id != null, "Stream element IDs must not be null.");
+    Require.that(!names.contains(id), String.format("Duplicate stream element ID: %s", id));
+    names = names.added(id);
+  }
+
+  /**
+   * Standard implementation of {@link SwimStreamContext.InitContext}.
+   */
+  static final class InitContextImpl implements SwimStreamContext.InitContext {
+
+    private final Schedule schedule;
+    private final PersistenceProvider persistence;
+    //These are to ensure that any given node of the graph is only instantiated once regardless of how
+    //many times it is referred to.
+
+    private final IdentityHashMap<Sink<?>, Receptacle<?>> receptacles = new IdentityHashMap<>();
+    private final IdentityHashMap<MapSink<?, ?>, MapReceptacle<?, ?>> mapReceptacles =
+        new IdentityHashMap<>();
+
+    private final IdentityHashMap<SwimStream<?>, Junction<?>> junctions = new IdentityHashMap<>();
+    private final IdentityHashMap<MapSwimStream<?, ?>, MapJunction<?, ?>> mapJunctions =
+        new IdentityHashMap<>();
+
+    InitContextImpl(final Schedule schedule, final PersistenceProvider persistence) {
+      this.schedule = schedule;
+      this.persistence = persistence;
+    }
+
+    @Override
+    public PersistenceProvider getPersistenceProvider() {
+      return persistence;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S> Junction<S> createFor(final SwimStream<S> stream) {
+      if (junctions.containsKey(stream)) {
+        return (Junction<S>) junctions.get(stream);
+      } else {
+        final Junction<S> out = stream.instantiate(this);
+        junctions.put(stream, out);
+        return out;
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> MapJunction<K, V> createFor(final MapSwimStream<K, V> stream) {
+      if (mapJunctions.containsKey(stream)) {
+        return (MapJunction<K, V>) mapJunctions.get(stream);
+      } else {
+        final MapJunction<K, V> out = stream.instantiate(this);
+        mapJunctions.put(stream, out);
+        return out;
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S> Receptacle<S> createFrom(final Sink<S> sink) {
+      if (receptacles.containsKey(sink)) {
+        return (Receptacle<S>) receptacles.get(sink);
+      } else {
+        final Receptacle<S> in = sink.instantiate(this);
+        receptacles.put(sink, in);
+        return in;
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> MapReceptacle<K, V> createFromMap(final MapSink<K, V> sink) {
+      if (mapReceptacles.containsKey(sink)) {
+        return (MapReceptacle<K, V>) mapReceptacles.get(sink);
+      } else {
+        final MapReceptacle<K, V> in = sink.instantiateReceptacle(this);
+        mapReceptacles.put(sink, in);
+        return in;
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S> Junction<S> getExisting(final SwimStream<S> stream) {
+      return (Junction<S>) junctions.get(stream);
+    }
+
+    @Override
+    public <S> void inject(final SwimStream<S> stream, final Junction<S> junction) {
+      if (!junctions.containsKey(stream)) {
+        junctions.put(stream, junction);
+      } else {
+        throw new IllegalArgumentException("Duplicate registration for stream.");
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> MapJunction<K, V> getExistingMap(final MapSwimStream<K, V> stream) {
+      return (MapJunction<K, V>) mapJunctions.get(stream);
+    }
+
+    @Override
+    public <K, V> void inject(final MapSwimStream<K, V> stream, final MapJunction<K, V> junction) {
+      if (!mapJunctions.containsKey(stream)) {
+        mapJunctions.put(stream, junction);
+      } else {
+        throw new IllegalArgumentException("Duplicate registration for map stream.");
+      }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <S> Receptacle<S> getExisting(final Sink<S> sink) {
+      return (Receptacle<S>) receptacles.get(sink);
+    }
+
+    @Override
+    public <S> void inject(final Sink<S> sink, final Receptacle<S> receptacle) {
+      receptacles.put(sink, receptacle);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K, V> MapReceptacle<K, V> getExistingMap(final MapSink<K, V> sink) {
+      return (MapReceptacle<K, V>) mapReceptacles.get(sink);
+    }
+
+    @Override
+    public <K, V> void injectMap(final MapSink<K, V> sink, final MapReceptacle<K, V> receptacle) {
+      mapReceptacles.put(sink, receptacle);
+    }
+
+
+    @Override
+    public Schedule getSchedule() {
+      return schedule;
+    }
+
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/DelayedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/DelayedMapStream.java
@@ -1,0 +1,104 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.DelayMapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.structure.Form;
+
+/**
+ * Stream that, interpreting its input as a sequence of discrete samples, will return the value received a fixed
+ * number of samples back from the most recent sample, for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+class DelayedMapStream<K, V> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final int steps;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The source stream.
+   * @param con         The instantiation context.
+   * @param steps       Number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   */
+  DelayedMapStream(final MapSwimStream<K, V> in, final BindingContext con,
+                   final int steps,
+                   final boolean isTransient) {
+    super(in.keyForm(), in.valueForm(), con);
+    validate(steps);
+    this.in = in;
+    this.steps = steps;
+    this.isTransient = isTransient;
+  }
+
+  private static void validate(final int steps) {
+    Require.that(steps > 1, "Delay must be at least 1");
+  }
+
+  /**
+   * @param in          The source stream.
+   * @param con         The instantiation context.
+   * @param steps       Number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   * @param ts          Assigns timestamps to the values.
+   */
+  DelayedMapStream(final MapSwimStream<K, V> in, final BindingContext con,
+                   final int steps,
+                   final boolean isTransient,
+                   final ToLongFunction<V> ts) {
+    super(in.keyForm(), in.valueForm(), con, ts);
+    validate(steps);
+    this.in = in;
+    this.steps = steps;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new DelayedMapStream<>(in, getContext(), steps, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final DelayMapConduit<K, V> conduit;
+    if (isTransient) {
+      conduit = new DelayMapConduit<>(steps);
+    } else {
+      final PersistenceProvider perProvider = context.getPersistenceProvider();
+      final Form<K> kForm = keyForm();
+      final Form<V> vForm = valueForm();
+      final Function<K, ListPersister<V>> bufferPeristers = k -> perProvider.forList(
+          StateTags.keyedStateTag(id(), kForm.mold(k).toValue()), vForm);
+      final SetPersister<K> keysPersister = perProvider.forSet(StateTags.stateTag(id()), kForm);
+      conduit = new DelayMapConduit<>(bufferPeristers, keysPersister, steps);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/DelayedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/DelayedStream.java
@@ -1,0 +1,96 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.DelayConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ListPersister;
+
+/**
+ * Stream that, interpreting its input as a sequence of discrete samples, will return the value received a fixed
+ * number of samples back from the most recent sample.
+ *
+ * @param <T> The type of the values.
+ */
+public class DelayedStream<T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final int steps;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The source stream.
+   * @param con         The instantiation context.
+   * @param steps       Number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   */
+  DelayedStream(final SwimStream<T> in, final BindingContext con,
+                final int steps,
+                final boolean isTransient) {
+    super(in.form(), con);
+    validate(steps);
+    this.in = in;
+    this.steps = steps;
+    this.isTransient = isTransient;
+  }
+
+  private static void validate(final int steps) {
+    Require.that(steps > 1, "Delay must be at least 1");
+  }
+
+  /**
+   * @param in          The source stream.
+   * @param con         The instantiation context.
+   * @param steps       Number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   * @param ts          Assigns timestamps to the values.
+   */
+  DelayedStream(final SwimStream<T> in, final BindingContext con,
+                final int steps,
+                final boolean isTransient,
+                final ToLongFunction<T> ts) {
+    super(in.form(), con, ts);
+    validate(steps);
+    this.in = in;
+    this.steps = steps;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new DelayedStream<>(in, getContext(), steps, isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+
+    final Junction<T> source = context.createFor(in);
+    final DelayConduit<T> conduit;
+
+    if (isTransient) {
+      conduit = new DelayConduit<>(steps);
+    } else {
+      final ListPersister<T> persister = context.getPersistenceProvider().forList(StateTags.stateTag(id()), form());
+      conduit = new DelayConduit<>(persister, steps);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/EvictionUtil.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/EvictionUtil.java
@@ -1,0 +1,36 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.impl.windows.PaneEvictor;
+import swim.dataflow.graph.impl.windows.SequenceThresholdEvictor;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+
+/**
+ * Eviction utility methods.
+ */
+final class EvictionUtil {
+
+  private EvictionUtil() {
+  }
+
+  static <T, W, K extends Comparable<K>> PaneEvictor<T, W, FingerTrieSeq<WithTimestamp<T>>> createEvictor(
+      final ThresholdEviction<T, K, W> strat) {
+    return new SequenceThresholdEvictor<>(strat.getCriterion(), strat.getThreshold(), strat.assumeStateOrdered());
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ExternalMapOutletStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ExternalMapOutletStream.java
@@ -1,0 +1,74 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * Map stream drawing value from an external source.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+final class ExternalMapOutletStream<K, V> extends AbstractMapStream<K, V> {
+
+  private final Supplier<MapJunction<K, V>> outlet;
+
+  /**
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param context   The instantiation context.
+   * @param junctionSupplier Supplier for the source junction.
+   */
+  ExternalMapOutletStream(final Form<K> keyForm, final Form<V> valueForm,
+                          final BindingContext context,
+                          final Supplier<MapJunction<K, V>> junctionSupplier) {
+    super(keyForm, valueForm, context);
+    outlet = junctionSupplier;
+  }
+
+  /**
+   * @param keyForm   The form of the type of the keys.
+   * @param valueForm The form of the type of the values.
+   * @param context   The instantiation context.
+   * @param junctionSupplier Supplier for the source junction.
+   * @param ts        Timestamp assignment for the values.
+   */
+  ExternalMapOutletStream(final Form<K> keyForm, final Form<V> valueForm,
+                          final BindingContext context,
+                          final Supplier<MapJunction<K, V>> junctionSupplier,
+                          final ToLongFunction<V> ts) {
+    super(keyForm, valueForm, context, ts);
+    outlet = junctionSupplier;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ExternalMapOutletStream<>(keyForm(), valueForm(), getContext(), outlet, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    return outlet.get();
+  }
+
+}
+

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ExternalOutletStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ExternalOutletStream.java
@@ -1,0 +1,59 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * Stream drawing value from an external source.
+ *
+ * @param <T> The type of the values.
+ */
+final class ExternalOutletStream<T> extends AbstractSwimStream<T> {
+
+  private final Supplier<Junction<T>> outlet;
+
+  /**
+   * @param valForm   The form of the types of the values.
+   * @param context   The instantiation context.
+   * @param junctionSupplier Supplier for the source junction.
+   * @param ts        Assigns timestamps to the values.
+   */
+  ExternalOutletStream(final Form<T> valForm,
+                       final BindingContext context,
+                       final Supplier<Junction<T>> junctionSupplier,
+                       final ToLongFunction<T> ts) {
+    super(valForm, context, ts);
+    outlet = junctionSupplier;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ExternalOutletStream<>(form(), getContext(), outlet, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+
+    return outlet.get();
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FilteredMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FilteredMapStream.java
@@ -1,0 +1,71 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiPredicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FilteredMapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+
+/**
+ * A filtered view on a map stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+class FilteredMapStream<K, V> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final BiPredicate<K, V> predicate;
+
+  /**
+   * @param input The input stream.
+   * @param con   The instantiation context.
+   * @param pred  Predicate to filter the stream.
+   */
+  FilteredMapStream(final MapSwimStream<K, V> input, final BindingContext con, final BiPredicate<K, V> pred) {
+    super(input.keyForm(), input.valueForm(), con);
+    in = input;
+    predicate = pred;
+  }
+
+  /**
+   * @param input The input stream.
+   * @param con   The instantiation context.
+   * @param pred  Predicate to filter the stream.
+   */
+  FilteredMapStream(final MapSwimStream<K, V> input, final BindingContext con, final BiPredicate<K, V> pred,
+                    final ToLongFunction<V> ts) {
+    super(input.keyForm(), input.valueForm(), con, ts);
+    in = input;
+    predicate = pred;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new FilteredMapStream<>(in, getContext(), predicate, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final FilteredMapConduit<K, V> conduit = new FilteredMapConduit<>(predicate);
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FilteredStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FilteredStream.java
@@ -1,0 +1,78 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FilteredConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+
+/**
+ * A filtered view of a stream.
+ *
+ * @param <T> The type of the values.
+ */
+class FilteredStream<T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final Predicate<T> predicate;
+
+  /**
+   * @param input   The input stream.
+   * @param context The instantiation context.
+   * @param pred    The predicate to filter the stream.
+   */
+  FilteredStream(final SwimStream<T> input,
+                 final BindingContext context,
+                 final Predicate<T> pred) {
+    super(input.form(), context);
+    in = input;
+    predicate = pred;
+  }
+
+  /**
+   * @param input   The input stream.
+   * @param context The instantiation context.
+   * @param pred    The predicate to filter the stream.
+   * @param ts      Time-stamp assigner for the stream.
+   */
+  FilteredStream(final SwimStream<T> input,
+                 final BindingContext context,
+                 final Predicate<T> pred,
+                 final ToLongFunction<T> ts) {
+    super(input.form(), context, ts);
+    in = input;
+    predicate = pred;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new FilteredStream<>(in, getContext(), predicate, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(in);
+    final FilteredConduit<T> conduit = new FilteredConduit<>(predicate);
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}
+
+

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FirstMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FirstMapStream.java
@@ -1,0 +1,88 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FirstValueMapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+
+/**
+ * A stream that will only ever contain the first value received from its source for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+class FirstMapStream<K, V> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final boolean resetOnRemoval;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The input stream.
+   * @param context         The instantiation context.
+   * @param resetOnRemoval Whether the first value resets on key removal.
+   * @param isTransient Whether to persist the first value.
+   */
+  FirstMapStream(final MapSwimStream<K, V> in, final BindingContext context,
+                 final boolean resetOnRemoval,
+                 final boolean isTransient) {
+    super(in.keyForm(), in.valueForm(), context);
+    this.in = in;
+    this.resetOnRemoval = resetOnRemoval;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param in          The input stream.
+   * @param context         The instantiation context.
+   * @param resetOnRemoval Whether the first value resets on key removal.
+   * @param isTransient Whether to persist the first value.
+   * @param ts          Assigns timestamps to the values.
+   */
+  FirstMapStream(final MapSwimStream<K, V> in, final BindingContext context,
+                 final boolean resetOnRemoval,
+                 final boolean isTransient,
+                        final ToLongFunction<V> ts) {
+    super(in.keyForm(), in.valueForm(), context, ts);
+    this.in = in;
+    this.resetOnRemoval = resetOnRemoval;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new FirstMapStream<>(in, getContext(), resetOnRemoval, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final FirstValueMapConduit<K, V> conduit;
+    if (isTransient) {
+      conduit = new FirstValueMapConduit<>(resetOnRemoval, valueForm());
+    } else {
+      final MapPersister<K, V> persister = context.getPersistenceProvider()
+          .forMap(StateTags.stateTag(id()), keyForm(), valueForm());
+      conduit = new FirstValueMapConduit<>(resetOnRemoval, persister);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FirstStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FirstStream.java
@@ -1,0 +1,81 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FirstValueConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * A stream that will only ever contain the first value received from its source.
+ *
+ * @param <T> The type of the values.
+ */
+final class FirstStream<T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The input stream.
+   * @param con         The instantiation context.
+   * @param isTransient Whether to persist the first value.
+   */
+  FirstStream(final SwimStream<T> in, final BindingContext con,
+              final boolean isTransient) {
+    super(in.form(), con);
+    this.in = in;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param in          The input stream.
+   * @param con         The instantiation context.
+   * @param isTransient Whether to persist the first value.
+   * @param ts          Assigns timestamps to the values.
+   */
+  FirstStream(final SwimStream<T> in, final BindingContext con,
+              final boolean isTransient,
+              final ToLongFunction<T> ts) {
+    super(in.form(), con, ts);
+    this.in = in;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new FirstStream<>(in, getContext(), isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(in);
+
+    final FirstValueConduit<T> conduit;
+    if (isTransient) {
+      conduit = new FirstValueConduit<>();
+    } else {
+      final ValuePersister<T> persister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), form().unit(null));
+      conduit = new FirstValueConduit<>(persister);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatMapStream.java
@@ -1,0 +1,130 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.concurrent.Schedule;
+import swim.dataflow.connector.AbstractJunction;
+import swim.dataflow.connector.FlatMapConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.VariableFlatMapConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.Iterables;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.DelaySpecifier;
+import swim.structure.Form;
+import swim.structure.form.DurationForm;
+
+/**
+ * Stream with a flat-map operation applied across its values. The sequences of values produced for each change is
+ * emitted sequentially with a specified delay.
+ *
+ * @param <S> The input type.
+ * @param <T> The output type.
+ */
+class FlatMapStream<S, T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<S> in;
+  private final Function<S, Iterable<T>> f;
+  private final DelaySpecifier delay;
+
+  /**
+   * @param inputs     The input stream.
+   * @param context    The instantiation context.
+   * @param valForm    The form of the type of the output values.
+   * @param mapping    The flat-map operation.
+   * @param delayStrat Specification for the delay.
+   */
+  FlatMapStream(final SwimStream<S> inputs,
+                final BindingContext context,
+                final Form<T> valForm, final Function<S, Iterable<T>> mapping,
+                final DelaySpecifier delayStrat) {
+    super(valForm, context);
+    in = inputs;
+    f = mapping;
+    delay = delayStrat;
+  }
+
+  FlatMapStream(final SwimStream<S> inputs,
+                final BindingContext context,
+                final Form<T> valForm, final Function<S, Iterable<T>> mapping,
+                final DelaySpecifier delayStrat, final ToLongFunction<T> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    f = mapping;
+    delay = delayStrat;
+  }
+
+  @Override
+  public <U> SwimStream<U> map(final Function<T, ? extends U> f2, final Form<U> form) {
+    final Function<S, Iterable<U>> composed = f.andThen(it -> Iterables.mapIterable(it, f2));
+    return new FlatMapStream<>(in, getContext(), form, composed, delay);
+  }
+
+  @Override
+  public <U> SwimStream<U> flatMap(final Function<T, Iterable<U>> f2, final Form<U> form, final DelaySpecifier delayStrat) {
+    if (delay.equals(delayStrat)) {
+      final Function<S, Iterable<U>> composed = f.andThen(it -> Iterables.flatMapIterable(it, f2));
+      return new FlatMapStream<>(in, getContext(), form, composed, delay);
+    } else {
+      return super.flatMap(f2, form, delayStrat);
+    }
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new FlatMapStream<>(in, getContext(), form(), f, delay, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<S> source = context.createFor(in);
+    final Schedule schedule = context.getSchedule();
+    return delay.matchDelay(dur -> simpleFlatMap(source, schedule, dur.getInterval()),
+        dyn -> dynamicFlatMap(context, source, schedule, dyn.getInitial(),
+            dyn.getIntervalStream(), dyn.isTransient()));
+  }
+
+  private AbstractJunction<T> dynamicFlatMap(final SwimStreamContext.InitContext context,
+                                             final Junction<S> source,
+                                             final Schedule schedule,
+                                             final Duration init,
+                                             final SwimStream<Duration> delays,
+                                             final boolean isTransient) {
+    final Junction<Duration> delayJunction = context.createFor(delays);
+    final VariableFlatMapConduit<S, T> junction;
+    if (isTransient) {
+      junction = new VariableFlatMapConduit<>(f, schedule, init);
+    } else {
+      final ValuePersister<Duration> persister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), new DurationForm(init));
+      junction = new VariableFlatMapConduit<>(f, schedule, persister);
+    }
+    delayJunction.subscribe(junction.second());
+    source.subscribe(junction.first());
+    return junction;
+  }
+
+  private AbstractJunction<T> simpleFlatMap(final Junction<S> source, final Schedule schedule, final Duration dur) {
+    final FlatMapConduit<S, T> conduit = new FlatMapConduit<>(f, schedule, dur);
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatMappedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatMappedMapStream.java
@@ -1,0 +1,98 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FlatMapEntriesConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * Flat-map operation across the key-value pairs of a map stream. A combine operation is supplied to merge
+ * together multiple values for a single key after the operation.
+ *
+ * @param <K1> The type of the input keys.
+ * @param <K2> The type if the output keys.
+ * @param <V1> The type of the input values.
+ * @param <V2> The type of the output values.
+ */
+class FlatMappedMapStream<K1, K2, V1, V2> extends AbstractMapStream<K2, V2> {
+
+  private final MapSwimStream<K1, V1> in;
+  private final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> f;
+  private final Function<K1, Set<K2>> onRemove;
+
+  /**
+   * @param input   The input stream.
+   * @param context The instantiation context.
+   * @param fun     Flat-map operation (which may result in multiple values for the new keys).
+   * @param onRem   Mapping for key removals.
+   * @param kform   The form of the type of the output keys.
+   * @param vform   The form of the type of the output values.
+   */
+  FlatMappedMapStream(
+          final MapSwimStream<K1, V1> input,
+          final BindingContext context,
+          final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> fun,
+          final Function<K1, Set<K2>> onRem,
+          final Form<K2> kform, final Form<V2> vform) {
+    super(kform, vform, context);
+    f = fun;
+    in = input;
+    onRemove = onRem;
+  }
+
+  /**
+   * @param input   The input stream.
+   * @param context The instantiation context.
+   * @param fun     Flat-map operation (which may result in multiple values for the new keys).
+   * @param onRem   Mapping for key removals.
+   * @param kform   The form of the type of the output keys.
+   * @param vform   The form of the type of the output values.
+   * @param ts      Timestamp assignment for the values.
+   */
+  FlatMappedMapStream(
+      final MapSwimStream<K1, V1> input,
+      final BindingContext context,
+      final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> fun,
+      final Function<K1, Set<K2>> onRem,
+      final Form<K2> kform, final Form<V2> vform,
+      final ToLongFunction<V2> ts) {
+    super(kform, vform, context, ts);
+    f = fun;
+    in = input;
+    onRemove = onRem;
+  }
+
+  @Override
+  public MapSwimStream<K2, V2> updateTimestamps(final ToLongFunction<V2> datation) {
+    return new FlatMappedMapStream<>(in, getContext(), f, onRemove, keyForm(), valueForm(), datation);
+  }
+
+  @Override
+  public MapJunction<K2, V2> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K1, V1> source = context.createFor(in);
+    final FlatMapEntriesConduit<K1, K2, V1, V2> conduit = new FlatMapEntriesConduit<>(f, onRemove);
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatmapEntriesChannel.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FlatmapEntriesChannel.java
@@ -1,0 +1,93 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Pair;
+import swim.streamlet.AbstractMapInletMapOutlet;
+import swim.streamlet.KeyEffect;
+
+/**
+ * Channel that generates a new map by applying a function to entries in a source map which results in a sequence
+ * of entries for the new map.
+ * @param <KI> The input key type.
+ * @param <KO> The output key type.
+ * @param <VI> The input value type.
+ * @param <VO> The output value type.
+ * @param <I> The input state type.
+ */
+final class FlatmapEntriesChannel<KI, KO, VI, VO, I> extends AbstractMapInletMapOutlet<KI, KO, VI, VO, I, Map<KO, VO>> {
+
+  private final BiFunction<KI, VI, Iterable<Pair<KO, VO>>> mapping;
+  private final Function<KI, Set<KO>> onRemove;
+  private HashTrieMap<KO, VO> state = HashTrieMap.empty();
+
+  /**
+   * @param mapping Mapping from entries into the input map to entries in the output map.
+   * @param onRemove Mapping from removed keys in the input map to keys to remove from the output.
+   */
+  FlatmapEntriesChannel(final BiFunction<KI, VI, Iterable<Pair<KO, VO>>> mapping,
+                        final Function<KI, Set<KO>> onRemove) {
+
+    this.mapping = mapping;
+    this.onRemove = onRemove;
+  }
+
+  @Override
+  public boolean containsKey(final KO key) {
+    return state.containsKey(key);
+  }
+
+  @Override
+  public VO get(final KO key) {
+    return state.get(key);
+  }
+
+  @Override
+  public Map<KO, VO> get() {
+    return state;
+  }
+
+  @Override
+  public Iterator<KO> keyIterator() {
+    return state.keyIterator();
+  }
+
+  @Override
+  protected void onReconcileOutputKey(final KI key, final KeyEffect effect, final int version) {
+    if (input != null) {
+      switch (effect) {
+        case UPDATE:
+          final Iterable<Pair<KO, VO>> entries = mapping.apply(key, input.get(key));
+          for (final Pair<KO, VO> entry : entries) {
+            state = state.updated(entry.getFirst(), entry.getSecond());
+          }
+          break;
+        case REMOVE:
+          for (final KO remKey : onRemove.apply(key)) {
+            state = state.removed(remKey);
+          }
+          break;
+
+        default:
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedMapStream.java
@@ -1,0 +1,116 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.MapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Stream of the intermediate results of apply an aggregation over a map stream, per key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <U> The type of the results.
+ */
+class FoldedMapStream<K, V, U> extends AbstractMapStream<K, U> {
+
+  private final MapSwimStream<K, V> in;
+  private final U seed;
+  private final BiFunction<U, V, U> foldFunction;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the results.
+   * @param seedValue   The seed value for the aggregation.
+   * @param foldOp     The aggregation operation.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  FoldedMapStream(final MapSwimStream<K, V> inputs,
+                  final BindingContext context,
+                  final Form<U> valForm,
+                  final U seedValue,
+                  final BiFunction<U, V, U> foldOp,
+                  final Sampling sampleStrat,
+                  final boolean isTransient) {
+    super(inputs.keyForm(), valForm, context);
+    in = inputs;
+    seed = seedValue;
+    foldFunction = foldOp;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the results.
+   * @param seedValue   The seed value for the aggregation.
+   * @param scanner     The aggregation operation.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts          Timestamp assignment for the values.
+   */
+  FoldedMapStream(final MapSwimStream<K, V> inputs,
+                  final BindingContext context,
+                  final Form<U> valForm,
+                  final U seedValue,
+                  final BiFunction<U, V, U> scanner,
+                  final Sampling sampleStrat,
+                  final boolean isTransient,
+                  final ToLongFunction<U> ts) {
+    super(inputs.keyForm(), valForm, context, ts);
+    in = inputs;
+    seed = seedValue;
+    foldFunction = scanner;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new FoldedMapStream<>(in, getContext(), valueForm(), seed, foldFunction, sampling, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, U> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final MapConduit<K, K, V, U> conduit;
+    if (isTransient) {
+      conduit = StatefulConduits.foldMap(seed, foldFunction);
+    } else {
+      final MapPersister<K, U> persister = context.getPersistenceProvider()
+          .forMap(StateTags.stateTag(id()), keyForm(), valueForm(), seed);
+      conduit = StatefulConduits.foldMapPersistent(persister, foldFunction);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedMapWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedMapWindowedStream.java
@@ -1,0 +1,220 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.collections.BTreeMap;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.FoldPaneUpdater;
+import swim.dataflow.graph.impl.windows.FoldingEvaluator;
+import swim.dataflow.graph.impl.windows.KeyedWindowConduit;
+import swim.dataflow.graph.impl.windows.MapPaneUpdater;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvaluator;
+import swim.dataflow.graph.impl.windows.PaneManager;
+import swim.dataflow.graph.impl.windows.ReducingEvaluator;
+import swim.dataflow.graph.impl.windows.SequencePaneUpdater;
+import swim.dataflow.graph.impl.windows.SequenceThresholdEvictor;
+import swim.dataflow.graph.impl.windows.ThresholdEvictor;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.KeyedWindowBinOp;
+import swim.dataflow.graph.windows.KeyedWindowFoldFunction;
+import swim.dataflow.graph.windows.KeyedWindowSpec;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+import swim.structure.Form;
+
+/**
+ * A stream that results from applying a fold operation across each key and window of a map stream.
+ *
+ * @param <K> The type of the keys of the map stream.
+ * @param <T> The type of the values of the map stream.
+ * @param <U> The type of the result of the fold operation.
+ * @param <W> The type of the windows.
+ */
+class FoldedMapWindowedStream<K, T, U, W, S extends WindowState<W, S>> extends AbstractMapStream<K, U> {
+
+  private final MapSwimStream<K, T> in;
+  private final KeyedWindowSpec<K, T, W, S> spec;
+  private final BiFunction<K, W, U> seedFun;
+  private final KeyedWindowFoldFunction<K, T, W, U> winFun;
+  private final KeyedWindowBinOp<K, U, W> combiner;
+  private final Sampling sampling;
+
+  /**
+   * @param stream  The input map stream.
+   * @param context The instantiation context.
+   * @param form    The form of the type of the output values.
+   * @param seed    The seed for the fold operation (which may depend on the key and window).
+   * @param fun     The fold operation.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  FoldedMapWindowedStream(final MapSwimStream<K, T> stream,
+                          final BindingContext context,
+                          final KeyedWindowSpec<K, T, W, S> windowSpec,
+                          final Form<U> form,
+                          final BiFunction<K, W, U> seed,
+                          final KeyedWindowFoldFunction<K, T, W, U> fun,
+                          final KeyedWindowBinOp<K, U, W> combOp,
+                          final Sampling samplingStrat) {
+    super(stream.keyForm(), form, context);
+    in = stream;
+    spec = windowSpec;
+    seedFun = seed;
+    winFun = fun;
+    combiner = combOp;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param stream  The input map stream.
+   * @param context The instantiation context.
+   * @param form    The form of the type of the output values.
+   * @param seed    The seed for the fold operation (which may depend on the key and window).
+   * @param fun     The fold operation.
+   * @param ts      Timestamp assignment for the values.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  FoldedMapWindowedStream(final MapSwimStream<K, T> stream,
+                          final BindingContext context,
+                          final KeyedWindowSpec<K, T, W, S> windowSpec,
+                          final Form<U> form,
+                          final BiFunction<K, W, U> seed,
+                          final KeyedWindowFoldFunction<K, T, W, U> fun,
+                          final KeyedWindowBinOp<K, U, W> combOp,
+                          final Sampling samplingStrat,
+                          final ToLongFunction<U> ts) {
+    super(stream.keyForm(), form, context, ts);
+    in = stream;
+    spec = windowSpec;
+    seedFun = seed;
+    winFun = fun;
+    combiner = combOp;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public MapJunction<K, U> instantiate(final SwimStreamContext.InitContext context) {
+    final PersistenceProvider persistence = context.getPersistenceProvider();
+
+    final Function<K, PaneManager<T, W, U>> paneManagers = k -> spec.getEvictionStrategy().apply(k).match(
+        none -> createWithoutEviction(k, persistence), threshold -> createWithEviction(k, persistence, threshold));
+    final MapJunction<K, T> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+
+    final ToLongFunction<T> ts = in.getTimestamps();
+    final TimestampAssigner<T> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+    final KeyedWindowConduit<K, T, W, U> conduit;
+    if (spec.isTransient()) {
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), paneManagers, timestamps);
+    } else {
+      final SetPersister<K> keysPersister = context.getPersistenceProvider().forSet(
+          StateTags.stateTag(id()), keyForm());
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), keysPersister, paneManagers, timestamps);
+    }
+
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  //When we have eviction it is necessary to maintain all of the data in the window.
+  private <C extends Comparable<C>> PaneManager<T, W, U> createWithEviction(
+      final K k,
+      final PersistenceProvider persistence,
+      final ThresholdEviction<T, C, W> eviction) {
+    final Function<W, U> keySeedFun = w -> seedFun.apply(k, w);
+    final WindowFoldFunction<T, W, U> keyedFun = (w, u, v) -> winFun.apply(k, w, u, v);
+    if (combiner == null) {
+      final SequencePaneUpdater<T, W> updater = new SequencePaneUpdater<>();
+      final SequenceThresholdEvictor<T, C, W> evictor = new SequenceThresholdEvictor<>(
+          eviction.getCriterion(), eviction.getThreshold(), eviction.assumeStateOrdered());
+
+      final FoldingEvaluator<T, W, U> evaluator = new FoldingEvaluator<>(keySeedFun, keyedFun);
+
+      final WindowAccumulators<W, FingerTrieSeq<WithTimestamp<T>>> accumulators = WindowStates.forSequencesState(
+          spec.isTransient(),
+          StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+          persistence,
+          spec.getWindowForm(),
+          in.valueForm()
+      );
+
+      return new DefaultPaneManager<>(accumulators,
+          spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+    } else {
+      final MapPaneUpdater<T, W, C, U> updater = new MapPaneUpdater<>(eviction.getCriterion());
+      final ThresholdEvictor<T, C, W, U> evictor = new ThresholdEvictor<>(eviction.getThreshold());
+
+      final WindowBinOp<U, W> keyedCombine = (w, u1, u2) -> combiner.apply(k, w, u1, u2);
+
+      final PaneEvaluator<BTreeMap<C, T, U>, W, U> evaluator = new ReducingEvaluator<>(keySeedFun, keyedFun, keyedCombine);
+
+      final WindowAccumulators<W, BTreeMap<C, T, U>> accumulators = WindowStates.forMapState(
+          spec.isTransient(),
+          StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+          persistence,
+          spec.getWindowForm(),
+          eviction.getCriterionForm(),
+          in.valueForm()
+      );
+      return new DefaultPaneManager<>(accumulators,
+          spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+    }
+  }
+
+  //Without eviction we only need to store the state of the operation.
+  private PaneManager<T, W, U> createWithoutEviction(final K k, final PersistenceProvider persistence) {
+    final Function<W, U> keySeedFun = w -> seedFun.apply(k, w);
+    final WindowFoldFunction<T, W, U> keyedFun = (w, u, v) -> winFun.apply(k, w, u, v);
+    final FoldPaneUpdater<T, W, U> updater = new FoldPaneUpdater<>(keySeedFun, keyedFun);
+    final NoOpEvictor<T, W, U> evictor = NoOpEvictor.instance();
+    final PaneEvaluator<U, W, U> evaluator = PaneEvaluator.identity();
+
+    final WindowAccumulators<W, U> accumulators = WindowStates.forSimpleState(
+        spec.isTransient(),
+        StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+        persistence,
+        spec.getWindowForm(),
+        valueForm()
+    );
+
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+  }
+
+  @Override
+  public MapSwimStream<K, U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new FoldedMapWindowedStream<>(in, getContext(), spec, valueForm(), seedFun, winFun, combiner, sampling, datation);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedStream.java
@@ -1,0 +1,114 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Conduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Stream of the intermediate results of apply an aggregation over a stream.
+ *
+ * @param <T> The type of the values.
+ * @param <U> The type of the results.
+ */
+class FoldedStream<T, U> extends AbstractSwimStream<U> {
+
+  private final SwimStream<T> in;
+  private final U seed;
+  private final BiFunction<U, T, U> foldFunction;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the outputs.
+   * @param seedValue   The seed value for the aggregation.
+   * @param scanner     The aggregation operation.
+   * @param sampleStrat Sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  FoldedStream(final SwimStream<T> inputs,
+               final BindingContext context,
+               final Form<U> valForm,
+               final U seedValue,
+               final BiFunction<U, T, U> scanner,
+               final Sampling sampleStrat,
+               final boolean isTransient) {
+    super(valForm, context);
+    in = inputs;
+    seed = seedValue;
+    foldFunction = scanner;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the outputs.
+   * @param seedValue   The seed value for the aggregation.
+   * @param folder     The aggregation operation.
+   * @param sampleStrat Sampling strategy for the link.
+   * @param ts          Timestamp assigner for the stream.
+   */
+  FoldedStream(final SwimStream<T> inputs,
+               final BindingContext context,
+               final Form<U> valForm,
+               final U seedValue,
+               final BiFunction<U, T, U> folder,
+               final Sampling sampleStrat,
+               final boolean isTransient,
+               final ToLongFunction<U> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    seed = seedValue;
+    foldFunction = folder;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new FoldedStream<>(in, getContext(), form(), seed, foldFunction, sampling, isTransient, datation);
+  }
+
+  @Override
+  public Junction<U> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final Conduit<T, U> foldConduit;
+    if (isTransient) {
+      foldConduit = StatefulConduits.fold(seed, foldFunction);
+    } else {
+      final ValuePersister<U> persister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), form(), seed);
+      foldConduit = StatefulConduits.foldPersistent(persister, foldFunction);
+    }
+    source.subscribe(foldConduit);
+    return foldConduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/FoldedWindowedStream.java
@@ -1,0 +1,206 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.collections.BTreeMap;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext.InitContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.FoldPaneUpdater;
+import swim.dataflow.graph.impl.windows.FoldingEvaluator;
+import swim.dataflow.graph.impl.windows.MapPaneUpdater;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvaluator;
+import swim.dataflow.graph.impl.windows.PaneManager;
+import swim.dataflow.graph.impl.windows.ReducingEvaluator;
+import swim.dataflow.graph.impl.windows.SequencePaneUpdater;
+import swim.dataflow.graph.impl.windows.SequenceThresholdEvictor;
+import swim.dataflow.graph.impl.windows.ThresholdEvictor;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.impl.windows.WindowConduit;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+import swim.structure.Form;
+
+/**
+ * A stream that results from a fold operation applied across the windows of a windowed stream.
+ *
+ * @param <T> The type of the input values.
+ * @param <W> The type of the windows.
+ * @param <U> The type of the outputs.
+ */
+public class FoldedWindowedStream<T, W, S extends WindowState<W, S>, U> extends AbstractSwimStream<U> {
+
+  private final SwimStream<T> in;
+  private final WindowSpec<T, W, S> spec;
+  private final Function<W, U> seedFun;
+  private final WindowFoldFunction<T, W, U> winFun;
+  private final WindowBinOp<U, W> combiner;
+  private final Sampling sampling;
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param seed          The seed for the operation.
+   * @param fun           The window function.
+   * @param combineFun    A function to combine intermediate results.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  FoldedWindowedStream(final SwimStream<T> input,
+                       final WindowSpec<T, W, S> windowSpec,
+                       final BindingContext context,
+                       final Function<W, U> seed,
+                       final WindowFoldFunction<T, W, U> fun,
+                       final WindowBinOp<U, W> combineFun,
+                       final Form<U> form,
+                       final Sampling samplingStrat) {
+    super(form, context);
+    in = input;
+    spec = windowSpec;
+    seedFun = seed;
+    winFun = fun;
+    combiner = combineFun;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param seed          The seed for the operation.
+   * @param fun           The window function.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  FoldedWindowedStream(final SwimStream<T> input,
+                       final WindowSpec<T, W, S> windowSpec,
+                       final BindingContext context,
+                       final Function<W, U> seed,
+                       final WindowFoldFunction<T, W, U> fun,
+                       final Form<U> form,
+                       final Sampling samplingStrat) {
+    this(input, windowSpec, context, seed, fun, null, form, samplingStrat);
+  }
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param seed          The seed for the operation.
+   * @param fun           The window function.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts            The timestamp assignment for the values.
+   */
+  FoldedWindowedStream(final SwimStream<T> input,
+                       final WindowSpec<T, W, S> windowSpec,
+                       final BindingContext context,
+                       final Function<W, U> seed,
+                       final WindowFoldFunction<T, W, U> fun,
+                       final WindowBinOp<U, W> combineFun,
+                       final Form<U> form,
+                       final Sampling samplingStrat,
+                       final ToLongFunction<U> ts) {
+    super(form, context, ts);
+    in = input;
+    spec = windowSpec;
+    seedFun = seed;
+    winFun = fun;
+    combiner = combineFun;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public SwimStream<U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new FoldedWindowedStream<>(in, spec, getContext(), seedFun, winFun, combiner, form(),
+        sampling, datation);
+  }
+
+  @Override
+  public Junction<U> instantiate(final InitContext context) {
+    final PersistenceProvider persistence = context.getPersistenceProvider();
+    final PaneManager<T, W, U> paneManager = spec.getEvictionStrategy().match(
+        none -> createWithoutEviction(persistence), eviction -> createWithEviction(persistence, eviction));
+
+    final ToLongFunction<T> ts = in.getTimestamps();
+    final TimestampAssigner<T> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+    final WindowConduit<T, W, U> conduit = new WindowConduit<>(
+        context.getSchedule(), paneManager, timestamps);
+
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  //When we have eviction it is necessary to maintain all of the data in the window.
+  private <K extends Comparable<K>> PaneManager<T, W, U> createWithEviction(
+      final PersistenceProvider persistence,
+      final ThresholdEviction<T, K, W> eviction) {
+
+    if (combiner == null) {
+      final SequencePaneUpdater<T, W> updater = new SequencePaneUpdater<>();
+      final SequenceThresholdEvictor<T, K, W> evictor = new SequenceThresholdEvictor<>(
+          eviction.getCriterion(), eviction.getThreshold(), eviction.assumeStateOrdered());
+      final FoldingEvaluator<T, W, U> evaluator = new FoldingEvaluator<>(seedFun, winFun);
+
+      final WindowAccumulators<W, FingerTrieSeq<WithTimestamp<T>>> accumulators = WindowStates.forSequencesState(
+          spec.isTransient(), StateTags.stateTag(id()), persistence, spec.getWindowForm(), in.form());
+
+      return new DefaultPaneManager<>(accumulators,
+          spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+    } else {
+      final MapPaneUpdater<T, W, K, U> updater = new MapPaneUpdater<>(eviction.getCriterion());
+      final ThresholdEvictor<T, K, W, U> evictor = new ThresholdEvictor<>(eviction.getThreshold());
+
+      final ReducingEvaluator<K, T, W, U> evaluator = new ReducingEvaluator<>(seedFun, winFun, combiner);
+
+      final WindowAccumulators<W, BTreeMap<K, T, U>> accumulators = WindowStates.forMapState(
+          spec.isTransient(), StateTags.stateTag(id()), persistence, spec.getWindowForm(), eviction.getCriterionForm(), in.form());
+      return new DefaultPaneManager<>(accumulators,
+          spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+    }
+  }
+
+  //Without eviction we only need to store the state of the operation.
+  private PaneManager<T, W, U> createWithoutEviction(final PersistenceProvider persistence) {
+    final FoldPaneUpdater<T, W, U> updater = new FoldPaneUpdater<>(seedFun, winFun);
+    final NoOpEvictor<T, W, U> evictor = NoOpEvictor.instance();
+    final PaneEvaluator<U, W, U> evaluator = PaneEvaluator.identity();
+    final WindowAccumulators<W, U> accumulators = WindowStates.forSimpleState(
+        spec.isTransient(), StateTags.stateTag(id()), persistence, spec.getWindowForm(), form());
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/Graphs.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/Graphs.java
@@ -1,0 +1,38 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.concurrent.Schedule;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+
+/**
+ * Factory for {@link SwimStreamContext}s.
+ */
+public final class Graphs {
+
+  private Graphs() { }
+
+  public static SwimStreamContext createContext(final Schedule schedule,
+                                                final PersistenceProvider persistence) {
+    return new ContextImpl(schedule, persistence);
+  }
+
+  public static SwimStreamContext.InitContext createInitContext(final Schedule schedule,
+                                                                final PersistenceProvider persistence) {
+    return new ContextImpl.InitContextImpl(schedule, persistence);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/InternalSinkHandle.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/InternalSinkHandle.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.dataflow.graph.SinkHandle;
+import swim.dataflow.graph.SwimStreamContext;
+
+/**
+ * Extended {@link SinkHandle} for use with {@link ContextImpl}.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+interface InternalSinkHandle<K, V> extends SinkHandle<K, V> {
+
+  void bindConnector(SwimStreamContext.InitContext context);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/JoinedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/JoinedStream.java
@@ -1,0 +1,116 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.JoinOnKeyJunction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Stream formed by the join of two map streams with a common key.
+ *
+ * @param <K>  The type of the keys.
+ * @param <V1> The type of the left values.
+ * @param <V2> The type of the right values.
+ * @param <U>  The type of the combination of the two values.
+ */
+class JoinedStream<K, V1, V2, U> extends AbstractMapStream<K, U> {
+
+  private final MapSwimStream<K, V1> left;
+  private final MapSwimStream<K, V2> right;
+  private final BiFunction<V1, V2, U> combiner;
+  private final Function<V1, U> leftOnly;
+  private final Function<V2, U> rightOnly;
+  private final Sampling sampling;
+
+  /**
+   * @param leftStream    The stream on the left of the join.
+   * @param rightStream   The stream on the right of the join.
+   * @param context       The instantiation context.
+   * @param form          The form of the type of the output values.
+   * @param combinFun     Function to combine left and right values.
+   * @param leftFun       Function to provide a value when only the left value is present (may be null).
+   * @param rightFun      Function to provide the value when only the right value is present (may be null).
+   * @param samplingStrat Sampling strategy for the link.
+   */
+  JoinedStream(final MapSwimStream<K, V1> leftStream,
+               final MapSwimStream<K, V2> rightStream,
+               final BindingContext context,
+               final Form<U> form,
+               final BiFunction<V1, V2, U> combinFun,
+               final Function<V1, U> leftFun,
+               final Function<V2, U> rightFun,
+               final Sampling samplingStrat) {
+    super(leftStream.keyForm(), form, context);
+    combiner = combinFun;
+    leftOnly = leftFun;
+    rightOnly = rightFun;
+    left = leftStream;
+    right = rightStream;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param leftStream    The stream on the left of the join.
+   * @param rightStream   The stream on the right of the join.
+   * @param context       The instantiation context.
+   * @param form          The form of the type of the output values.
+   * @param combinFun     Function to combine left and right values.
+   * @param leftFun       Function to provide a value when only the left value is present (may be null).
+   * @param rightFun      Function to provide the value when only the right value is present (may be null).
+   * @param samplingStrat Sampling strategy for the link.
+   * @param ts            Timestamp assignment for the values.
+   */
+  JoinedStream(final MapSwimStream<K, V1> leftStream,
+               final MapSwimStream<K, V2> rightStream,
+               final BindingContext context,
+               final Form<U> form,
+               final BiFunction<V1, V2, U> combinFun,
+               final Function<V1, U> leftFun,
+               final Function<V2, U> rightFun,
+               final Sampling samplingStrat,
+               final ToLongFunction<U> ts) {
+    super(leftStream.keyForm(), form, context, ts);
+    combiner = combinFun;
+    leftOnly = leftFun;
+    rightOnly = rightFun;
+    left = leftStream;
+    right = rightStream;
+    sampling = samplingStrat;
+
+  }
+
+  @Override
+  public MapSwimStream<K, U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new JoinedStream<>(left, right, getContext(), valueForm(), combiner, leftOnly, rightOnly, sampling, datation);
+  }
+
+  @Override
+  public MapJunction<K, U> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V1> leftSource = context.createFor(left);
+    final MapJunction<K, V2> rightSource = context.createFor(right);
+    final JoinOnKeyJunction<K, V1, V2, U> junction = new JoinOnKeyJunction<>(combiner, leftOnly, rightOnly);
+    leftSource.subscribe(junction.first());
+    rightSource.subscribe(junction.second());
+    return junction;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyFetch.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyFetch.java
@@ -1,0 +1,91 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.IdentityConduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * A stream of values for a specified key in a map stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+class KeyFetch<K, V> extends AbstractSwimStream<V> {
+
+  private final MapSwimStream<K, V> keyedStream;
+
+  private final K key;
+
+  private final Sampling sampling;
+
+  /**
+   * @param stream        The source map stream.
+   * @param context       The instantiation context.
+   * @param selector      The key to select.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  KeyFetch(final MapSwimStream<K, V> stream,
+           final BindingContext context,
+           final K selector,
+           final Sampling samplingStrat) {
+    super(stream.valueForm(), context);
+    keyedStream = stream;
+    key = selector;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param stream        The source map stream.
+   * @param context       The instantiation context.
+   * @param selector      The key to select.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts            Time stamp assigner for the stream.
+   */
+  KeyFetch(final MapSwimStream<K, V> stream,
+           final BindingContext context,
+           final K selector,
+           final Form<V> valForm,
+           final Sampling samplingStrat,
+           final ToLongFunction<V> ts) {
+    super(stream.valueForm(), context, ts);
+    keyedStream = stream;
+    key = selector;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public SwimStream<V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new KeyFetch<>(keyedStream, getContext(), key, form(), sampling, datation);
+  }
+
+  @Override
+  public Junction<V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(keyedStream);
+    final IdentityConduit<V> identity = new IdentityConduit<>();
+    source.subscribe(key, identity);
+    return StreamDecoupling.sampleStream(id(), context, identity, sampling, StreamInterpretation.DISCRETE);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyStream.java
@@ -1,0 +1,71 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Set;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapKeysCollector;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.CollectionSwimStream;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * A stream of the key sets of a map stream.
+ *
+ * @param <K> The type of the keys of the map stream.
+ * @param <V> The type of the values of the map stream.
+ */
+class KeyStream<K, V> extends AbstractCollectionStream<K, Set<K>> {
+
+  private final MapSwimStream<K, V> inner;
+
+  /**
+   * @param source  The source map stream.
+   * @param context The instantiation context.
+   */
+  KeyStream(final MapSwimStream<K, V> source, final BindingContext context) {
+    super(Form.forCollection(Set.class, source.keyForm()), context);
+    inner = source;
+  }
+
+  /**
+   * @param source  The source map stream.
+   * @param context The instantiation context.
+   * @param ts      Time stamp assigner for the stream.
+   */
+  KeyStream(final MapSwimStream<K, V> source,
+            final BindingContext context,
+            final ToLongFunction<Set<K>> ts) {
+    super(Form.forCollection(Set.class, source.keyForm()), context, ts);
+    inner = source;
+  }
+
+  @Override
+  public CollectionSwimStream<K, Set<K>> updateTimestamps(final ToLongFunction<Set<K>> datation) {
+    return new KeyStream<>(inner, getContext(), datation);
+  }
+
+  @Override
+  public Junction<Set<K>> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(inner);
+    final MapKeysCollector<K, V> collector = new MapKeysCollector<>();
+    source.subscribe(collector);
+    return collector;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyValueStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/KeyValueStream.java
@@ -1,0 +1,72 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Map;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapExtractor;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * A stream of key-value pairs representing the entries of a map stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class KeyValueStream<K, V> extends AbstractSwimStream<Map<K, V>> {
+
+  private final MapSwimStream<K, V> inner;
+
+  /**
+   * @param source  The source map stream.
+   * @param context The instantiation context.
+   */
+  KeyValueStream(final MapSwimStream<K, V> source, final BindingContext context) {
+    super(Form.forMap(Map.class, source.keyForm(), source.valueForm()), context);
+    inner = source;
+  }
+
+  /**
+   * @param source  The source map stream.
+   * @param context The instantiation context.
+   * @param ts      Timestamp assigner for the stream.
+   */
+  KeyValueStream(final MapSwimStream<K, V> source,
+                 final BindingContext context,
+                 final ToLongFunction<Map<K, V>> ts) {
+    super(Form.forMap(Map.class, source.keyForm(), source.valueForm()), context, ts);
+    inner = source;
+  }
+
+  @Override
+  public SwimStream<Map<K, V>> updateTimestamps(
+          final ToLongFunction<Map<K, V>> datation) {
+    return new KeyValueStream<>(inner, getContext(), datation);
+  }
+
+  @Override
+  public Junction<Map<K, V>> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(inner);
+    final MapExtractor<K, V> collector = new MapExtractor<>();
+    source.subscribe(collector);
+    return collector;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/MapSinkBinding.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/MapSinkBinding.java
@@ -1,0 +1,49 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.graph.MapSink;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+
+/**
+ * A binding from a map stream to a sink.
+ *
+ * @param <K> The type of the keys of the stream.
+ * @param <V> The type of the values of the stream.
+ */
+class MapSinkBinding<K, V> implements InternalSinkHandle<K, V> {
+
+  private final MapSwimStream<K, V> stream;
+  private final MapSink<K, V> sink;
+
+  /**
+   * @param in  The stream to be bound.
+   * @param out The target sink.
+   */
+  MapSinkBinding(final MapSwimStream<K, V> in, final MapSink<K, V> out) {
+    stream = in;
+    sink = out;
+  }
+
+  @Override
+  public void bindConnector(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(stream);
+    final MapReceptacle<K, V> receptacle = context.createFromMap(sink);
+    source.subscribe(receptacle);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/MapWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/MapWindowedStream.java
@@ -1,0 +1,153 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.MapWindowedSwimStream;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.KeyedWindowBinOp;
+import swim.dataflow.graph.windows.KeyedWindowFoldFunction;
+import swim.dataflow.graph.windows.KeyedWindowFunction;
+import swim.dataflow.graph.windows.KeyedWindowSpec;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+/**
+ * A mapped stream with windows defined across the keys.
+ *
+ * @param <K> The type of th
+ * @param <T>
+ * @param <W>
+ */
+class MapWindowedStream<K, T, W, S extends WindowState<W, S>> implements MapWindowedSwimStream<K, T, W> {
+
+  private final Form<W> winForm;
+  private final MapSwimStream<K, T> underlying;
+  private final Function<K, TemporalWindowAssigner<T, W, S>> assigner;
+  private final Function<K, Trigger<T, W>> trigger;
+  private final Function<K, EvictionStrategy<T, W>> eviction;
+  private final Sampling sampling;
+  private final BindingContext context;
+  private final boolean isTransient;
+
+  protected BindingContext getContext() {
+    return context;
+  }
+
+  /**
+   * @param stream        The underlying map stream.
+   * @param con           The instantiation context.
+   * @param form          The form of the windows.
+   * @param winAssigner   Assigns windows to values.
+   * @param winTrigger    Trigger to close windows.
+   * @param evictionStrat Strategy for evicting expired values from the windows.
+   * @param samplingStrat Sampling strategy for the link.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  MapWindowedStream(final MapSwimStream<K, T> stream,
+                    final BindingContext con,
+                    final Form<W> form,
+                    final Function<K, TemporalWindowAssigner<T, W, S>> winAssigner,
+                    final Function<K, Trigger<T, W>> winTrigger,
+                    final Function<K, EvictionStrategy<T, W>> evictionStrat,
+                    final Sampling samplingStrat,
+                    final boolean isTransient) {
+    winForm = form;
+    underlying = stream;
+    assigner = winAssigner;
+    trigger = winTrigger;
+    sampling = samplingStrat;
+    context = con;
+    eviction = evictionStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public Form<K> keyForm() {
+    return underlying.keyForm();
+  }
+
+  @Override
+  public Form<T> valueForm() {
+    return underlying.valueForm();
+  }
+
+  @Override
+  public Form<W> windowForm() {
+    return winForm;
+  }
+
+  @Override
+  public <U> MapSwimStream<K, U> mapWindow(final KeyedWindowFunction<K, T, W, U> winFun, final Form<U> form) {
+    return new TransformedMapWindowedStream<>(underlying, getContext(),
+        new KeyedWindowSpec<>(assigner, trigger, eviction, winForm, isTransient), form, winFun, sampling);
+  }
+
+  @Override
+  public <U> MapSwimStream<K, U> fold(final U seed, final KeyedWindowFoldFunction<K, T, W, U> winFun,
+                                      final BinaryOperator<U> combiner, final Form<U> form) {
+    return new FoldedMapWindowedStream<>(underlying, context,
+        new KeyedWindowSpec<>(assigner, trigger, eviction, winForm, isTransient), form, (k, w) -> seed, winFun,
+        (k, w, u1, u2) -> combiner.apply(u1, u2), sampling);
+  }
+
+  @Override
+  public <U> MapSwimStream<K, U> foldByKeyWithCombiner(final BiFunction<K, W, U> seed,
+                                                       final KeyedWindowFoldFunction<K, T, W, U> winFun,
+                                                       final KeyedWindowBinOp<K, U, W> combiner,
+                                                       final Form<U> form) {
+    return new FoldedMapWindowedStream<>(underlying, context,
+        new KeyedWindowSpec<>(assigner, trigger, eviction, winForm, isTransient), form, seed, winFun, combiner,
+        sampling);
+  }
+
+  @Override
+  public MapSwimStream<K, T> reduceByKey(final KeyedWindowBinOp<K, T, W> op) {
+    return new ReducedByKeyMapWindowedStream<>(underlying, context,
+        new KeyedWindowSpec<>(assigner, trigger, eviction, winForm, isTransient), op, sampling);
+  }
+
+  @Override
+  public MapWindowedSwimStream<K, T, W> withTrigger(final Function<K, Trigger<T, W>> trigger) {
+    return new MapWindowedStream<>(underlying, context, winForm, assigner, trigger, eviction, sampling, isTransient);
+  }
+
+  @Override
+  public MapWindowedSwimStream<K, T, W> withEviction(final Function<K, EvictionStrategy<T, W>> eviction) {
+    return new MapWindowedStream<>(underlying, context, winForm, assigner, trigger, eviction, sampling, isTransient);
+  }
+
+  /**
+   * Set whether the stream state is transient.
+   *
+   * @param isTransient Whether the stream is transient.
+   * @return Copy of this stream with the flag altered.
+   */
+  @Override
+  public MapWindowedSwimStream<K, T, W> setIsTransient(final boolean isTransient) {
+    if (this.isTransient == isTransient) {
+      return this;
+    } else {
+      return new MapWindowedStream<>(underlying, context, winForm, assigner, trigger, eviction, sampling, isTransient);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredKeysMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredKeysMapStream.java
@@ -1,0 +1,111 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.ModalKeyFilterConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Map stream where the entries are filtered according to a variable predicate on the keys only.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <M> The type of the control stream for the predicate.
+ */
+public class ModalFilteredKeysMapStream<K, V, M> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final M init;
+  private final Function<M, Predicate<K>> switcher;
+  private final SwimStream<M> control;
+  private final boolean isTransient;
+
+  /**
+   * @param input          The input stream.
+   * @param context        The stream initialization context.
+   * @param initialMode    The initial mode.
+   * @param modalPredicate The modal predicate.
+   * @param controlStream  Stream of mode values to control the predicate.
+   * @param isTransient    Whether the state of this stream is stored persistently.
+   */
+  ModalFilteredKeysMapStream(final MapSwimStream<K, V> input,
+                             final BindingContext context,
+                             final M initialMode,
+                             final Function<M, Predicate<K>> modalPredicate,
+                             final SwimStream<M> controlStream,
+                             final boolean isTransient) {
+    super(input.keyForm(), input.valueForm(), context);
+    in = input;
+    init = initialMode;
+    switcher = modalPredicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param input          The input stream.
+   * @param context        The stream initialization context.
+   * @param initialMode    The initial mode.
+   * @param modalPredicate The modal predicate.
+   * @param controlStream  Stream of mode values to control the predicate.
+   * @param ts             Timestamp assignment for the values.
+   * @param isTransient    Whether the state of this stream is stored persistently.
+   */
+  ModalFilteredKeysMapStream(final MapSwimStream<K, V> input,
+                             final BindingContext context,
+                             final M initialMode,
+                             final Function<M, Predicate<K>> modalPredicate,
+                             final SwimStream<M> controlStream,
+                             final boolean isTransient,
+                             final ToLongFunction<V> ts) {
+    super(input.keyForm(), input.valueForm(), context, ts);
+    in = input;
+    init = initialMode;
+    switcher = modalPredicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ModalFilteredKeysMapStream<>(in, getContext(), init, switcher, control, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final Junction<M> modes = context.createFor(control);
+    final ModalKeyFilterConduit<K, V, M> conduit;
+    if (isTransient) {
+      conduit = new ModalKeyFilterConduit<>(init, switcher);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), control.form(), init);
+      conduit = new ModalKeyFilterConduit<>(modePersister, switcher);
+    }
+    source.subscribe(conduit.first());
+    modes.subscribe(conduit.second());
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredMapStream.java
@@ -1,0 +1,111 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.ModalFilteredMapConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Map stream where the entries are filtered according to a variable predicate.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <M> The type of the control stream for the predicate.
+ */
+final class ModalFilteredMapStream<K, V, M> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final M init;
+  private final Function<M, BiPredicate<K, V>> switcher;
+  private final SwimStream<M> control;
+  private final boolean isTransient;
+
+  /**
+   * @param input          The input stream.
+   * @param context        The stream initialization context.
+   * @param initialMode    The initial mode.
+   * @param modalPredicate The modal predicate.
+   * @param controlStream  Stream of mode values to control the predicate.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFilteredMapStream(final MapSwimStream<K, V> input,
+                         final BindingContext context,
+                         final M initialMode,
+                         final Function<M, BiPredicate<K, V>> modalPredicate,
+                         final SwimStream<M> controlStream,
+                         final boolean isTransient) {
+    super(input.keyForm(), input.valueForm(), context);
+    in = input;
+    init = initialMode;
+    switcher = modalPredicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param input          The input stream.
+   * @param context        The stream initialization context.
+   * @param initialMode    The initial mode.
+   * @param modalPredicate The modal predicate.
+   * @param controlStream  Stream of mode values to control the predicate.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts             Timestamp assignment for the values.
+   */
+  ModalFilteredMapStream(final MapSwimStream<K, V> input,
+                         final BindingContext context,
+                         final M initialMode,
+                         final Function<M, BiPredicate<K, V>> modalPredicate,
+                         final SwimStream<M> controlStream,
+                         final boolean isTransient,
+                         final ToLongFunction<V> ts) {
+    super(input.keyForm(), input.valueForm(), context, ts);
+    in = input;
+    init = initialMode;
+    switcher = modalPredicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ModalFilteredMapStream<>(in, getContext(), init, switcher, control, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final Junction<M> modes = context.createFor(control);
+    final ModalFilteredMapConduit<K, V, M> conduit;
+    if (isTransient) {
+      conduit = new ModalFilteredMapConduit<>(init, switcher);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), control.form(), init);
+      conduit = new ModalFilteredMapConduit<>(modePersister, switcher);
+    }
+    source.subscribe(conduit.first());
+    modes.subscribe(conduit.second());
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFilteredStream.java
@@ -1,0 +1,99 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.ModalFilteredConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+/**
+ * Stream where the values are filtered according to a variable predicate.
+ *
+ * @param <T> The type of the values.
+ * @param <M> The type of the control stream for the predicate.
+ */
+class ModalFilteredStream<T, M> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final M init;
+  private final Function<M, Predicate<T>> switcher;
+  private final SwimStream<M> control;
+  private final boolean isTransient;
+
+  /**
+   * @param input         The stream of input values.
+   * @param context       The stream initialization context.
+   * @param initialMode   The initial control value.
+   * @param predicate     The modal predicate.
+   * @param controlStream A stream of control values.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFilteredStream(final SwimStream<T> input,
+                      final BindingContext context,
+                      final M initialMode,
+                      final Function<M, Predicate<T>> predicate,
+                      final SwimStream<M> controlStream,
+                      final boolean isTransient) {
+    super(input.form(), context);
+    in = input;
+    init = initialMode;
+    switcher = predicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  ModalFilteredStream(final SwimStream<T> input,
+                      final BindingContext context,
+                      final M initialMode,
+                      final Function<M, Predicate<T>> predicate,
+                      final SwimStream<M> controlStream,
+                      final boolean isTransient,
+                      final ToLongFunction<T> ts) {
+    super(input.form(), context, ts);
+    in = input;
+    init = initialMode;
+    switcher = predicate;
+    control = controlStream;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ModalFilteredStream<>(in, getContext(), init, switcher, control, isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(in);
+    final Junction<M> modes = context.createFor(control);
+    final ModalFilteredConduit<T, M> junction;
+    if (isTransient) {
+      junction = new ModalFilteredConduit<>(init, switcher);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), control.form(), init);
+      junction = new ModalFilteredConduit<>(modePersister, switcher);
+    }
+    source.subscribe(junction.first());
+    modes.subscribe(junction.second());
+    return junction;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFlatMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFlatMapStream.java
@@ -1,0 +1,188 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.ModalFlatMapConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.Iterables;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.DelaySpecifier;
+import swim.structure.Form;
+import swim.structure.form.DurationForm;
+
+/**
+ * Stream with a flat-map operation applied across its values. The sequences of values produced for each change is
+ * emitted sequentially with a specified delay. The operation used to update the accumulation can be controlled by a
+ * separate control stream.
+ *
+ * @param <S> The input type.
+ * @param <T> The output type.
+ * @param <M> The control stream.
+ */
+public class ModalFlatMapStream<S, T, M> extends AbstractSwimStream<T> {
+
+  private final SwimStream<S> in;
+  private final Function<M, Function<S, Iterable<T>>> f;
+  private final M initial;
+  private final DelaySpecifier delay;
+  private final SwimStream<M> controlStream;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs    The source stream.
+   * @param context   The instantiation context.
+   * @param valForm   The form of the outputs.
+   * @param init      The initial mode.
+   * @param mapping   The modal flat-map operation.
+   * @param delaySpec The specifier for the delay on the outputs.
+   * @param control   The control stream.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFlatMapStream(final SwimStream<S> inputs,
+                     final BindingContext context,
+                     final Form<T> valForm,
+                     final M init,
+                     final Function<M, Function<S, Iterable<T>>> mapping,
+                     final DelaySpecifier delaySpec,
+                     final SwimStream<M> control,
+                     final boolean isTransient) {
+    super(valForm, context);
+    in = inputs;
+    f = mapping;
+    delay = delaySpec;
+    controlStream = control;
+    initial = init;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs    The source stream.
+   * @param context   The instantiation context.
+   * @param valForm   The form of the outputs.
+   * @param init      The initial mode.
+   * @param mapping   The modal flat-map operation.
+   * @param delaySpec The specifier for the delay on the outputs.
+   * @param control   The control stream.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts        Timestamp assigner for the stream.
+   */
+  ModalFlatMapStream(final SwimStream<S> inputs,
+                     final BindingContext context,
+                     final Form<T> valForm,
+                     final M init,
+                     final Function<M, Function<S, Iterable<T>>> mapping,
+                     final DelaySpecifier delaySpec,
+                     final SwimStream<M> control,
+                     final boolean isTransient,
+                     final ToLongFunction<T> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    f = mapping;
+    delay = delaySpec;
+    controlStream = control;
+    initial = init;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public <U> SwimStream<U> map(final Function<T, ? extends U> f2, final Form<U> form) {
+    final Function<M, Function<S, Iterable<U>>> composed =
+        control -> f.apply(control).andThen(it -> Iterables.mapIterable(it, f2));
+    return new ModalFlatMapStream<>(in, getContext(), form, initial, composed, delay, controlStream, isTransient);
+  }
+
+  @Override
+  public <U> SwimStream<U> flatMap(final Function<T, Iterable<U>> f2, final Form<U> form, final DelaySpecifier delaySpec) {
+    if (delay.equals(delaySpec)) {
+      final Function<M, Function<S, Iterable<U>>> composed =
+          control -> f.apply(control).andThen(it -> Iterables.flatMapIterable(it, f2));
+      return new ModalFlatMapStream<>(in, getContext(), form, initial, composed, delay, controlStream, isTransient);
+    } else {
+      return super.flatMap(f2, form, delaySpec);
+    }
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ModalFlatMapStream<>(in, getContext(), form(), initial, f, delay, controlStream, isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<S> source = context.createFor(in);
+    final Junction<M> modes = context.createFor(controlStream);
+    final ModalFlatMapConduit<S, T, M> junction;
+    if (isTransient) {
+      junction = delay.matchDelay(dur -> new ModalFlatMapConduit<>(
+              initial, f, context.getSchedule(), dur.getInterval()),
+          dyn -> dynamicDelay(context, dyn.getInitial(), dyn.getIntervalStream(), dyn.isTransient()));
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), controlStream.form(), initial);
+      junction = delay.matchDelay(dur -> new ModalFlatMapConduit<>(
+              modePersister, f, context.getSchedule(), dur.getInterval()),
+          dyn -> dynamicDelay(context, dyn.getInitial(), dyn.getIntervalStream(), modePersister, dyn.isTransient()));
+    }
+    source.subscribe(junction.first());
+    modes.subscribe(junction.third());
+    return junction;
+  }
+
+  private ModalFlatMapConduit<S, T, M> dynamicDelay(final SwimStreamContext.InitContext context,
+                                                    final Duration initDur,
+                                                    final SwimStream<Duration> durStr,
+                                                    final boolean delayIsTransient) {
+
+    final ModalFlatMapConduit<S, T, M> conduit;
+    if (delayIsTransient) {
+      conduit = new ModalFlatMapConduit<>(
+          initial, f, context.getSchedule(), initDur);
+    } else {
+      final ValuePersister<Duration> periodPersister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), new DurationForm(initDur));
+      conduit = new ModalFlatMapConduit<>(
+          initial, f, context.getSchedule(), periodPersister);
+    }
+    final Junction<Duration> durations = context.createFor(durStr);
+    durations.subscribe(conduit.second());
+    return conduit;
+  }
+
+  private ModalFlatMapConduit<S, T, M> dynamicDelay(final SwimStreamContext.InitContext context,
+                                                    final Duration initDur,
+                                                    final SwimStream<Duration> durStr,
+                                                    final ValuePersister<M> modePersister,
+                                                    final boolean delayIsTransient) {
+    final ModalFlatMapConduit<S, T, M> conduit;
+    if (delayIsTransient) {
+      conduit = new ModalFlatMapConduit<>(
+          modePersister, f, context.getSchedule(), initDur);
+    } else {
+      final ValuePersister<Duration> periodPersister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), new DurationForm(initDur));
+      conduit = new ModalFlatMapConduit<>(
+          modePersister, f, context.getSchedule(), periodPersister);
+    }
+    final Junction<Duration> durations = context.createFor(durStr);
+    durations.subscribe(conduit.second());
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFoldedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFoldedMapStream.java
@@ -1,0 +1,141 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapJunction2;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Stream of rolling aggregate values over another map stream. The operation that is applied can be modified with an
+ * independent control stream.
+ *
+ * @param <K> The key type of the input stream.
+ * @param <V> The value type of the input stream.
+ * @param <U> The value type of the outputs.
+ * @param <M> The type of the control stream.
+ */
+class ModalFoldedMapStream<K, V, U, M> extends AbstractMapStream<K, U> {
+  private final MapSwimStream<K, V> in;
+  private final U seed;
+  private final M init;
+  private final Function<M, BiFunction<U, V, U>> modalFoldFunction;
+  private final SwimStream<M> controlStream;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the output values.
+   * @param seedValue   The seed value for the aggregation.
+   * @param initialMode The initial value of the mode.
+   * @param folder     The aggregation operation.
+   * @param control     The control stream.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFoldedMapStream(final MapSwimStream<K, V> inputs,
+                       final BindingContext context,
+                       final Form<U> valForm,
+                       final U seedValue,
+                       final M initialMode,
+                       final Function<M, BiFunction<U, V, U>> folder,
+                       final SwimStream<M> control,
+                       final Sampling sampleStrat,
+                       final boolean isTransient) {
+    super(inputs.keyForm(), valForm, context);
+    in = inputs;
+    seed = seedValue;
+    modalFoldFunction = folder;
+    controlStream = control;
+    init = initialMode;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param valForm     The form of the type of the output values.
+   * @param seedValue   The seed value for the aggregation.
+   * @param initialMode The initial value of the mode.
+   * @param folder     The aggregation operation.
+   * @param control     The control stream.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param ts          Timestamp assignment for the values.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFoldedMapStream(final MapSwimStream<K, V> inputs,
+                       final BindingContext context,
+                       final Form<U> valForm,
+                       final U seedValue,
+                       final M initialMode,
+                       final Function<M, BiFunction<U, V, U>> folder,
+                       final SwimStream<M> control,
+                       final Sampling sampleStrat,
+                       final boolean isTransient,
+                       final ToLongFunction<U> ts) {
+    super(inputs.keyForm(), valForm, context, ts);
+    in = inputs;
+    seed = seedValue;
+    modalFoldFunction = folder;
+    controlStream = control;
+    init = initialMode;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new ModalFoldedMapStream<>(in, getContext(), valueForm(), seed, init, modalFoldFunction,
+        controlStream, sampling, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, U> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final Junction<M> control = context.createFor(controlStream);
+    final MapJunction2<K, K, V, U, M> conduit;
+    if (isTransient) {
+      conduit = StatefulConduits.modalFoldMap(init, seed, modalFoldFunction);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(StateTags.modeTag(id()),
+          controlStream.form(), init);
+      final MapPersister<K, U> statePersister = context.getPersistenceProvider().forMap(
+          StateTags.stateTag(id()),
+          keyForm(), valueForm(), seed);
+      conduit = StatefulConduits.modalFoldMap(modePersister, statePersister, modalFoldFunction);
+    }
+    source.subscribe(conduit.first());
+    control.subscribe(conduit.second());
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFoldedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalFoldedStream.java
@@ -1,0 +1,137 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.Junction2;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Stream of rolling aggregate values over another stream. The operation that is applied can be modified with an
+ * independent control stream.
+ *
+ * @param <T> The type of the inputs.
+ * @param <U> The type of the outputs.
+ * @param <M> The type of the control stream.
+ */
+class ModalFoldedStream<T, U, M> extends AbstractSwimStream<U> {
+
+  private final SwimStream<T> in;
+  private final M initialMode;
+  private final U seed;
+  private final Function<M, BiFunction<U, T, U>> modalFoldFunction;
+  private final SwimStream<M> controlStream;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param initial     The initial mode.
+   * @param valForm     The form of the type of the outputs.
+   * @param seedValue   The seed value for the aggregation.
+   * @param folder     The aggregation operation.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param control     The control stream.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalFoldedStream(final SwimStream<T> inputs,
+                    final BindingContext context,
+                    final M initial,
+                    final Form<U> valForm,
+                    final U seedValue,
+                    final Function<M, BiFunction<U, T, U>> folder,
+                    final Sampling sampleStrat,
+                    final SwimStream<M> control,
+                    final boolean isTransient) {
+    super(valForm, context);
+    in = inputs;
+    seed = seedValue;
+    modalFoldFunction = folder;
+    controlStream = control;
+    initialMode = initial;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param initial     The initial mode.
+   * @param valForm     The form of the type of the outputs.
+   * @param seedValue   The seed value for the aggregation.
+   * @param folder     The aggregation operation.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param control     The control stream.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts          Timestamp assigner for the stream.
+   */
+  ModalFoldedStream(final SwimStream<T> inputs,
+                    final BindingContext context,
+                    final M initial,
+                    final Form<U> valForm,
+                    final U seedValue,
+                    final Function<M, BiFunction<U, T, U>> folder,
+                    final Sampling sampleStrat,
+                    final SwimStream<M> control,
+                    final boolean isTransient,
+                    final ToLongFunction<U> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    seed = seedValue;
+    modalFoldFunction = folder;
+    controlStream = control;
+    initialMode = initial;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new ModalFoldedStream<>(in, getContext(), initialMode, form(),
+        seed, modalFoldFunction, sampling, controlStream, isTransient, datation);
+  }
+
+  @Override
+  public Junction<U> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context,
+        context.createFor(in), sampling, StreamInterpretation.DISCRETE);
+    final Junction<M> control = context.createFor(controlStream);
+    final Junction2<T, M, U> junction;
+    if (isTransient) {
+      junction = StatefulConduits.modalFold(initialMode, seed, modalFoldFunction);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), controlStream.form(), initialMode);
+      final ValuePersister<U> statePersister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), form(), seed);
+      junction = StatefulConduits.modalFold(modePersister, statePersister, modalFoldFunction);
+    }
+    source.subscribe(junction.first());
+    control.subscribe(junction.second());
+    return junction;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalKeyFetch.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalKeyFetch.java
@@ -1,0 +1,97 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.ModalKeyFetchConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * A stream of values for a specified key in a map stream. The selected key can be modified by a control stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public class ModalKeyFetch<K, V> extends AbstractSwimStream<V> {
+
+  private final MapSwimStream<K, V> keyedStream;
+  private final SwimStream<K> keys;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param stream        The source map stream.
+   * @param context       The instantiation context.
+   * @param selector      The key selection stream.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalKeyFetch(final MapSwimStream<K, V> stream,
+                final BindingContext context,
+                final SwimStream<K> selector,
+                final Sampling samplingStrat,
+                final boolean isTransient) {
+    super(stream.valueForm(), context);
+    keyedStream = stream;
+    keys = selector;
+    sampling = samplingStrat;
+    this.isTransient = isTransient;
+  }
+
+  ModalKeyFetch(final MapSwimStream<K, V> stream,
+                final BindingContext context,
+                final SwimStream<K> selector,
+                final Sampling samplingStrat,
+                final boolean isTransient,
+                final ToLongFunction<V> ts) {
+    super(stream.valueForm(), context, ts);
+    keyedStream = stream;
+    keys = selector;
+    sampling = samplingStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ModalKeyFetch<>(keyedStream, getContext(), keys, sampling, isTransient, datation);
+  }
+
+  @Override
+  public Junction<V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(keyedStream);
+    final Junction<K> control = context.createFor(keys);
+    final ModalKeyFetchConduit<K, V> selector;
+    if (isTransient) {
+      selector = new ModalKeyFetchConduit<>();
+    } else {
+      final ValuePersister<K> keyPersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), keys.form());
+      selector = new ModalKeyFetchConduit<>(keyPersister);
+    }
+    control.subscribe(selector.keySelector());
+    source.subscribe(selector.mapInput());
+    return StreamDecoupling.sampleStream(id(), context, selector, sampling, StreamInterpretation.DISCRETE);
+  }
+
+}
+

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalReducedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalReducedMapStream.java
@@ -1,0 +1,129 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapJunction2;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * Accumulates the values associated with each key over time. The operation used to update the accumulation can be
+ * controlled by a separate control stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <M> The type of the control values.
+ */
+class ModalReducedMapStream<K, V, M> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final Function<M, BinaryOperator<V>> modalOperator;
+  private final SwimStream<M> controlStream;
+  private final M init;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source map stream.
+   * @param context     The instantiation context.
+   * @param op          The modal accumulation operator.
+   * @param initialMode The initial value of the mode.
+   * @param control     The control stream.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalReducedMapStream(final MapSwimStream<K, V> inputs,
+                        final BindingContext context,
+                        final Function<M, BinaryOperator<V>> op,
+                        final M initialMode,
+                        final SwimStream<M> control,
+                        final Sampling sampleStrat,
+                        final boolean isTransient) {
+    super(inputs.keyForm(), inputs.valueForm(), context);
+    in = inputs;
+    modalOperator = op;
+    controlStream = control;
+    init = initialMode;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source map stream.
+   * @param context     The instantiation context.
+   * @param op          The modal accumulation operator.
+   * @param initialMode The initial value of the mode.
+   * @param control     The control stream.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts          Timestamp assignment for the values.
+   */
+  ModalReducedMapStream(final MapSwimStream<K, V> inputs,
+                        final BindingContext context,
+                        final Function<M, BinaryOperator<V>> op,
+                        final M initialMode,
+                        final SwimStream<M> control,
+                        final Sampling sampleStrat,
+                        final boolean isTransient,
+                        final ToLongFunction<V> ts) {
+    super(inputs.keyForm(), inputs.valueForm(), context, ts);
+    in = inputs;
+    modalOperator = op;
+    controlStream = control;
+    init = initialMode;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ModalReducedMapStream<>(in, getContext(), modalOperator, init, controlStream, sampling,
+        isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final Junction<M> modes = context.createFor(controlStream);
+    final MapJunction2<K, K, V, V, M> conduit;
+    if (isTransient) {
+      conduit = StatefulConduits.modalReduceMap(init, modalOperator);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(StateTags.modeTag(id()),
+          controlStream.form(), init);
+      final MapPersister<K, V> statePersister = context.getPersistenceProvider().forMap(
+          StateTags.stateTag(id()),
+          keyForm(), valueForm(), null);
+      conduit = StatefulConduits.modalReduceMap(modePersister, statePersister, modalOperator);
+    }
+    source.subscribe(conduit.first());
+    modes.subscribe(conduit.second());
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalReducedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalReducedStream.java
@@ -1,0 +1,124 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.Junction2;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * Reduces the values of the stream over time. The operation used to update the reduction can be controlled by a
+ * separate control stream.
+ *
+ * @param <T> The type of the values.
+ * @param <M> The type of the control stream.
+ */
+class ModalReducedStream<T, M> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final M initialMode;
+  private final Function<M, BinaryOperator<T>> modalOperator;
+  private final SwimStream<M> controlStream;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param initial     The initial mode.
+   * @param op          The modal accumulation operator.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param control     The control stream.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalReducedStream(final SwimStream<T> inputs,
+                     final BindingContext context,
+                     final M initial,
+                     final Function<M, BinaryOperator<T>> op,
+                     final Sampling sampleStrat,
+                     final SwimStream<M> control,
+                     final boolean isTransient) {
+    super(inputs.form(), context);
+    in = inputs;
+    modalOperator = op;
+    controlStream = control;
+    initialMode = initial;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The source stream.
+   * @param context     The instantiation context.
+   * @param initial     The initial mode.
+   * @param op          The modal accumulation operator.
+   * @param sampleStrat The sampling strategy for the link.
+   * @param control     The control stream.
+   * @param ts          Timestamp assigner for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalReducedStream(final SwimStream<T> inputs,
+                     final BindingContext context,
+                     final M initial,
+                     final Function<M, BinaryOperator<T>> op,
+                     final Sampling sampleStrat,
+                     final SwimStream<M> control,
+                     final boolean isTransient,
+                     final ToLongFunction<T> ts) {
+    super(inputs.form(), context, ts);
+    in = inputs;
+    modalOperator = op;
+    controlStream = control;
+    initialMode = initial;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ModalReducedStream<>(in, getContext(), initialMode, modalOperator, sampling, controlStream,
+        isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final Junction<M> control = context.createFor(controlStream);
+    final Junction2<T, M, T> junction;
+    if (isTransient) {
+      junction = StatefulConduits.modalReduce(initialMode, modalOperator);
+    } else {
+      final ValuePersister<M> modePersister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), controlStream.form(), initialMode);
+      final ValuePersister<T> statePersister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), form(), null);
+      junction = StatefulConduits.modalReduce(modePersister, statePersister, modalOperator);
+    }
+    source.subscribe(junction.first());
+    control.subscribe(junction.second());
+    return junction;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalTransformedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ModalTransformedStream.java
@@ -1,0 +1,139 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.ModalTransformConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.DelaySpecifier;
+import swim.structure.Form;
+
+/**
+ * Stream with a transformation applied to the values. The transformation can be modified by an independent control
+ * stream.
+ *
+ * @param <S> The input type.
+ * @param <T> The output type.
+ * @param <M> The type of the control stream.
+ */
+class ModalTransformedStream<S, T, M> extends AbstractSwimStream<T> {
+
+  private final SwimStream<S> in;
+  private final M initialMode;
+  private final Function<M, Function<S, ? extends T>> f;
+  private final SwimStream<M> controlStream;
+  private final boolean memoizeValue;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs  The source stream.
+   * @param context The instantiation context.
+   * @param initial The initial mode.
+   * @param mapping The modal transformation.
+   * @param memoize Whether to memoize the result.
+   * @param control The control stream.
+   * @param valForm The form of the type of the outputs.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ModalTransformedStream(final SwimStream<S> inputs,
+                         final BindingContext context,
+                         final M initial,
+                         final Function<M, Function<S, ? extends T>> mapping,
+                         final boolean memoize,
+                         final SwimStream<M> control,
+                         final Form<T> valForm,
+                         final boolean isTransient) {
+    super(valForm, context);
+    in = inputs;
+    f = mapping;
+    controlStream = control;
+    initialMode = initial;
+    memoizeValue = memoize;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs  The source stream.
+   * @param context The instantiation context.
+   * @param initial The initial mode.
+   * @param mapping The modal transformation.
+   * @param memoize Whether to memoize the result.
+   * @param control The control stream.
+   * @param valForm The form of the type of the outputs.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts      Timestamp assigner.
+   */
+  ModalTransformedStream(final SwimStream<S> inputs,
+                         final BindingContext context,
+                         final M initial,
+                         final Function<M, Function<S, ? extends T>> mapping,
+                         final boolean memoize,
+                         final SwimStream<M> control,
+                         final Form<T> valForm,
+                         final boolean isTransient,
+                         final ToLongFunction<T> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    f = mapping;
+    controlStream = control;
+    initialMode = initial;
+    memoizeValue = memoize;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public <U> SwimStream<U> map(final Function<T, ? extends U> f2, final Form<U> form) {
+    final Function<M, Function<S, ? extends U>> composed = control -> f.apply(control).andThen(f2);
+    return new ModalTransformedStream<>(in, getContext(), initialMode, composed, memoizeValue, controlStream,
+        form, isTransient);
+  }
+
+  @Override
+  public <U> SwimStream<U> flatMap(final Function<T, Iterable<U>> f2, final Form<U> form,
+                                   final DelaySpecifier delaySpec) {
+    final Function<M, Function<S, Iterable<U>>> composed = control -> f.apply(control).andThen(f2);
+    return new ModalFlatMapStream<>(in, getContext(), form, initialMode, composed, delaySpec,
+        controlStream, isTransient);
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ModalTransformedStream<>(in, getContext(), initialMode, f, memoizeValue, controlStream, form(),
+        isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<S> source = context.createFor(in);
+    final Junction<M> control = context.createFor(controlStream);
+    final ModalTransformConduit<S, T, M> junction;
+    if (isTransient) {
+      junction = new ModalTransformConduit<>(initialMode, f);
+    } else {
+      final ValuePersister<M> persister = context.getPersistenceProvider().forValue(
+          StateTags.modeTag(id()), controlStream.form(), initialMode);
+      junction = new ModalTransformConduit<>(persister, f);
+    }
+    source.subscribe(junction.first());
+    control.subscribe(junction.second());
+    return junction;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/PartAndWinStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/PartAndWinStream.java
@@ -1,0 +1,141 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.MapWindowedSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.CombinedState;
+import swim.dataflow.graph.windows.CombinedWindowAssigner;
+import swim.dataflow.graph.windows.KeyedWindowBinOp;
+import swim.dataflow.graph.windows.KeyedWindowFoldFunction;
+import swim.dataflow.graph.windows.KeyedWindowFunction;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+/**
+ * A stream that has been simultaneously partitioned and temporally windowed.
+ *
+ * @param <T> The type of the values.
+ * @param <P> The type of the partitions.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the state store tracking open partitions and windows.
+ */
+class PartAndWinStream<Con, T, P, W, S extends CombinedState<P, W, S>> implements MapWindowedSwimStream<P, T, W> {
+
+  private final SwimStream<T> in;
+  private final Con context;
+  private final CombinedWindowAssigner<T, P, W, S> assigner;
+  private final Function<P, Trigger<T, W>> trigger;
+  private final Function<P, EvictionStrategy<T, W>> eviction;
+  private final Form<P> partForm;
+  private final Form<W> winForm;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  PartAndWinStream(final SwimStream<T> input,
+                   final Con con,
+                   final CombinedWindowAssigner<T, P, W, S> winAssigner,
+                   final Function<P, Trigger<T, W>> winTrigger,
+                   final Function<P, EvictionStrategy<T, W>> evictionStrat,
+                   final Form<P> pform, final Form<W> wform,
+                   final Sampling samplingStrat,
+                   final boolean isTransient) {
+    in = input;
+    context = con;
+    assigner = winAssigner;
+    trigger = winTrigger;
+    eviction = evictionStrat;
+    partForm = pform;
+    winForm = wform;
+    sampling = samplingStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public Form<P> keyForm() {
+    return partForm;
+  }
+
+  @Override
+  public Form<T> valueForm() {
+    return in.form();
+  }
+
+  @Override
+  public Form<W> windowForm() {
+    return winForm;
+  }
+
+  @Override
+  public <U> MapSwimStream<P, U> mapWindow(final KeyedWindowFunction<P, T, W, U> winFun, final Form<U> form) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <U> MapSwimStream<P, U> fold(final U seed, final KeyedWindowFoldFunction<P, T, W, U> winFun,
+                                      final BinaryOperator<U> combiner, final Form<U> form) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <U> MapSwimStream<P, U> fold(final U seed,
+                                      final KeyedWindowFoldFunction<P, T, W, U> winFun,
+                                      final Form<U> form) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <U> MapSwimStream<P, U> foldByKeyWithCombiner(final BiFunction<P, W, U> seed, final KeyedWindowFoldFunction<P, T, W, U> winFun, final KeyedWindowBinOp<P, U, W> combiner, final Form<U> form) {
+    return null;
+  }
+
+  @Override
+  public <U> MapSwimStream<P, U> foldByKey(final BiFunction<P, W, U> seed,
+                                           final KeyedWindowFoldFunction<P, T, W, U> winFun,
+                                           final Form<U> form) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public MapSwimStream<P, T> reduceByKey(final KeyedWindowBinOp<P, T, W> op) {
+    throw new UnsupportedOperationException();
+  }
+
+
+  @Override
+  public MapWindowedSwimStream<P, T, W> withTrigger(final Function<P, Trigger<T, W>> trigger) {
+    return new PartAndWinStream<>(in, context, assigner, trigger, eviction, partForm, winForm, sampling, isTransient);
+  }
+
+  @Override
+  public MapWindowedSwimStream<P, T, W> withEviction(final Function<P, EvictionStrategy<T, W>> eviction) {
+    return new PartAndWinStream<>(in, context, assigner, trigger, eviction, partForm, winForm, sampling, isTransient);
+  }
+
+  @Override
+  public MapWindowedSwimStream<P, T, W> setIsTransient(final boolean isTransient) {
+    if (this.isTransient == isTransient) {
+      return this;
+    } else {
+      return new PartAndWinStream<>(in, context, assigner, trigger, eviction, partForm, winForm, sampling, isTransient);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/PartitionedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/PartitionedStream.java
@@ -1,0 +1,110 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.partitions.PartitionConduit;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.dataflow.graph.windows.PartitionState;
+import swim.structure.Form;
+
+/**
+ * A stream that has been split into partitions, forming a map stream.
+ *
+ * @param <T> The type of the values.
+ * @param <P> The type of the partitions (forming the keys of the map).
+ * @param <S> The type of the state tracking the partitions.
+ */
+class PartitionedStream<T, P, S extends PartitionState<P, S>> extends AbstractMapStream<P, T> {
+
+  private final SwimStream<T> in;
+  private final PartitionAssigner<T, P, S> assigner;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param input         The input stream.
+   * @param context       Graph instantiation context,.
+   * @param partAssigner  Assignment of partitions to values.
+   * @param partForm      The form of the partitions.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  PartitionedStream(final SwimStream<T> input,
+                    final BindingContext context,
+                    final PartitionAssigner<T, P, S> partAssigner,
+                    final Form<P> partForm,
+                    final Sampling samplingStrat,
+                    final boolean isTransient) {
+    super(partForm, input.form(), context);
+    in = input;
+    assigner = partAssigner;
+    sampling = samplingStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param input         The input stream.
+   * @param context       Graph instantiation context,.
+   * @param partAssigner  Assignment of partitions to values.
+   * @param partForm      The form of the partitions.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   * @param ts            Timestamp assignment for the values.
+   */
+  PartitionedStream(final SwimStream<T> input,
+                    final BindingContext context,
+                    final PartitionAssigner<T, P, S> partAssigner,
+                    final Form<P> partForm,
+                    final Sampling samplingStrat,
+                    final boolean isTransient,
+                    final ToLongFunction<T> ts) {
+    super(partForm, input.form(), context, ts);
+    in = input;
+    assigner = partAssigner;
+    sampling = samplingStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapJunction<P, T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+    final PartitionConduit<T, P, S> conduit;
+    if (isTransient) {
+      conduit = new PartitionConduit<>(assigner, valueForm());
+    } else {
+      final MapPersister<P, T> persister = context.getPersistenceProvider().forMap(
+          StateTags.stateTag(id()), keyForm(), valueForm());
+      conduit = new PartitionConduit<>(assigner, persister);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  @Override
+  public MapSwimStream<P, T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new PartitionedStream<>(in, getContext(), assigner, keyForm(), sampling, isTransient, datation);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/Recurring.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/Recurring.java
@@ -1,0 +1,125 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.concurrent.atomic.AtomicReference;
+import swim.concurrent.Schedule;
+import swim.concurrent.TimerFunction;
+import swim.concurrent.TimerRef;
+
+/**
+ * A recurring time event (it will reschedule itself on successful completion).
+ */
+public abstract class Recurring implements TimerFunction {
+
+  private final Schedule schedule;
+  private long periodMillis;
+
+  /**
+   * @param schedule Scheduler to execute the events.
+   * @param periodMillis Period between executions.
+   */
+  public Recurring(final Schedule schedule,
+            final long periodMillis) {
+    this.schedule = schedule;
+    this.periodMillis = periodMillis;
+  }
+
+  /**
+   * Update the period.
+   * @param periodMs The new period in ms.
+   */
+  public void setPeriod(final long periodMs) {
+    periodMillis = periodMs;
+    if (isRunning()) {
+      ref.reschedule(periodMillis);
+    }
+  }
+
+  /**
+   * State type for this class.
+   */
+  private enum State {
+    NEW,
+    RUNNING,
+    STOPPED
+  }
+
+  /**
+   * The current state of the recurring event.
+   */
+  private final AtomicReference<State> state = new AtomicReference<>(State.NEW);
+
+  /**
+   * Reference into the scheduler for the event.
+   */
+  private TimerRef ref = null;
+
+  /**
+   * Start executing the events.
+   */
+  public void start() {
+    while (state.get() == State.NEW) {
+      if (state.compareAndSet(State.NEW, State.RUNNING)) {
+        ref = schedule.setTimer(periodMillis, this);
+      }
+    }
+    if (state.get() == State.STOPPED) {
+      throw new IllegalStateException("Recurring event already stopped.");
+    }
+  }
+
+  /**
+   * Determine if the events are running.
+   * @return Whether we are in the running state.
+   */
+  public boolean isRunning() {
+    return state.get() == State.RUNNING;
+  }
+
+  /**
+   * Stop executing the events.
+   */
+  public void stop() {
+    while (state.get() == State.RUNNING) {
+      if (state.compareAndSet(State.RUNNING, State.STOPPED)) {
+        ref.cancel();
+      }
+    }
+  }
+
+  /**
+   * Called when the event triggers.
+   */
+  protected abstract void onTrigger();
+
+  @Override
+  public void runTimer() {
+    if (state.get() == State.RUNNING) {
+      try {
+        onTrigger();
+      } catch (final RuntimeException | Error ex) {
+        stop();
+        throw ex;
+      } finally {
+        if (state.get() == State.RUNNING) {
+          if (ref != null) {
+            ref.reschedule(periodMillis);
+          }
+        }
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedByEntriesMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedByEntriesMapStream.java
@@ -1,0 +1,108 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.ReduceFieldsConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * Maintain an instantaneous reduced view of the values of a map stream, for all keys.
+ *
+ * @param <K> The key type of the map stream.
+ * @param <V> The value type of the map stream.
+ * @param <U> The type of the output of the reduction.
+ */
+class ReducedByEntriesMapStream<K, V, U> extends AbstractSwimStream<U> {
+
+  private final MapSwimStream<K, V> in;
+  private final U seed;
+  private final BiFunction<U, ? super V, U> operation;
+  private final BinaryOperator<U> combiner;
+  private final Sampling sampling;
+
+  /**
+   * @param input         The source map stream.
+   * @param context       The instantiation context.
+   * @param seedValue     The seed value for the reduction.
+   * @param op            The reduction operation.
+   * @param combine       Combiner for intermediate results.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  ReducedByEntriesMapStream(final MapSwimStream<K, V> input,
+                            final BindingContext context,
+                            final U seedValue,
+                            final BiFunction<U, ? super V, U> op,
+                            final BinaryOperator<U> combine, final Form<U> form,
+                            final Sampling samplingStrat) {
+    super(form, context);
+    seed = seedValue;
+    in = input;
+    operation = op;
+    combiner = combine;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param input         The source map stream.
+   * @param context       The instantiation context.
+   * @param seedValue     The seed value for the reduction.
+   * @param op            The reduction operation.
+   * @param combine       Combiner for intermediate results.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts            Timestamp assigner for the stream.
+   */
+  ReducedByEntriesMapStream(final MapSwimStream<K, V> input,
+                            final BindingContext context,
+                            final U seedValue,
+                            final BiFunction<U, ? super V, U> op,
+                            final BinaryOperator<U> combine, final Form<U> form,
+                            final Sampling samplingStrat,
+                            final ToLongFunction<U> ts) {
+    super(form, context, ts);
+    seed = seedValue;
+    in = input;
+    operation = op;
+    combiner = combine;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public SwimStream<U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new ReducedByEntriesMapStream<>(in, getContext(), seed, operation, combiner, form(), sampling);
+  }
+
+  @Override
+  public Junction<U> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = StreamDecoupling.sampleMapStream(id(), context,
+        context.createFor(in), sampling, StreamInterpretation.DISCRETE);
+    final ReduceFieldsConduit<K, V, U> conduit = new ReduceFieldsConduit<>(seed, operation, combiner);
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedByKeyMapWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedByKeyMapWindowedStream.java
@@ -1,0 +1,176 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.collections.BTreeMap;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.KeyedWindowConduit;
+import swim.dataflow.graph.impl.windows.MapPaneUpdater;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvaluator;
+import swim.dataflow.graph.impl.windows.PaneManager;
+import swim.dataflow.graph.impl.windows.ReducePaneUpdater;
+import swim.dataflow.graph.impl.windows.ReducingEvaluator;
+import swim.dataflow.graph.impl.windows.ThresholdEvictor;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.windows.KeyedWindowBinOp;
+import swim.dataflow.graph.windows.KeyedWindowSpec;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+
+/**
+ * Map stream of the reductions of the values over a window for each key of a mapped stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ * @param <W> The type of the windows.
+ */
+class ReducedByKeyMapWindowedStream<K, V, W, S extends WindowState<W, S>> extends AbstractMapStream<K, V> {
+
+  private final MapSwimStream<K, V> in;
+  private final KeyedWindowSpec<K, V, W, S> spec;
+  private final KeyedWindowBinOp<K, V, W> operator;
+  private final Sampling sampling;
+
+  /**
+   * @param stream   The source map stream.
+   * @param context  The instantiation context.
+   * @param reduceOp The reduction operation.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  ReducedByKeyMapWindowedStream(final MapSwimStream<K, V> stream,
+                                final BindingContext context,
+                                final KeyedWindowSpec<K, V, W, S> winSpec,
+                                final KeyedWindowBinOp<K, V, W> reduceOp,
+                                final Sampling samplingStrat) {
+    super(stream.keyForm(), stream.valueForm(), context);
+    in = stream;
+    operator = reduceOp;
+    spec = winSpec;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param stream   The source map stream.
+   * @param context  The instantiation context.
+   * @param reduceOp The reduction operation.
+   * @param ts       Timestamp assignment for the values.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  ReducedByKeyMapWindowedStream(final MapSwimStream<K, V> stream,
+                                final BindingContext context,
+                                final KeyedWindowSpec<K, V, W, S> winSpec,
+                                final KeyedWindowBinOp<K, V, W> reduceOp,
+                                final Sampling samplingStrat,
+                                final ToLongFunction<V> ts) {
+    super(stream.keyForm(), stream.valueForm(), context, ts);
+    in = stream;
+    operator = reduceOp;
+    spec = winSpec;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final PersistenceProvider persistence = context.getPersistenceProvider();
+
+    final Function<K, PaneManager<V, W, V>> paneManagers = k -> spec.getEvictionStrategy().apply(k).match(
+        none -> createWithoutEviction(k, persistence), threshold -> createWithEviction(k, persistence, threshold));
+    final MapJunction<K, V> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+
+    final ToLongFunction<V> ts = in.getTimestamps();
+    final TimestampAssigner<V> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+    final KeyedWindowConduit<K, V, W, V> conduit;
+    if (spec.isTransient()) {
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), paneManagers, timestamps);
+    } else {
+      final SetPersister<K> keysPersister = context.getPersistenceProvider().forSet(
+          StateTags.stateTag(id()), keyForm());
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), keysPersister, paneManagers, timestamps);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  //When we have eviction it is necessary to maintain all of the data in the window.
+  private <C extends Comparable<C>> PaneManager<V, W, V> createWithEviction(
+      final K k,
+      final PersistenceProvider persistence,
+      final ThresholdEviction<V, C, W> eviction) {
+    final MapPaneUpdater<V, W, C, V> updater = new MapPaneUpdater<>(eviction.getCriterion());
+    final ThresholdEvictor<V, C, W, V> evictor = new ThresholdEvictor<>(eviction.getThreshold());
+
+    final WindowBinOp<V, W> keyedOp = (w, v1, v2) -> operator.apply(k, w, v1, v2);
+    final WindowFoldFunction<V, W, V> accFun = (w, acc, value) -> acc == null ? value : operator.apply(k, w, acc, value);
+
+    final ReducingEvaluator<C, V, W, V> evaluator = new ReducingEvaluator<>(w -> null, accFun, keyedOp);
+
+    final WindowAccumulators<W, BTreeMap<C, V, V>> accumulators = WindowStates.forMapState(
+        spec.isTransient(),
+        StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+        persistence,
+        spec.getWindowForm(),
+        eviction.getCriterionForm(),
+        valueForm()
+    );
+
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+  }
+
+  //Without eviction we only need to store the state of the operation.
+  private PaneManager<V, W, V> createWithoutEviction(final K k, final PersistenceProvider persistence) {
+
+    final WindowBinOp<V, W> keyedOp = (w, v1, v2) -> operator.apply(k, w, v1, v2);
+    final ReducePaneUpdater<V, W> updater = new ReducePaneUpdater<>(keyedOp);
+    final NoOpEvictor<V, W, V> evictor = NoOpEvictor.instance();
+    final PaneEvaluator<V, W, V> evaluator = PaneEvaluator.identity();
+
+
+    final WindowAccumulators<W, V> accumulators = WindowStates.forSimpleState(
+        spec.isTransient(),
+        StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+        persistence,
+        spec.getWindowForm(),
+        valueForm()
+    );
+
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ReducedByKeyMapWindowedStream<>(in, getContext(), spec, operator, sampling, datation);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedMapStream.java
@@ -1,0 +1,99 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BinaryOperator;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.MapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * Accumulates the values associated with each key over time.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+final class ReducedMapStream<K, V> extends AbstractMapStream<K, V> {
+  private final MapSwimStream<K, V> in;
+  private final BinaryOperator<V> operator;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The input stream.
+   * @param context     Instantiation context.
+   * @param op          Operation to apply on each new value and the previous state of the accumulation.
+   * @param sampleStrat Sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ReducedMapStream(final MapSwimStream<K, V> inputs,
+                   final BindingContext context,
+                   final BinaryOperator<V> op,
+                   final Sampling sampleStrat,
+                   final boolean isTransient) {
+    super(inputs.keyForm(), inputs.valueForm(), context);
+    in = inputs;
+    operator = op;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param inputs      The input stream.
+   * @param context     Instantiation context.
+   * @param op          Operation to apply on each new value and the previous state of the accumulation.
+   * @param sampleStrat Sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param ts          Timestamp assignment for the values.
+   */
+  ReducedMapStream(final MapSwimStream<K, V> inputs,
+                   final BindingContext context,
+                   final BinaryOperator<V> op,
+                   final Sampling sampleStrat,
+                   final boolean isTransient,
+                   final ToLongFunction<V> ts) {
+    super(inputs.keyForm(), inputs.valueForm(), context, ts);
+    in = inputs;
+    operator = op;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new ReducedMapStream<>(in, getContext(), operator, sampling, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final MapConduit<K, K, V, V> conduit;
+    if (isTransient) {
+      conduit = StatefulConduits.reduceMap(operator);
+    } else {
+      final MapPersister<K, V> statePersister = context.getPersistenceProvider()
+          .forMap(StateTags.stateTag(id()), keyForm(), valueForm(), null);
+      conduit = StatefulConduits.reduceMap(statePersister, operator);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedStream.java
@@ -1,0 +1,93 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BinaryOperator;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Conduit;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.StatefulConduits;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * Reduces the values of the stream over time.
+ *
+ * @param <T> The type of the values.
+ */
+class ReducedStream<T> extends AbstractSwimStream<T> {
+  private final SwimStream<T> in;
+  private final BinaryOperator<T> operator;
+  private final Sampling sampling;
+  private final boolean isTransient;
+
+  /**
+   * @param inputs      The input stream.
+   * @param context     Instantiation context.
+   * @param op          Operation to apply on each new value and the previous state of the reduction.
+   * @param sampleStrat Sampling strategy for the link.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   */
+  ReducedStream(final SwimStream<T> inputs,
+                final BindingContext context,
+                final BinaryOperator<T> op,
+                final Sampling sampleStrat,
+                final boolean isTransient) {
+    super(inputs.form(), context);
+    in = inputs;
+    operator = op;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  ReducedStream(final SwimStream<T> inputs,
+                final BindingContext context,
+                final BinaryOperator<T> op,
+                final Sampling sampleStrat,
+                final boolean isTransient,
+                final ToLongFunction<T> ts) {
+    super(inputs.form(), context, ts);
+    in = inputs;
+    operator = op;
+    sampling = sampleStrat;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ReducedStream<>(in, getContext(), operator, sampling, isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context,
+        context.createFor(in), sampling, StreamInterpretation.DISCRETE);
+    final Conduit<T, T> conduit;
+    if (isTransient) {
+      conduit = StatefulConduits.reduce(operator);
+    } else {
+      final ValuePersister<T> statePersister = context.getPersistenceProvider().forValue(
+          StateTags.stateTag(id()), form(), null);
+      conduit = StatefulConduits.reduce(statePersister, operator);
+    }
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/ReducedWindowedStream.java
@@ -1,0 +1,149 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.collections.BTreeMap;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.MapPaneUpdater;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvaluator;
+import swim.dataflow.graph.impl.windows.PaneManager;
+import swim.dataflow.graph.impl.windows.ReducePaneUpdater;
+import swim.dataflow.graph.impl.windows.ReducingEvaluator;
+import swim.dataflow.graph.impl.windows.ThresholdEvictor;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.impl.windows.WindowConduit;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+
+/**
+ * Stream of the reductions of another stream over a window.
+ *
+ * @param <T> The type of the inputs.
+ * @param <W> The type of the windows.
+ */
+class ReducedWindowedStream<T, W, S extends WindowState<W, S>> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final WindowSpec<T, W, S> spec;
+  private final WindowBinOp<T, W> operator;
+  private final Sampling sampling;
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param op            The binary operator to apply.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  ReducedWindowedStream(final SwimStream<T> input,
+                        final WindowSpec<T, W, S> windowSpec,
+                        final BindingContext context,
+                        final WindowBinOp<T, W> op,
+                        final Sampling samplingStrat) {
+    super(input.form(), context);
+    in = input;
+    spec = windowSpec;
+    operator = op;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param op            The binary operator to apply.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts            Timestamp assignment for the values.
+   */
+  ReducedWindowedStream(final SwimStream<T> input,
+                        final WindowSpec<T, W, S> windowSpec,
+                        final BindingContext context,
+                        final WindowBinOp<T, W> op,
+                        final Sampling samplingStrat,
+                        final ToLongFunction<T> ts) {
+    super(input.form(), context);
+    in = input;
+    spec = windowSpec;
+    operator = op;
+    sampling = samplingStrat;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new ReducedWindowedStream<>(in, spec, getContext(), operator, sampling, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final PersistenceProvider persistence = context.getPersistenceProvider();
+    final PaneManager<T, W, T> paneManager = spec.getEvictionStrategy().match(
+        none -> createWithoutEviction(persistence), eviction -> createWithEviction(persistence, eviction));
+
+    final ToLongFunction<T> ts = in.getTimestamps();
+    final TimestampAssigner<T> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+
+    final WindowConduit<T, W, T> conduit = new WindowConduit<>(context.getSchedule(), paneManager, timestamps);
+
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in), sampling, StreamInterpretation.DISCRETE);
+
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  //When we have eviction it is necessary to maintain all of the data in the window.
+  private <K extends Comparable<K>> PaneManager<T, W, T> createWithEviction(final PersistenceProvider persistence,
+                                                                            final ThresholdEviction<T, K, W> eviction) {
+    final MapPaneUpdater<T, W, K, T> updater = new MapPaneUpdater<>(eviction.getCriterion());
+    final ThresholdEvictor<T, K, W, T> evictor = new ThresholdEvictor<>(eviction.getThreshold());
+
+    final WindowFoldFunction<T, W, T> accFun = (w, acc, value) -> acc == null ? value : operator.apply(w, acc, value);
+
+    final ReducingEvaluator<K, T, W, T> evaluator = new ReducingEvaluator<>(w -> null, accFun, operator);
+
+    final WindowAccumulators<W, BTreeMap<K, T, T>> accumulators = WindowStates.forMapState(
+        spec.isTransient(), StateTags.stateTag(id()), persistence, spec.getWindowForm(), eviction.getCriterionForm(), form());
+
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+  }
+
+  //Without eviction we only need to store the state of the operation.
+  private PaneManager<T, W, T> createWithoutEviction(final PersistenceProvider persistence) {
+    final ReducePaneUpdater<T, W> updater = new ReducePaneUpdater<>(operator);
+    final NoOpEvictor<T, W, T> evictor = NoOpEvictor.instance();
+    final PaneEvaluator<T, W, T> evaluator = PaneEvaluator.identity();
+    final WindowAccumulators<W, T> accumulators = WindowStates.forSimpleState(
+        spec.isTransient(), StateTags.stateTag(id()), persistence, spec.getWindowForm(), form());
+
+    return new DefaultPaneManager<>(accumulators,
+        spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/SinkBinding.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/SinkBinding.java
@@ -1,0 +1,49 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.Receptacle;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.Unit;
+
+/**
+ * Binding of a stream to a sink.
+ *
+ * @param <T> The type of the data.
+ */
+class SinkBinding<T> implements InternalSinkHandle<Unit, T> {
+
+  private final SwimStream<T> stream;
+  private final Sink<T> sink;
+
+  /**
+   * @param in  The stream to bind to the sink.
+   * @param out The target sink.
+   */
+  SinkBinding(final SwimStream<T> in, final Sink<T> out) {
+    stream = in;
+    sink = out;
+  }
+
+  @Override
+  public void bindConnector(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(stream);
+    final Receptacle<T> receptacle = context.createFrom(sink);
+    source.subscribe(receptacle);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/StateTags.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/StateTags.java
@@ -1,0 +1,92 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.dataflow.graph.Require;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Utilities to create identifying tags for states stored by stream elements.
+ */
+final class StateTags {
+
+  private StateTags() { }
+
+  static final String TAG = "StateKey";
+  static final String PERIOD_SUFFIX = "period";
+  static final String MODE_SUFFIX = "mode";
+  static final String STATE_SUFFIX = "state";
+
+  static final String NAME_PROP = "element";
+  static final String KIND_PROP = "kind";
+  static final String KEY_PROP = "key";
+
+  /**
+   * Create a tag for a state.
+   * @param baseName Name uniquely identifying the stream element.
+   * @param suffix Name to distinguish multiple states for a single element.
+   * @return The tag.
+   */
+  private static Value createTag(final String baseName, final String suffix) {
+    Require.that(baseName != null, "The base name must be non-null.");
+    return Record.create(1).attr(TAG, Record.create(2)
+        .slot(NAME_PROP, baseName)
+        .slot(KIND_PROP, suffix));
+  }
+
+  /**
+   * Create a tag for a state that stores the frequency of updates for an element.
+   * @param baseName Name uniquely identifying the stream element.
+   * @return The tag.
+   */
+  public static Value periodTag(final String baseName) {
+    return createTag(baseName, PERIOD_SUFFIX);
+  }
+
+  /**
+   * Create a tag for a state that stores the current mode of a modal element.
+   * @param baseName Name uniquely identifying the stream element.
+   * @return The tag.
+   */
+  public static Value modeTag(final String baseName) {
+    return createTag(baseName, MODE_SUFFIX);
+  }
+
+  /**
+   * Create a tag for a state that stores the current state of a stateful element.
+   * @param baseName Name uniquely identifying the stream element.
+   * @return The tag.
+   */
+  public static Value stateTag(final String baseName) {
+    return createTag(baseName, STATE_SUFFIX);
+  }
+
+  /**
+   * Create a tag for an element that requires an arbitrary number of states.
+   * @param baseName Name uniquely identifying the stream element.
+   * @param key Key to distinguish the states of this element.
+   * @return THe tag.
+   */
+  public static Value keyedStateTag(final String baseName, final Value key) {
+    Require.that(baseName != null, "The base name must be non-null.");
+    Require.that(key != null, "The key must be non-null.");
+    return Record.create(1).attr(TAG, Record.create(3)
+        .slot(NAME_PROP, baseName)
+        .slot(KIND_PROP, STATE_SUFFIX)
+        .slot(KEY_PROP, key));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/StreamDecoupling.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/StreamDecoupling.java
@@ -1,0 +1,161 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.time.Duration;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapJunction2;
+import swim.dataflow.connector.PeriodicConduit;
+import swim.dataflow.connector.RateLimitedMapConduit;
+import swim.dataflow.connector.SamplingMapConduit;
+import swim.dataflow.connector.VariablePeriodicConduit;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.dataflow.graph.sampling.Sampling;
+
+/**
+ * Static methods to temporally decouple a stream (the rate at which the stream emits data becomes different from
+ * the rate at which it receives it).
+ */
+final class StreamDecoupling {
+
+  private StreamDecoupling() {
+  }
+
+  /**
+   * Sample from a junction, producing another junction.
+   *
+   * @param id             The ID of the stream component.
+   * @param context        The stream initialization context.
+   * @param in             The input junction.
+   * @param sampling       The sampling strategy.
+   * @param interpretation Semantic interpretation of the stream.
+   * @param <T>            The type of the stream.
+   * @return Junection producing the sampled data.
+   */
+  public static <T> Junction<T> sampleStream(final String id,
+                                             final SwimStreamContext.InitContext context,
+                                             final Junction<T> in,
+                                             final Sampling sampling,
+                                             final StreamInterpretation interpretation) {
+
+    return sampling.match(() -> in,
+        dur -> constantSampling(context, in, dur.getInterval(), interpretation),
+        dyn -> dynamicSampling(id, context, in, dyn.getInitial(), dyn.getIntervalStream(), dyn.isTransient(), interpretation));
+  }
+
+  /**
+   * Sample from a map junction, producing another map junction.
+   *
+   * @param id             The ID of the stream component.
+   * @param context        The stream initialization context.
+   * @param in             The input junction.
+   * @param sampling       The sampling strategy.
+   * @param interpretation Semantic interpretation of the stream.
+   * @param <K>            The type of the keys.
+   * @param <V>            The type of the values.
+   * @return Junction emitting the sampled data.
+   */
+  public static <K, V> MapJunction<K, V> sampleMapStream(final String id,
+                                                         final SwimStreamContext.InitContext context,
+                                                         final MapJunction<K, V> in,
+                                                         final Sampling sampling,
+                                                         final StreamInterpretation interpretation) {
+    return sampling.match(() -> in,
+        dur -> constantSamplingMap(context, in, dur.getInterval(), interpretation),
+        dyn -> dynamicSamplingMap(id, context, in, dyn.getInitial(), dyn.getIntervalStream(), dyn.isTransient(), interpretation));
+  }
+
+  private static <T> Junction<T> dynamicSampling(final String id,
+                                                 final SwimStreamContext.InitContext context,
+                                                 final Junction<T> in,
+                                                 final Duration dur0,
+                                                 final SwimStream<Duration> durs,
+                                                 final boolean isTransient,
+                                                 final StreamInterpretation interpretation) {
+    final Junction<Duration> control = context.createFor(durs);
+    final VariablePeriodicConduit<T> conduit;
+    if (isTransient) {
+      conduit = new VariablePeriodicConduit<>(
+          context.getSchedule(), dur0, interpretation);
+    } else {
+      final ValuePersister<Duration> persister = context.getPersistenceProvider().forValue(
+          StateTags.periodTag(id), durs.form(), dur0);
+      conduit = new VariablePeriodicConduit<>(
+          context.getSchedule(), persister, interpretation);
+    }
+    control.subscribe(conduit.second());
+    in.subscribe(conduit.first());
+    return conduit;
+  }
+
+  private static <K, V> MapJunction<K, V> dynamicSamplingMap(final String id,
+                                                             final SwimStreamContext.InitContext context,
+                                                             final MapJunction<K, V> in,
+                                                             final Duration dur0,
+                                                             final SwimStream<Duration> durs,
+                                                             final boolean isTransient,
+                                                             final StreamInterpretation interpretation) {
+    final MapJunction2<K, K, V, V, Duration> conduit;
+    if (isTransient) {
+      if (interpretation == StreamInterpretation.DISCRETE) {
+        conduit = new RateLimitedMapConduit<>(context.getSchedule(), dur0);
+      } else {
+        conduit = new SamplingMapConduit<>(context.getSchedule(), dur0);
+      }
+    } else {
+      final ValuePersister<Duration> persister = context.getPersistenceProvider().forValue(
+          StateTags.periodTag(id), durs.form(), dur0);
+      if (interpretation == StreamInterpretation.DISCRETE) {
+        conduit = new RateLimitedMapConduit<>(context.getSchedule(), persister);
+      } else {
+        conduit = new SamplingMapConduit<>(context.getSchedule(), persister);
+      }
+    }
+
+    in.subscribe(conduit.first());
+
+    final Junction<Duration> periods = context.createFor(durs);
+    periods.subscribe(conduit.second());
+    return conduit;
+  }
+
+  private static <T> Junction<T> constantSampling(final SwimStreamContext.InitContext context,
+                                                  final Junction<T> in,
+                                                  final Duration dur,
+                                                  final StreamInterpretation interpretation) {
+    final PeriodicConduit<T> conduit = new PeriodicConduit<>(
+        context.getSchedule(), dur, interpretation);
+    in.subscribe(conduit);
+    return conduit;
+  }
+
+  private static <K, V> MapJunction2<K, K, V, V, Duration> constantSamplingMap(final SwimStreamContext.InitContext context,
+                                                                               final MapJunction<K, V> in, final Duration dur,
+                                                                               final StreamInterpretation interpretation) {
+    final MapJunction2<K, K, V, V, Duration> conduit;
+    if (interpretation == StreamInterpretation.DISCRETE) {
+      conduit = new RateLimitedMapConduit<>(context.getSchedule(), dur);
+    } else {
+      conduit = new SamplingMapConduit<>(context.getSchedule(), dur);
+    }
+    in.subscribe(conduit.first());
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedColStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedColStream.java
@@ -1,0 +1,85 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.TransformConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.CollectionSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * A stream of collections derived from another stream.
+ *
+ * @param <T> The type of the input values.
+ * @param <U> The type of the elements of the collections.
+ * @param <C> The type of the collections.
+ */
+class TransformedColStream<T, U, C extends Collection<U>> extends AbstractCollectionStream<U, C> {
+
+  private final SwimStream<T> in;
+  private final Function<T, C> f;
+  private final boolean memoizeValue;
+
+  /**
+   * @param input     The source stream.
+   * @param context   The instantiation context.
+   * @param transform The transformation.
+   * @param memoize Whether to memoize the result.
+   * @param form      The form of the type of the collections.
+   */
+  TransformedColStream(final SwimStream<T> input, final BindingContext context, final Function<T, C> transform,
+                       final boolean memoize, final Form<C> form) {
+    super(form, context);
+    in = input;
+    f = transform;
+    memoizeValue = memoize;
+  }
+
+  /**
+   * @param input     The source stream.
+   * @param context   The instantiation context.
+   * @param transform The transformation.
+   *  @param memoize Whether to memoize the result.
+   * @param form      The form of the type of the collections.
+   * @param ts        Timestamp assigner for the stream.
+   */
+  TransformedColStream(final SwimStream<T> input, final BindingContext context, final Function<T, C> transform,
+                       final boolean memoize, final Form<C> form,
+                       final ToLongFunction<C> ts) {
+    super(form, context, ts);
+    in = input;
+    f = transform;
+    memoizeValue = memoize;
+  }
+
+  @Override
+  public CollectionSwimStream<U, C> updateTimestamps(final ToLongFunction<C> datation) {
+    return new TransformedColStream<>(in, getContext(), f, memoizeValue, form(), datation);
+  }
+
+  @Override
+  public Junction<C> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(in);
+    final TransformConduit<T, C> conduit = new TransformConduit<>(f);
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedMapStream.java
@@ -1,0 +1,99 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.FlatMapEntriesConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * A map stream formed by applying a function to the key-value pairs of another stream.
+ *
+ * @param <K1> The type of the input keys.
+ * @param <K2> The type of the output keys.
+ * @param <V1> The type of the input values.
+ * @param <V2> The type of the output values.
+ */
+class TransformedMapStream<K1, K2, V1, V2> extends AbstractMapStream<K2, V2> {
+
+  private final MapSwimStream<K1, V1> in;
+  private final BiFunction<K1, V1, Pair<K2, V2>> f;
+  private final Function<K1, Set<K2>> onRemove;
+
+  /**
+   * @param input   The source stream.
+   * @param context The instantiation context.
+   * @param fun     The transformation function.
+   * @param onRem   Keys to remove from the derived map when a key is moved from the source.
+   * @param kform   The form of the type of the output keys.
+   * @param vform   The form of the type of the output values.
+   */
+  TransformedMapStream(
+          final MapSwimStream<K1, V1> input,
+          final BindingContext context,
+          final BiFunction<K1, V1, Pair<K2, V2>> fun,
+          final Function<K1, Set<K2>> onRem,
+          final Form<K2> kform, final Form<V2> vform) {
+    super(kform, vform, context);
+    in = input;
+    f = fun;
+    onRemove = onRem;
+  }
+
+  /**
+   * @param input   The source stream.
+   * @param context The instantiation context.
+   * @param fun     The transformation function.
+   * @param onRem   Keys to remove from the derived map when a key is moved from the source.
+   * @param kform   The form of the type of the output keys.
+   * @param vform   The form of the type of the output values.
+   * @param ts      Timestamp assignment for the values.
+   */
+  TransformedMapStream(
+      final MapSwimStream<K1, V1> input,
+      final BindingContext context,
+      final BiFunction<K1, V1, Pair<K2, V2>> fun,
+      final Function<K1, Set<K2>> onRem,
+      final Form<K2> kform, final Form<V2> vform,
+      final ToLongFunction<V2> ts) {
+    super(kform, vform, context, ts);
+    in = input;
+    f = fun;
+    onRemove = onRem;
+  }
+
+  @Override
+  public MapSwimStream<K2, V2> updateTimestamps(final ToLongFunction<V2> datation) {
+    return new TransformedMapStream<>(in, getContext(), f, onRemove, keyForm(), valueForm(), datation);
+  }
+
+  @Override
+  public MapJunction<K2, V2> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K1, V1> source = context.createFor(in);
+    final BiFunction<K1, V1, Iterable<Pair<K2, V2>>> itFun = (k1, v1) -> Collections.singletonList(f.apply(k1, v1));
+    final FlatMapEntriesConduit<K1, K2, V1, V2> conduit = new FlatMapEntriesConduit<>(itFun, onRemove);
+    source.subscribe(conduit);
+    return conduit;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedMapWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedMapWindowedStream.java
@@ -1,0 +1,157 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.KeyedWindowConduit;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvictor;
+import swim.dataflow.graph.impl.windows.PaneManager;
+import swim.dataflow.graph.impl.windows.SequencePaneUpdater;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.impl.windows.WindowFunctionEvaluator;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.KeyedWindowFunction;
+import swim.dataflow.graph.windows.KeyedWindowSpec;
+import swim.dataflow.graph.windows.WindowFunction;
+import swim.dataflow.graph.windows.WindowState;
+import swim.structure.Form;
+
+/**
+ * Stream formed by applying a function across the contents of each window for each key of a windowed map stream.
+ *
+ * @param <K> The type of the keys of the stream.
+ * @param <T> The input value type (type of the window contents).
+ * @param <U> The output value type.
+ * @param <W> The type of the windows.
+ */
+class TransformedMapWindowedStream<K, T, U, W, S extends WindowState<W, S>> extends AbstractMapStream<K, U> {
+
+  private final MapSwimStream<K, T> in;
+  private final KeyedWindowFunction<K, T, W, U> winFun;
+  private final KeyedWindowSpec<K, T, W, S> spec;
+  private final Sampling sampling;
+
+  /**
+   * @param stream        The source stream.
+   * @param context       The instantiation context.
+   * @param winSpec       Specification for the window.
+   * @param form          The form of the type of the outputs.
+   * @param fun           The function to apply to the window.
+   * @param samplingStrat      The sampling strategy for the link.
+   */
+  TransformedMapWindowedStream(final MapSwimStream<K, T> stream,
+                               final BindingContext context,
+                               final KeyedWindowSpec<K, T, W, S> winSpec,
+                               final Form<U> form,
+                               final KeyedWindowFunction<K, T, W, U> fun,
+                               final Sampling samplingStrat) {
+    super(stream.keyForm(), form, context);
+    in = stream;
+    winFun = fun;
+    spec = winSpec;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param stream   The source stream.
+   * @param context  The instantiation context.
+   * @param winSpec  Specification for the window.
+   * @param form     The form of the type of the outputs.
+   * @param fun      The function to apply to the window.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts       Timestamp assignment for the values.
+   */
+  TransformedMapWindowedStream(final MapSwimStream<K, T> stream,
+                               final BindingContext context,
+                               final KeyedWindowSpec<K, T, W, S> winSpec,
+                               final Form<U> form,
+                               final KeyedWindowFunction<K, T, W, U> fun,
+                               final Sampling samplingStrat,
+                               final ToLongFunction<U> ts) {
+    super(stream.keyForm(), form, context, ts);
+    in = stream;
+    winFun = fun;
+    spec = winSpec;
+    sampling = samplingStrat;
+  }
+
+  private Function<K, PaneManager<T, W, U>> createManagerFactory(final PersistenceProvider persistence) {
+    return k -> {
+      final SequencePaneUpdater<T, W> updater = new SequencePaneUpdater<>();
+      final PaneEvictor<T, W, FingerTrieSeq<WithTimestamp<T>>> evictor = spec.getEvictionStrategy().apply(k).match(
+          none -> NoOpEvictor.instance(),
+          EvictionUtil::createEvictor
+      );
+
+      final WindowFunction<T, W, U> keyFun = (w, contents) -> winFun.apply(k, w, contents);
+      final WindowFunctionEvaluator<T, W, U> evaluator = new WindowFunctionEvaluator<>(keyFun);
+
+      final WindowAccumulators<W, FingerTrieSeq<WithTimestamp<T>>> accumulators = WindowStates.forSequencesState(
+          spec.isTransient(),
+          StateTags.keyedStateTag(id(), keyForm().mold(k).toValue()),
+          persistence,
+          spec.getWindowForm(),
+          in.valueForm()
+      );
+      return new DefaultPaneManager<>(accumulators,
+          spec.getAssigner().apply(k), spec.getTrigger().apply(k), updater, evictor, evaluator);
+    };
+  }
+
+  @Override
+  public MapJunction<K, U> instantiate(final SwimStreamContext.InitContext context) {
+
+    final Function<K, PaneManager<T, W, U>> managerFactory = createManagerFactory(context.getPersistenceProvider());
+
+    final MapJunction<K, T> source = StreamDecoupling.sampleMapStream(id(), context, context.createFor(in),
+        sampling, StreamInterpretation.DISCRETE);
+
+    final ToLongFunction<T> ts = in.getTimestamps();
+    final TimestampAssigner<T> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+    final KeyedWindowConduit<K, T, W, U> conduit;
+    if (spec.isTransient()) {
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), managerFactory, timestamps);
+    } else {
+      final SetPersister<K> keysPersister = context.getPersistenceProvider().forSet(
+          StateTags.stateTag(id()), keyForm());
+      conduit = new KeyedWindowConduit<>(
+          context.getSchedule(), keysPersister, managerFactory, timestamps);
+    }
+
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+  @Override
+  public MapSwimStream<K, U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new TransformedMapWindowedStream<>(in, getContext(), spec, valueForm(), winFun, sampling, datation);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedStream.java
@@ -1,0 +1,122 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MemoizingConduit;
+import swim.dataflow.connector.TransformConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.structure.Form;
+
+/**
+ * A stream which transforms the values of another stream.
+ *
+ * @param <S> The type of the inputs.
+ * @param <T> The type of the outputs.
+ */
+public class TransformedStream<S, T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<S> in;
+  private final Function<S, ? extends T> f;
+  private final boolean memoizeValue;
+
+  /**
+   * @param inputs  The source stream.
+   * @param context The instantiation context.
+   * @param mapping The transformation.
+   * @param memoize Whether to memoize the result.
+   * @param valForm The form of the type of the outputs.
+   */
+  TransformedStream(final SwimStream<S> inputs,
+                    final BindingContext context,
+                    final Function<S, ? extends T> mapping,
+                    final boolean memoize,
+                    final Form<T> valForm) {
+    super(valForm, context);
+    in = inputs;
+    f = mapping;
+    memoizeValue = memoize;
+  }
+
+  /**
+   * @param inputs  The source stream.
+   * @param context The instantiation context.
+   * @param mapping The transformation.
+   * @param memoize Whether to memoize the result.
+   * @param valForm The form of the type of the outputs.
+   * @param ts      Timestamp assigner for the stream.
+   */
+  TransformedStream(final SwimStream<S> inputs,
+                    final BindingContext context,
+                    final Function<S, ? extends T> mapping,
+                    final boolean memoize,
+                    final Form<T> valForm,
+                    final ToLongFunction<T> ts) {
+    super(valForm, context, ts);
+    in = inputs;
+    f = mapping;
+    memoizeValue = memoize;
+  }
+
+
+  @Override
+  public <U> SwimStream<U> map(final Function<T, ? extends U> f2, final Form<U> form) {
+    return new TransformedStream<>(in, getContext(), f.andThen(f2), memoizeValue, form);
+  }
+
+  @Override
+  public <U, M> SwimStream<U> mapModal(final M initialMode, final Function<M, Function<T, ? extends U>> f2,
+                                       final Form<U> form,
+                                       final SwimStream<M> controlStream,
+                                       final boolean isTransient) {
+    final Function<M, Function<S, ? extends U>> mapped = control -> f.andThen(f2.apply(control));
+    return new ModalTransformedStream<>(in, getContext(), initialMode, mapped, memoizeValue, controlStream, form,
+        isTransient);
+  }
+
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new TransformedStream<>(in, getContext(), f, memoizeValue, form(), datation);
+  }
+
+  @Override
+  public <U> SwimStream<U> fold(final U seed, final BiFunction<U, T, U> op, final Form<U> form,
+                                final Sampling samplingStrat, final boolean isTransient) {
+    final BiFunction<U, S, U> mappedOp = (U state, S value) -> op.apply(state, f.apply(value));
+    return new FoldedStream<>(in, getContext(), form, seed, mappedOp, samplingStrat, isTransient);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<S> source = context.createFor(in);
+    final TransformConduit<S, T> conduit = new TransformConduit<>(f);
+    source.subscribe(conduit);
+    if (memoizeValue) {
+      final MemoizingConduit<T> memoizer = new MemoizingConduit<>();
+      conduit.subscribe(memoizer);
+      return memoizer;
+    } else {
+      return conduit;
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedValuesMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedValuesMapStream.java
@@ -1,0 +1,93 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.BiFunction;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.MapConduit;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapMemoizingConduit;
+import swim.dataflow.connector.TransformMapConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * Map stream based on another with the values transformed.
+ *
+ * @param <K>  The key type of the stream.
+ * @param <V1> The input value type.
+ * @param <V2> The output value type.
+ */
+class TransformedValuesMapStream<K, V1, V2> extends AbstractMapStream<K, V2> {
+
+  private final MapSwimStream<K, V1> in;
+  private final BiFunction<K, V1, ? extends V2> f;
+  private final boolean memoizeValues;
+
+  /**
+   * @param input       The source stream.
+   * @param context     The instantiation context.
+   * @param mapFunction The transformation.
+   * @param memoize Memoize the computed values.
+   * @param form        The form of the type of the output values.
+   */
+  TransformedValuesMapStream(final MapSwimStream<K, V1> input,
+                             final BindingContext context, final BiFunction<K, V1, ? extends V2> mapFunction,
+                             final boolean memoize,
+                             final Form<V2> form) {
+    super(input.keyForm(), form, context);
+    in = input;
+    f = mapFunction;
+    memoizeValues = memoize;
+  }
+
+  /**
+   * @param input       The source stream.
+   * @param context     The instantiation context.
+   * @param mapFunction The transformation.
+   * @param form        The form of the type of the output values.
+   * @param ts          Timestamp assignment for the values.
+   */
+  TransformedValuesMapStream(final MapSwimStream<K, V1> input,
+                             final BindingContext context, final BiFunction<K, V1, ? extends V2> mapFunction,
+                             final boolean memoize,
+                             final Form<V2> form, final ToLongFunction<V2> ts) {
+    super(input.keyForm(), form, context);
+    in = input;
+    f = mapFunction;
+    memoizeValues = memoize;
+  }
+
+  @Override
+  public MapSwimStream<K, V2> updateTimestamps(final ToLongFunction<V2> datation) {
+    return new TransformedValuesMapStream<>(in, getContext(), f, memoizeValues, valueForm(), datation);
+  }
+
+  @Override
+  public MapJunction<K, V2> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V1> source = context.createFor(in);
+    final TransformMapConduit<K, V1, V2> conduit = new TransformMapConduit<>(f);
+    source.subscribe(conduit);
+    if (memoizeValues) {
+      final MapConduit<K, K, V2, V2> memoizer = new MapMemoizingConduit<>();
+      conduit.subscribe(memoizer);
+      return memoizer;
+    } else {
+      return conduit;
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedWindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/TransformedWindowedStream.java
@@ -1,0 +1,132 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.windows.DefaultPaneManager;
+import swim.dataflow.graph.impl.windows.NoOpEvictor;
+import swim.dataflow.graph.impl.windows.PaneEvictor;
+import swim.dataflow.graph.impl.windows.SequencePaneUpdater;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.impl.windows.WindowConduit;
+import swim.dataflow.graph.impl.windows.WindowFunctionEvaluator;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.WindowFunction;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.structure.Form;
+
+/**
+ * Stream formed by applying a function across the windows of a windowed stream.
+ *
+ * @param <T> The type of the values in the windows.
+ * @param <W> The type of the windows.
+ * @param <U> The type of the outputs.
+ */
+class TransformedWindowedStream<T, W, S extends WindowState<W, S>, U> extends AbstractSwimStream<U> {
+
+  private final SwimStream<T> in;
+  private final WindowSpec<T, W, S> spec;
+  private final WindowFunction<T, W, U> winFun;
+  private final Sampling sampling;
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param fun           The window function.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   */
+  TransformedWindowedStream(final SwimStream<T> input,
+                            final WindowSpec<T, W, S> windowSpec,
+                            final BindingContext context,
+                            final WindowFunction<T, W, U> fun,
+                            final Form<U> form,
+                            final Sampling samplingStrat) {
+    super(form, context);
+    in = input;
+    spec = windowSpec;
+    winFun = fun;
+    sampling = samplingStrat;
+  }
+
+  /**
+   * @param input         The source stream.
+   * @param windowSpec    The specification of the windows.
+   * @param context       The instantiation context.
+   * @param fun           The window function.
+   * @param form          The form of the type of the outputs.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param ts            Timestamp assigner for the stream.
+   */
+  TransformedWindowedStream(final SwimStream<T> input,
+                            final WindowSpec<T, W, S> windowSpec,
+                            final BindingContext context,
+                            final WindowFunction<T, W, U> fun,
+                            final Form<U> form,
+                            final Sampling samplingStrat,
+                            final ToLongFunction<U> ts) {
+    super(form, context, ts);
+    in = input;
+    spec = windowSpec;
+    winFun = fun;
+    sampling = samplingStrat;
+  }
+
+
+  @Override
+  public SwimStream<U> updateTimestamps(final ToLongFunction<U> datation) {
+    return new TransformedWindowedStream<>(in, spec, getContext(), winFun, form(), sampling, datation);
+  }
+
+  @Override
+  public Junction<U> instantiate(final SwimStreamContext.InitContext context) {
+    final SequencePaneUpdater<T, W> updater = new SequencePaneUpdater<>();
+    final PaneEvictor<T, W, FingerTrieSeq<WithTimestamp<T>>> evictor = spec.getEvictionStrategy().match(
+        none -> NoOpEvictor.instance(),
+        EvictionUtil::createEvictor
+    );
+    final WindowFunctionEvaluator<T, W, U> evaluator = new WindowFunctionEvaluator<>(winFun);
+
+    final WindowAccumulators<W, FingerTrieSeq<WithTimestamp<T>>> accumulators = WindowStates.forSequencesState(
+        spec.isTransient(), StateTags.stateTag(id()), context.getPersistenceProvider(), spec.getWindowForm(), in.form());
+    final DefaultPaneManager<T, W, S, FingerTrieSeq<WithTimestamp<T>>, U> paneManager =
+        new DefaultPaneManager<>(accumulators,
+            spec.getAssigner(), spec.getTrigger(), updater, evictor, evaluator);
+
+    final ToLongFunction<T> ts = in.getTimestamps();
+    final TimestampAssigner<T> timestamps =
+        ts == null ? TimestampAssigner.fromClock() : TimestampAssigner.fromData(ts);
+
+
+    final WindowConduit<T, W, U> conduit = new WindowConduit<>(
+        context.getSchedule(), paneManager, timestamps);
+
+    final Junction<T> source = StreamDecoupling.sampleStream(id(), context, context.createFor(in), sampling, StreamInterpretation.DISCRETE);
+
+    source.subscribe(conduit);
+    return conduit;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/UnionStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/UnionStream.java
@@ -1,0 +1,82 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.UnionJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.structure.Form;
+
+/**
+ * Stream formed by the union of two or more other streams.
+ *
+ * @param <T> The type of the values.
+ */
+class UnionStream<T> extends AbstractSwimStream<T> {
+
+  private final FingerTrieSeq<SwimStream<? extends T>> parts;
+
+  /**
+   * @param form    The form of the type of the values.
+   * @param partSeq The component streams.
+   * @param context The instantiation context.
+   */
+  UnionStream(final Form<T> form, final FingerTrieSeq<SwimStream<? extends T>> partSeq, final BindingContext context) {
+    super(form, context);
+    parts = partSeq;
+  }
+
+  UnionStream(final Form<T> form, final FingerTrieSeq<SwimStream<? extends T>> partSeq,
+              final BindingContext context,
+              final ToLongFunction<T> ts) {
+    super(form, context, ts);
+    parts = partSeq;
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new UnionStream<>(form(), parts, getContext(), datation);
+  }
+
+  @Override
+  public SwimStream<T> union(final Iterable<SwimStream<? extends T>> others) {
+    FingerTrieSeq<SwimStream<? extends T>> newParts = parts;
+    for (final SwimStream<? extends T> other : others) {
+      newParts = newParts.appended(other);
+    }
+    return new UnionStream<>(form(), newParts, getContext());
+  }
+
+  @Override
+  public SwimStream<T> union(final SwimStream<? extends T> other) {
+    return new UnionStream<>(form(), parts.appended(other), getContext());
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final UnionJunction<T> junction = new UnionJunction<>(parts.size());
+    int i = 0;
+    for (final SwimStream<? extends T> stream : parts) {
+      final Junction<? extends T> source = context.createFor(stream);
+      source.subscribe(junction.getInput(i));
+      ++i;
+    }
+    return junction;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/VariableDelayedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/VariableDelayedMapStream.java
@@ -1,0 +1,117 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.VariableDelayMapJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.structure.Form;
+
+/**
+ * Stream that, interpreting its input as a sequence of discrete samples, will return the value received a variable
+ * number of samples back from the most recent sample, for each key.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+final class VariableDelayedMapStream<K, V> extends AbstractMapStream<K, V> {
+  private final MapSwimStream<K, V> in;
+  private final SwimStream<Integer> delays;
+  private final int init;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The source stream.
+   * @param context     The instantiation context.
+   * @param delays      Stream of number of samples of delay.
+   * @param init        The initial number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   */
+  VariableDelayedMapStream(final MapSwimStream<K, V> in,
+                           final BindingContext context,
+                           final SwimStream<Integer> delays,
+                           final int init,
+                           final boolean isTransient) {
+    super(in.keyForm(), in.valueForm(), context);
+    validate(init);
+    this.in = in;
+    this.delays = delays;
+    this.init = init;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param in          The source stream.
+   * @param context     The instantiation context.
+   * @param delays      Stream of number of samples of delay.
+   * @param init        The initial number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   * @param ts          Assigns timestamps to the values.
+   */
+  VariableDelayedMapStream(final MapSwimStream<K, V> in,
+                           final BindingContext context,
+                           final SwimStream<Integer> delays,
+                           final int init,
+                           final boolean isTransient,
+                           final ToLongFunction<V> ts) {
+    super(in.keyForm(), in.valueForm(), context, ts);
+    validate(init);
+    this.in = in;
+    this.delays = delays;
+    this.init = init;
+    this.isTransient = isTransient;
+  }
+
+  private static void validate(final int steps) {
+    Require.that(steps > 1, "Delay must be at least 1");
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new VariableDelayedMapStream<>(in, getContext(), delays, init, isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final MapJunction<K, V> source = context.createFor(in);
+    final Junction<Integer> control = context.createFor(delays);
+    final VariableDelayMapJunction<K, V> junction;
+    if (isTransient) {
+      junction = new VariableDelayMapJunction<>(init);
+    } else {
+      final PersistenceProvider perProvider = context.getPersistenceProvider();
+      final Form<K> kForm = keyForm();
+      final Form<V> vForm = valueForm();
+      final Function<K, ListPersister<V>> bufferPeristers = k -> perProvider.forList(
+          StateTags.keyedStateTag(id(), kForm.mold(k).toValue()), vForm);
+      final SetPersister<K> keysPersister = perProvider.forSet(StateTags.stateTag(id()), kForm);
+      junction = new VariableDelayMapJunction<>(bufferPeristers, keysPersister,
+          perProvider.forValue(StateTags.modeTag(id()), Form.forInteger(), init));
+    }
+    source.subscribe(junction.first());
+    control.subscribe(junction.second());
+    return junction;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/VariableDelayedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/VariableDelayedStream.java
@@ -1,0 +1,112 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.VariableDelayJunction;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+
+/**
+ * Stream that, interpreting its input as a sequence of discrete samples, will return the value received a variable
+ * number of samples back from the most recent sample.
+ *
+ * @param <T> The type of the values.
+ */
+class VariableDelayedStream<T> extends AbstractSwimStream<T> {
+
+  private final SwimStream<T> in;
+  private final SwimStream<Integer> delays;
+  private final int init;
+  private final boolean isTransient;
+
+  /**
+   * @param in          The source stream.
+   * @param context     The instantiation context.
+   * @param delays      Stream of number of samples of delay.
+   * @param init        The initial number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   */
+  VariableDelayedStream(final SwimStream<T> in,
+                        final BindingContext context,
+                        final SwimStream<Integer> delays,
+                        final int init,
+                        final boolean isTransient) {
+    super(in.form(), context);
+    validate(init);
+    this.in = in;
+    this.delays = delays;
+    this.init = init;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param in          The source stream.
+   * @param context     The instantiation context.
+   * @param delays      Stream of number of samples of delay.
+   * @param init        The initial number of samples of delay.
+   * @param isTransient Whether to store the buffer of samples persistently.
+   * @param ts          Assigns timestamps to the values.
+   */
+  VariableDelayedStream(final SwimStream<T> in,
+                        final BindingContext context,
+                        final SwimStream<Integer> delays,
+                        final int init,
+                        final boolean isTransient,
+                        final ToLongFunction<T> ts) {
+    super(in.form(), context, ts);
+    validate(init);
+    this.in = in;
+    this.delays = delays;
+    this.init = init;
+    this.isTransient = isTransient;
+  }
+
+  private static void validate(final int steps) {
+    Require.that(steps > 1, "Delay must be at least 1");
+  }
+
+  @Override
+  public SwimStream<T> updateTimestamps(final ToLongFunction<T> datation) {
+    return new VariableDelayedStream<>(in, getContext(), delays, init, isTransient, datation);
+  }
+
+  @Override
+  public Junction<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<T> source = context.createFor(in);
+    final Junction<Integer> control = context.createFor(delays);
+    final VariableDelayJunction<T> junction;
+    if (isTransient) {
+      junction = new VariableDelayJunction<>(init);
+    } else {
+      final ListPersister<T> listPersister = context.getPersistenceProvider()
+          .forList(StateTags.stateTag(id()), form());
+      final ValuePersister<Integer> delayPersister = context.getPersistenceProvider().forValue(StateTags.modeTag(id()),
+          Form.forInteger().unit(init));
+
+      junction = new VariableDelayJunction<>(listPersister, delayPersister);
+    }
+
+    source.subscribe(junction.first());
+    control.subscribe(junction.second());
+    return junction;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowJoinFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowJoinFunction.java
@@ -1,0 +1,108 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import swim.dataflow.graph.Either;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.windows.WindowFunction;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.reducing;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * Joins two streams together across a shared windowing strategy according to a keying function for both types.
+ *
+ * @param <T1> The type of the left hand values.
+ * @param <T2> The type of the right hand values.
+ * @param <K>  The type of the keys.
+ * @param <U>  The type of the combination of the values.
+ * @param <W>  The type of the windows.
+ */
+class WindowJoinFunction<T1, T2, K, U, W> implements WindowFunction<Either<T1, T2>, W, List<Pair<K, U>>> {
+
+  private final Function<T1, K> firstToKey;
+  private final Function<T2, K> secondToKey;
+  private final BiFunction<T1, T2, U> combine;
+
+  /**
+   * @param firstKeys  Assigns keys to the first type.
+   * @param secondKeys Assigns keys to the second type.
+   * @param combineFun Combines values of both types.
+   */
+  WindowJoinFunction(final Function<T1, K> firstKeys,
+                     final Function<T2, K> secondKeys,
+                     final BiFunction<T1, T2, U> combineFun) {
+    firstToKey = firstKeys;
+    secondToKey = secondKeys;
+    combine = combineFun;
+  }
+
+  @Override
+  public List<Pair<K, U>> apply(final W window, final Iterable<Either<T1, T2>> contents) {
+    final Function<Either<T1, T2>, K> toKey = either -> either.match(firstToKey, secondToKey);
+
+    final Map<K, Acc<T1, T2>> map = stream(contents.spliterator(), false)
+            .collect(groupingBy(toKey, reducing(new Acc<>(null, null),
+                    WindowJoinFunction::from, Acc::add)));
+
+    return map.entrySet().stream()
+            .flatMap(this::complete)
+            .collect(toList());
+  }
+
+  private static <S, T> Acc<S, T> from(final Either<S, T> either) {
+    return either.match(l -> new Acc<>(l, null), r -> new Acc<>(null, r));
+  }
+
+  private Stream<Pair<K, U>> complete(final Map.Entry<K, Acc<T1, T2>> entry) {
+    final Acc<T1, T2> acc = entry.getValue();
+    if (acc.left != null && acc.right != null) {
+      return Stream.of(new Pair<>(entry.getKey(), combine.apply(acc.left, acc.right)));
+    } else {
+      return Stream.empty();
+    }
+  }
+
+  /**
+   * Accumulation of values for a key.
+   *
+   * @param <S> The left hand type.
+   * @param <T> The right hand type.
+   */
+  private static final class Acc<S, T> {
+    private final S left;
+    private final T right;
+
+    Acc(final S leftVal, final T rightVal) {
+      left = leftVal;
+      right = rightVal;
+    }
+
+    Acc<S, T> add(final Acc<S, T> other) {
+      final S l = left != null ? left : other.left;
+      final T r = right != null ? right : other.right;
+      return new Acc<>(l, r);
+    }
+
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowStates.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowStates.java
@@ -1,0 +1,144 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import swim.collections.BTreeMap;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.impl.windows.MapWindowAccumulators;
+import swim.dataflow.graph.impl.windows.PersisterAccumulators;
+import swim.dataflow.graph.impl.windows.WindowAccumulators;
+import swim.dataflow.graph.persistence.BTreeMapForm;
+import swim.dataflow.graph.persistence.FingerTrieSeqForm;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.structure.Form;
+import swim.structure.Value;
+
+/**
+ * Factories for {@link WindowAccumulators}s to hold the current state of a windowed conduit.
+ */
+final class WindowStates {
+
+  private WindowStates() {
+  }
+
+  /**
+   * Create a {@link Form} for a {@link FingerTrieSeq} of elements.
+   * @param elementForm The form of the elements.
+   * @param <T> The type of the elements.
+   * @return The {@link Form} of the sequence.
+   */
+  static <T> Form<FingerTrieSeq<WithTimestamp<T>>> sequenceForm(final Form<T> elementForm) {
+    final Form<WithTimestamp<T>> withTsForm = WithTimestamp.form(elementForm);
+    return new FingerTrieSeqForm<>(withTsForm);
+  }
+
+  /**
+   * Create a {@link Form} for a {@link BTreeMap}.
+   * @param keyForm The form of the map key type.
+   * @param valForm The form of the map value type.
+   * @param <K> The type of the keys.
+   * @param <V> The type of the values.
+   * @param <U> The aggregation type.
+   * @return The form of the map.
+   */
+  static <K, V, U> Form<BTreeMap<K, V, U>> mapForm(final Form<K> keyForm, final Form<V> valForm) {
+    return new BTreeMapForm<>(keyForm, valForm);
+  }
+
+  /**
+   * Create an accumulator for a non-collection type.
+   * @param isTransient Whether the state is transient.
+   * @param key The unique key to identify the state store.
+   * @param persistence Context for creating state stores.
+   * @param windowForm The form of the windows.
+   * @param stateForm The form of the state values.
+   * @param <W> The type of the windows.
+   * @param <U> The type of the state values.
+   * @return The accumulators.
+   */
+  static <W, U> WindowAccumulators<W, U> forSimpleState(final boolean isTransient,
+                                                        final Value key,
+                                                        final PersistenceProvider persistence,
+                                                        final Form<W> windowForm,
+                                                        final Form<U> stateForm) {
+    if (isTransient) {
+      return new MapWindowAccumulators<>();
+    } else {
+      final MapPersister<W, U> persister = persistence.forMap(key, windowForm, stateForm);
+      return new PersisterAccumulators<>(persister);
+    }
+  }
+
+  /**
+   * Create an accumulator for a map type.
+   * @param isTransient Whether the state is transient.
+   * @param key The unique key to identify the state store.
+   * @param persistence Context for creating state stores.
+   * @param windowForm The form of the windows.@param windowForm
+   * @param criterionForm The form of the eviction criterion.
+   * @param form The form of the map values.
+   * @param <U> The aggregation type.
+   * @param <W> The window type.
+   * @param <T> The type of the state values.
+   * @param <K> The type of the eviction criteria.
+   * @return The accumulators.
+   */
+  static <U, W, T, K extends Comparable<K>> WindowAccumulators<W, BTreeMap<K, T, U>> forMapState(
+      final boolean isTransient,
+      final Value key,
+      final PersistenceProvider persistence,
+      final Form<W> windowForm,
+      final Form<K> criterionForm,
+      final Form<T> form) {
+    if (isTransient) {
+      return new MapWindowAccumulators<>();
+    } else {
+      final Form<BTreeMap<K, T, U>> stateForm = mapForm(criterionForm, form);
+      final MapPersister<W, BTreeMap<K, T, U>> persister = persistence.forMap(
+          key, windowForm, stateForm);
+      return new PersisterAccumulators<>(persister);
+    }
+  }
+
+  /**
+   * Create an accumulator for a sequence type.
+   * @param isTransient Whether the state is transient.
+   * @param key The unique key to identify the state store.
+   * @param persistence Context for creating state stores.
+   * @param windowForm The form of the windows.@param windowForm
+   * @param elementForm The form of the state values.
+   * @param <W> The window type.
+   * @param <T> The type of the state values.
+   * @return The accumulators.
+   */
+  static <W, T> WindowAccumulators<W, FingerTrieSeq<WithTimestamp<T>>> forSequencesState(
+      final boolean isTransient,
+      final Value key,
+      final PersistenceProvider persistence,
+      final Form<W> windowForm,
+      final Form<T> elementForm) {
+    if (isTransient) {
+      return new MapWindowAccumulators<>();
+    } else {
+      final Form<FingerTrieSeq<WithTimestamp<T>>> stateForm = WindowStates.sequenceForm(elementForm);
+      final MapPersister<W, FingerTrieSeq<WithTimestamp<T>>> persister = persistence.forMap(
+          key, windowForm, stateForm);
+      return new PersisterAccumulators<>(persister);
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowedStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WindowedStream.java
@@ -1,0 +1,148 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.WindowedSwimStream;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+import swim.dataflow.graph.windows.WindowFunction;
+import swim.dataflow.graph.windows.WindowSpec;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.eviction.NoEviction;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.dataflow.graph.windows.triggers.UnboundedTrigger;
+import swim.structure.Form;
+
+/**
+ * A stream split into a sequence of windows.
+ *
+ * @param <T> The type of the stream.
+ * @param <W> The type of the windows.
+ */
+class WindowedStream<T, W, S extends WindowState<W, S>> implements WindowedSwimStream<T, W> {
+
+  private final Form<W> winForm;
+  private final SwimStream<T> underlying;
+  private final TemporalWindowAssigner<T, W, S> assigner;
+  private final Trigger<T, W> trigger;
+  private final EvictionStrategy<T, W> evictionStrategy;
+  private final Sampling sampling;
+  private final BindingContext context;
+  private final boolean isTransient;
+
+  /**
+   * @param stream        The source stream.
+   * @param con           The instantiation context.
+   * @param form          The form of the type of the windows.
+   * @param winAssigner   Assigns values to windows.
+   * @param winTrigger    Determines when windows close.
+   * @param samplingStrat The sampling strategy for the link.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  WindowedStream(final SwimStream<T> stream,
+                 final BindingContext con,
+                 final Form<W> form,
+                 final TemporalWindowAssigner<T, W, S> winAssigner,
+                 final Trigger<T, W> winTrigger,
+                 final EvictionStrategy<T, W> eviction,
+                 final Sampling samplingStrat,
+                 final boolean isTransient) {
+    winForm = form;
+    underlying = stream;
+    assigner = winAssigner;
+    trigger = winTrigger;
+    evictionStrategy = eviction;
+    sampling = samplingStrat;
+    context = con;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public Form<T> form() {
+    return underlying.form();
+  }
+
+  @Override
+  public Form<W> windowForm() {
+    return winForm;
+  }
+
+  @Override
+  public <U> SwimStream<U> mapWindow(final WindowFunction<T, W, U> winFun, final Form<U> form) {
+    return new TransformedWindowedStream<>(underlying, createSpec(), context, winFun, form, sampling);
+  }
+
+  private WindowSpec<T, W, S> createSpec() {
+    return new WindowSpec<>(
+        assigner,
+        trigger == null ? new UnboundedTrigger<>() : trigger,
+        evictionStrategy == null ? NoEviction.instance() : evictionStrategy,
+        winForm,
+        isTransient
+    );
+  }
+
+  @Override
+  public <U> SwimStream<U> fold(final U seed, final WindowFoldFunction<T, W, U> winFun, final Form<U> form) {
+    return new FoldedWindowedStream<>(underlying, createSpec(), context, w -> seed, winFun,
+        form, sampling);
+  }
+
+  @Override
+  public <U> SwimStream<U> fold(final U seed, final WindowFoldFunction<T, W, U> winFun,
+                                final WindowBinOp<U, W> combiner, final Form<U> form) {
+    return new FoldedWindowedStream<>(underlying, createSpec(), context, w -> seed, winFun,
+        combiner, form, sampling);
+  }
+
+  @Override
+  public <U> SwimStream<U> foldBy(final Function<W, U> seed, final WindowFoldFunction<T, W, U> winFun, final Form<U> form) {
+    return new FoldedWindowedStream<>(underlying, createSpec(), context, seed, winFun, form, sampling);
+  }
+
+  @Override
+  public <U> SwimStream<U> foldWithCombiner(final Function<W, U> seed, final WindowFoldFunction<T, W, U> winFun, final WindowBinOp<U, W> combiner, final Form<U> form) {
+    return new FoldedWindowedStream<>(underlying, createSpec(), context, seed, winFun, combiner,
+        form, sampling);
+  }
+
+  @Override
+  public SwimStream<T> reduce(final WindowBinOp<T, W> op) {
+    return new ReducedWindowedStream<>(underlying, createSpec(), context, op, sampling);
+  }
+
+  @Override
+  public WindowedSwimStream<T, W> withTrigger(final Trigger<T, W> trigger) {
+    return new WindowedStream<>(this.underlying, context, winForm, assigner, trigger,
+        evictionStrategy, sampling, isTransient);
+  }
+
+  @Override
+  public WindowedSwimStream<T, W> withEviction(final EvictionStrategy<T, W> strategy) {
+    return new WindowedStream<>(this.underlying, context, winForm, assigner, trigger, strategy, sampling, isTransient);
+  }
+
+  @Override
+  public WindowedSwimStream<T, W> setTransient(final boolean isTransient) {
+    return new WindowedStream<>(this.underlying, context, winForm, assigner, trigger,
+        evictionStrategy, sampling, isTransient);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WrappedMapStream.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/WrappedMapStream.java
@@ -1,0 +1,101 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.StatefulMapCollector;
+import swim.dataflow.connector.TransientMapCollector;
+import swim.dataflow.connector.ValueToMapConduit;
+import swim.dataflow.graph.BindingContext;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.structure.Form;
+
+/**
+ * Map stream generated from a standard stream.
+ *
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+class WrappedMapStream<K, V> extends AbstractMapStream<K, V> {
+
+  private final SwimStream<V> inner;
+  private final Function<V, K> keys;
+  private final boolean isTransient;
+
+  /**
+   * @param toWrap  The stream to wrap.
+   * @param context The instantiation context.
+   * @param keyFun  Assigns keys to values.
+   * @param kform   The form of the keys.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  WrappedMapStream(final SwimStream<V> toWrap,
+                   final BindingContext context,
+                   final Function<V, K> keyFun,
+                   final Form<K> kform,
+                   final boolean isTransient) {
+    super(kform, toWrap.form(), context);
+    inner = toWrap;
+    keys = keyFun;
+    this.isTransient = isTransient;
+  }
+
+  /**
+   * @param toWrap  The stream to wrap.
+   * @param context The instantiation context.
+   * @param keyFun  Assigns keys to values.
+   * @param kform   The form of the keys.
+   * @param ts      Timestamp assignment for the values.
+   * @param isTransient   Whether the state of this stream is stored persistently.
+   */
+  WrappedMapStream(final SwimStream<V> toWrap,
+                   final BindingContext context,
+                   final Function<V, K> keyFun,
+                   final Form<K> kform,
+                   final boolean isTransient,
+                   final ToLongFunction<V> ts) {
+    super(kform, toWrap.form(), context, ts);
+    inner = toWrap;
+    keys = keyFun;
+    this.isTransient = isTransient;
+  }
+
+  @Override
+  public MapSwimStream<K, V> updateTimestamps(final ToLongFunction<V> datation) {
+    return new WrappedMapStream<>(inner, getContext(), keys, keyForm(), isTransient, datation);
+  }
+
+  @Override
+  public MapJunction<K, V> instantiate(final SwimStreamContext.InitContext context) {
+    final Junction<V> source = context.createFor(inner);
+    final ValueToMapConduit<V, K, V> collector;
+    if (isTransient) {
+      collector = new TransientMapCollector<>(keys, x -> x);
+    } else {
+      final MapPersister<K, V> persister = context.getPersistenceProvider().forMap(
+          StateTags.stateTag(id()), keyForm(), valueForm());
+      collector = new StatefulMapCollector<>(keys, x -> x, persister);
+    }
+    source.subscribe(collector);
+    return collector;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionConduit.java
@@ -1,0 +1,96 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.partitions;
+
+import java.util.HashSet;
+import java.util.Set;
+import swim.dataflow.connector.AbstractMapJunction;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.connector.ValueToMapConduit;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.dataflow.graph.windows.PartitionState;
+import swim.structure.Form;
+
+public class PartitionConduit<T, P, S extends PartitionState<P, S>>
+    extends AbstractMapJunction<P, T> implements ValueToMapConduit<T, P, T> {
+
+  private final MapPersister<P, T> persister;
+  private final PartitionAssigner<T, P, S> partitions;
+  private S partitionState;
+
+  /**
+   * @param partitionStrat The partition assignment strategy.
+   * @param persister Persistent storage for the current state.
+   */
+  public PartitionConduit(final PartitionAssigner<T, P, S> partitionStrat,
+                          final MapPersister<P, T> persister) {
+    partitions = partitionStrat;
+    partitionState = partitionStrat.stateFactory().get();
+    this.persister = persister;
+  }
+
+  /**
+   * @param partitionStrat The partition assignment strategy.
+   * @param valForm        The form of the type of the values.
+   */
+  public PartitionConduit(final PartitionAssigner<T, P, S> partitionStrat,
+                          final Form<T> valForm) {
+    this(partitionStrat, new TrivialMapPersister<>(valForm));
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    final T val = value.get();
+    final PartitionAssigner.Assignment<P, S> assignment = partitions.partitionsFor(val, partitionState);
+    addToPartitions(val, assignment.partitions());
+    final HashSet<P> toRemove = new HashSet<>(partitionState.activePartitions());
+    toRemove.removeAll(assignment.updatedState().activePartitions());
+    flushPartitions(toRemove);
+    partitionState = assignment.updatedState();
+  }
+
+  /**
+   * Update the latest value for every partition assigned to a value.
+   *
+   * @param value      The value.
+   * @param partitions The assigned partitions.
+   */
+  private void addToPartitions(final T value, final Set<P> partitions) {
+    for (final P part : partitions) {
+      persister.put(part, value);
+    }
+    final Deferred<MapView<P, T>> mapView = Deferred.value(persister.get());
+    for (final P part : partitions) {
+      emit(part, Deferred.value(value), mapView);
+    }
+  }
+
+  /**
+   * A partition assigner is permitted to expire partitions. Remove all expired partitions from the map.
+   *
+   * @param partitions The set of expire partitions.
+   */
+  private void flushPartitions(final Set<P> partitions) {
+    for (final P part : partitions) {
+      if (persister.containsKey(part)) {
+        persister.remove(part);
+        emitRemoval(part, Deferred.value(persister.get()));
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionConduit.java
@@ -17,7 +17,6 @@ package swim.dataflow.graph.impl.partitions;
 import java.util.HashSet;
 import java.util.Set;
 import swim.dataflow.connector.AbstractMapJunction;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.MapView;
 import swim.dataflow.connector.ValueToMapConduit;
 import swim.dataflow.graph.persistence.MapPersister;
@@ -25,6 +24,7 @@ import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPers
 import swim.dataflow.graph.windows.PartitionAssigner;
 import swim.dataflow.graph.windows.PartitionState;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 public class PartitionConduit<T, P, S extends PartitionState<P, S>>
     extends AbstractMapJunction<P, T> implements ValueToMapConduit<T, P, T> {

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionSet.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/PartitionSet.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.partitions;
+
+import java.util.Set;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.windows.PartitionState;
+
+/**
+ * Simple partition state that keeps all partitions in a set.
+ * @param <P> The type of the partitions.
+ */
+public class PartitionSet<P> implements PartitionState<P, PartitionSet<P>> {
+
+  /**
+   * The partition set.
+   */
+  private final HashTrieSet<P> partitions;
+
+  public PartitionSet() {
+    this(HashTrieSet.empty());
+  }
+
+  private PartitionSet(final HashTrieSet<P> parts) {
+    partitions = parts;
+  }
+
+  @Override
+  public Set<P> activePartitions() {
+    return partitions;
+  }
+
+  @Override
+  public PartitionSet<P> removePartition(final P partititon) {
+    return new PartitionSet<>(partitions.removed(partititon));
+  }
+
+  @Override
+  public PartitionSet<P> addPartition(final P partition) {
+    return new PartitionSet<>(partitions.added(partition));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/SimplePartitionAssigner.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/partitions/SimplePartitionAssigner.java
@@ -1,0 +1,92 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.partitions;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.dataflow.graph.windows.PartitionState;
+
+/**
+ * Trivial partition assignment that adds new partitions to the state and never removes them.
+ * @param <T> The type of the values.
+ * @param <P> The type of the partitions.
+ * @param <S> The type of the partition state.
+ */
+public class SimplePartitionAssigner<T, P, S extends PartitionState<P, S>> implements PartitionAssigner<T, P, S> {
+
+  private final Function<T, Set<P>> partFun;
+
+  private final Supplier<S> fac;
+
+  /**
+   * @param parts Function to assign partitions to values.
+   * @param stateFac Factory to create the empty state.
+   */
+  public SimplePartitionAssigner(final Function<T, Set<P>> parts, final Supplier<S> stateFac) {
+    partFun = parts;
+    fac = stateFac;
+  }
+
+  @Override
+  public Supplier<S> stateFactory() {
+    return fac;
+  }
+
+  @Override
+  public Assignment<P, S> partitionsFor(final T data, final S active) {
+    final Set<P> parts = partFun.apply(data);
+    S newStateAcc = active;
+    for (final P part : parts) {
+      newStateAcc = newStateAcc.addPartition(part);
+    }
+    final S newState = newStateAcc;
+    return new Assignment<P, S>() {
+      @Override
+      public Set<P> partitions() {
+        return parts;
+      }
+
+      @Override
+      public S updatedState() {
+        return newState;
+      }
+    };
+  }
+
+  /**
+   * Create an assigner that assigns multiple partitions to each value and stores them in a simple set.
+   * @param f The assignment.
+   * @param <T> The type of the values.
+   * @param <P> The type of the partitions.
+   * @return The assigner.
+   */
+  public static <T, P> SimplePartitionAssigner<T, P, PartitionSet<P>> ofMulti(final Function<T, Set<P>> f) {
+    return new SimplePartitionAssigner<>(f, PartitionSet::new);
+  }
+
+  /**
+   * Create an assigner that assigns a single partition to each value and stores them in a simple set.
+   * @param f The assignment.
+   * @param <T> The type of the values.
+   * @param <P> The type of the partitions.
+   * @return The assigner.
+   */
+  public static <T, P> SimplePartitionAssigner<T, P, PartitionSet<P>> of(final Function<T, P> f) {
+    return new SimplePartitionAssigner<>(f.andThen(Collections::singleton), PartitionSet::new);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/DataTimeContext.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/DataTimeContext.java
@@ -1,0 +1,47 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Map;
+import swim.collections.BTreeMap;
+import swim.collections.FingerTrieSeq;
+
+/**
+ * A time context that uses the timestamp extracted from incoming data to trigger events.
+ */
+final class DataTimeContext implements InternalTimeContext {
+
+  private BTreeMap<Long, FingerTrieSeq<PaneManager.WindowCallback>, Object> callbacks = BTreeMap.empty();
+
+  @Override
+  public void scheduleAt(final long timestamp, final PaneManager.WindowCallback callback) {
+    final FingerTrieSeq<PaneManager.WindowCallback> existing = callbacks.getOrDefault(timestamp, FingerTrieSeq.empty());
+    callbacks = callbacks.updated(timestamp, existing.appended(callback));
+  }
+
+  @Override
+  public void setNow(final long nowTs) {
+    for (final Map.Entry<Long, FingerTrieSeq<PaneManager.WindowCallback>> entry : callbacks) {
+      if (entry.getKey() <= nowTs) {
+        callbacks = callbacks.removed(entry.getKey());
+        for (final PaneManager.WindowCallback cb : entry.getValue()) {
+          cb.runEvent(entry.getKey(), nowTs);
+        }
+      } else {
+        break;
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/DefaultPaneManager.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/DefaultPaneManager.java
@@ -1,0 +1,244 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.TreeSet;
+import swim.dataflow.graph.timestamps.TimestampContext;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.WindowState;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.dataflow.graph.windows.triggers.TriggerAction;
+
+/**
+ * Default implementation of {@link PaneManager} that delegates to a window assigner, trigger, pane updater, pane
+ * evictor and evaluator to provide the logic.
+ * @param <T> The type of the elements.
+ * @param <W> The type of the window.
+ * @param <WS> The type of the state containing the currently open windows.
+ * @param <S> The type of the state of a window pane.
+ * @param <U> The type of the result of evaluating a window pane.
+ */
+public final class DefaultPaneManager<T, W, WS extends WindowState<W, WS>, S, U>
+        implements PaneManager<T, W, U> {
+
+  private final TemporalWindowAssigner<T, W, WS> assigner;
+  private final Trigger<T, W> trigger;
+  private final PaneUpdater<T, W, S> updater;
+  private final PaneEvictor<T, W, S> evictor;
+  private final PaneEvaluator<S, W, U> evaluator;
+
+  private WS openWindows;
+
+  private boolean initialized = false;
+
+  //Window pane states for open windows.
+  private WindowAccumulators<W, S> windowAccumulators;
+
+  WindowAccumulators<W, S> getAccumulators() {
+    return windowAccumulators;
+  }
+
+  void setInternalState(final boolean isInitialized, final WS windows, final WindowAccumulators<W, S> acc) {
+    initialized = isInitialized;
+    openWindows = windows;
+    windowAccumulators = acc;
+  }
+
+  void setInternalState(final WS windows, final WindowAccumulators<W, S> acc) {
+    setInternalState(true, windows, acc);
+  }
+
+  private Listener<W, U> listener;
+
+  public DefaultPaneManager(final WindowAccumulators<W, S> accumulators,
+                            final TemporalWindowAssigner<T, W, WS> assigner,
+                            final Trigger<T, W> trigger,
+                            final PaneUpdater<T, W, S> updater,
+                            final PaneEvictor<T, W, S> evictor,
+                            final PaneEvaluator<S, W, U> evaluator) {
+    this.assigner = assigner;
+    this.trigger = trigger;
+    this.updater = updater;
+    this.evictor = evictor;
+    this.evaluator = evaluator;
+    openWindows = assigner.stateInitializer().apply(accumulators.windows());
+    windowAccumulators = accumulators;
+    listener = null;
+  }
+
+  @Override
+  public void setListener(final Listener<W, U> listener) {
+    this.listener = listener;
+  }
+
+  /**
+   * Used to present the current timestamp to the trigger.
+   */
+  private static final class TimeContext implements TimestampContext {
+
+    /**
+     * The current timestamp.
+     */
+    private final long current;
+
+    /**
+     * Contains the times of callbacks requested by the trigger.
+     */
+    private final TreeSet<Long> requested = new TreeSet<>();
+
+    private TimeContext(final long current) {
+      this.current = current;
+    }
+
+
+    @Override
+    public long currentTimestamp() {
+      return current;
+    }
+
+    public NavigableSet<Long> getRequests() {
+      return requested;
+    }
+
+    @Override
+    public void scheduleAt(final long ts) {
+      if (ts > current) {
+        requested.add(ts);
+      }
+    }
+  }
+
+  @Override
+  public void update(final T data, final long timestamp, final PaneManager.TimeContext timeContext) {
+
+    //If we have yet to initialize, call the restore handler for each window in the store.
+    if (!initialized) {
+      final TimeContext initContext = new TimeContext(timestamp);
+      for (final W window : openWindows.openWindows()) {
+        final Optional<S> windowState = windowAccumulators.getForWindow(window);
+        if (windowState.isPresent()) {
+          final S cleanedState = evictor.evict(windowState.get(), window, data, timestamp);
+          final TriggerAction action = trigger.onRestore(window, initContext);
+          handleAction(timeContext, initContext, window, cleanedState, action);
+        }
+      }
+      initialized = true;
+    }
+    final TimeContext tContext = new TimeContext(timestamp);
+    //Get the windows to which the value will contribute.
+    final TemporalWindowAssigner.Assignment<W, WS> assignment = assigner.windowsFor(
+            data, timestamp, openWindows);
+    openWindows = assignment.updatedState();
+
+    for (final W window : assignment.windows()) {
+      //Either get the current pane state or create a new one.
+      final S windowState = windowAccumulators.getForWindow(window)
+          .orElseGet(() -> updater.createPane(window));
+
+      //Add the contribution for the current value then evict expired data from the state.
+      final S updatedState = updater.addContribution(windowState, window, data, timestamp);
+      final S cleanedState = evictor.evict(updatedState, window, data, timestamp);
+
+      windowAccumulators.updateWindow(window, cleanedState);
+
+      //Determine what should happen with the window.
+
+      final TriggerAction action = trigger.onNewValue(data, window, tContext);
+
+      handleAction(timeContext, tContext, window, cleanedState, action);
+
+    }
+  }
+
+  @Override
+  public void close() {
+    windowAccumulators.close();
+  }
+
+  private void handleAction(final PaneManager.TimeContext timeContext,
+                            final TimeContext tContext,
+                            final W window,
+                            final S state, final TriggerAction action) {
+    switch (action) {
+      case TRIGGER:
+        triggerWindow(window, state);
+        addRequested(timeContext, window, tContext.getRequests());
+        break;
+      case TRIGGER_AND_PURGE:
+        triggerWindow(window, state);
+        purgeWindow(window);
+        break;
+      case PURGE:
+        purgeWindow(window);
+        break;
+      default:
+        addRequested(timeContext, window, tContext.getRequests());
+    }
+  }
+
+  /**
+   * Purging a window removes it from the state entirely.
+   * @param window The window.
+   */
+  private void purgeWindow(final W window) {
+    windowAccumulators.removeWindow(window);
+    openWindows = openWindows.removeWindow(window);
+  }
+
+  /**
+   * Adds requested callbacks for a window.
+   * @param window The window.
+   * @param requests The times of the requested callbacks.
+   */
+  private void addRequested(final PaneManager.TimeContext timeContext, final W window, final NavigableSet<Long> requests) {
+    for (final Long t : requests) {
+      timeContext.scheduleAt(t, (treq, tact) -> {
+        final TimeContext tContext = new TimeContext(tact);
+
+        //Execute the callback.
+        final TriggerAction action = trigger.onTimer(window, tContext);
+        switch (action) {
+          case TRIGGER:
+            windowAccumulators.getForWindow(window).ifPresent(s -> triggerWindow(window, s));
+            addRequested(timeContext, window, tContext.getRequests());
+            break;
+          case TRIGGER_AND_PURGE:
+            windowAccumulators.getForWindow(window).ifPresent(s -> triggerWindow(window, s));
+            purgeWindow(window);
+            break;
+          case PURGE:
+            purgeWindow(window);
+            break;
+          default:
+            addRequested(timeContext, window, tContext.getRequests());
+        }
+      });
+    }
+  }
+
+  /**
+   * Evaluate the state of the pane of a window.
+   * @param window The window.
+   * @param state The state of the pane.
+   */
+  private void triggerWindow(final W window, final S state) {
+    if (listener != null) {
+      listener.accept(window, evaluator.evaluate(window, state));
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/FoldPaneUpdater.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/FoldPaneUpdater.java
@@ -1,0 +1,50 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Function;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+
+/**
+ * Window pane update that maintains the state of a fold operation only and not the individual values. Hence it cannot
+ * be used in combination with a non-trivial eviction strategy.
+ * @param <T> The type of the values.
+ * @param <W> The type of the widows.
+ * @param <U> The state of the fold operation.
+ */
+public class FoldPaneUpdater<T, W, U> implements PaneUpdater<T, W, U> {
+
+  private final Function<W, U> seed;
+  private final WindowFoldFunction<T, W, U> update;
+
+  /**
+   * @param seedVal Initializes the state based on the window.
+   * @param updFun Updates the state from the latest value and the window.
+   */
+  public FoldPaneUpdater(final Function<W, U> seedVal, final WindowFoldFunction<T, W, U> updFun) {
+    seed = seedVal;
+    update = updFun;
+  }
+
+  @Override
+  public U createPane(final W window) {
+    return seed.apply(window);
+  }
+
+  @Override
+  public U addContribution(final U state, final W window, final T data, final long timestamp) {
+    return update.apply(window, state, data);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/FoldingEvaluator.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/FoldingEvaluator.java
@@ -1,0 +1,52 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Function;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+
+/**
+ * Applies a fold operation across a window pane sequence state. This is required for folded windows that require
+ * eviction but do not have any intermediate value combiner.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <U> The result type.
+ */
+public class FoldingEvaluator<T, W, U> implements PaneEvaluator<FingerTrieSeq<WithTimestamp<T>>, W, U> {
+
+  private final Function<W, U> seed;
+  private final WindowFoldFunction<T, W, U> update;
+
+  /**
+   * @param seedValues The seed value for the fold.
+   * @param folder     The fold operation.
+   */
+  public FoldingEvaluator(final Function<W, U> seedValues, final WindowFoldFunction<T, W, U> folder) {
+    seed = seedValues;
+    update = folder;
+  }
+
+  @Override
+  public U evaluate(final W window, final FingerTrieSeq<WithTimestamp<T>> state) {
+    U result = seed.apply(window);
+    for (final WithTimestamp<T> entry : state) {
+      result = update.apply(window, result, entry.getData());
+    }
+    return result;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/InternalTimeContext.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/InternalTimeContext.java
@@ -1,0 +1,29 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Extensions of {@link swim.dataflow.graph.impl.windows.PaneManager.TimeContext} for internal use.
+ */
+interface InternalTimeContext extends PaneManager.TimeContext {
+
+  /**
+   * Set the current timestamp.
+   *
+   * @param nowTs The current time.
+   */
+  void setNow(long nowTs);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/KeyedWindowConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/KeyedWindowConduit.java
@@ -1,0 +1,139 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
+import swim.collections.HashTrieMap;
+import swim.concurrent.Schedule;
+import swim.concurrent.TimerFunction;
+import swim.dataflow.connector.AbstractMapJunction;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.MapConduit;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+
+public class KeyedWindowConduit<K, V, W, U> extends AbstractMapJunction<K, U> implements MapConduit<K, K, V, U> {
+
+  private final SetPersister<K> keyPersister;
+  private final Function<K, PaneManager<V, W, U>> paneFactory;
+  private final ToLongFunction<V> timestamps;
+  private final InternalTimeContext timeContext;
+  private HashTrieMap<K, PaneManager<V, W, U>> paneManagers = HashTrieMap.empty();
+  private HashTrieMap<K, U> latest = HashTrieMap.empty();
+
+  /**
+   * @param schedule Schedule for timer callbacks.
+   * @param keyPersister Persistence for the active keys.
+   * @param paneFactory The window pane manager factory.
+   * @param ts           Assigns timestamps to values.
+   */
+  public KeyedWindowConduit(final Schedule schedule,
+                            final SetPersister<K> keyPersister,
+                            final Function<K, PaneManager<V, W, U>> paneFactory,
+                            final TimestampAssigner<V> ts) {
+    this.paneFactory = paneFactory;
+    this.keyPersister = keyPersister;
+    timeContext = ts.match(fromData -> new DataTimeContext(), fromClock -> new ScheduleTimeContext(schedule, fromClock));
+    timestamps = ts.match(fromData -> fromData, fromClock -> ts);
+    for (final K key : keyPersister.get()) {
+      final PaneManager<V, W, U> manager = getNewManager(key);
+      paneManagers = paneManagers.updated(key, manager);
+    }
+  }
+
+  /**
+   * @param schedule Schedule for timer callbacks.
+   * @param paneFactory The window pane manager factory.
+   * @param ts           Assigns timestamps to values.
+   */
+  public KeyedWindowConduit(final Schedule schedule,
+                            final Function<K, PaneManager<V, W, U>> paneFactory,
+                            final TimestampAssigner<V> ts) {
+    this(schedule, new TrivialSetPersisiter<>(), paneFactory, ts);
+  }
+
+  @Override
+  public void notifyChange(final K key, final Deferred<V> defVal, final Deferred<MapView<K, V>> map) {
+    final V value = defVal.get();
+    PaneManager<V, W, U> manager = paneManagers.get(key);
+    if (manager == null) {
+      manager = getNewManager(key);
+      paneManagers = paneManagers.updated(key, manager);
+    }
+    final long timestamp = timestamps.applyAsLong(value);
+    timeContext.setNow(timestamp);
+    manager.update(value, timestamp, timeContext);
+  }
+
+  private PaneManager<V, W, U> getNewManager(final K key) {
+    final PaneManager<V, W, U> manager;
+    manager = paneFactory.apply(key);
+    manager.setListener((w, u) -> {
+      latest = latest.updated(key, u);
+      emit(key, Deferred.value(u), Deferred.value(MapView.wrap(latest)));
+    });
+    keyPersister.add(key);
+    return manager;
+  }
+
+  @Override
+  public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+    final PaneManager<V, W, U> manager = paneManagers.get(key);
+    if (manager != null) {
+      paneManagers = paneManagers.removed(key);
+      latest = latest.removed(key);
+      keyPersister.remove(key);
+      try {
+        manager.close();
+      } finally {
+        emitRemoval(key, Deferred.value(MapView.wrap(latest)));
+      }
+    }
+  }
+
+  /**
+   * Time context that uses a {@link Schedule} to trigger events, using clock time.
+   */
+  private final class ScheduleTimeContext implements InternalTimeContext {
+
+    private final Schedule schedule;
+    private long now = Long.MIN_VALUE;
+    private final LongSupplier clock;
+
+    private ScheduleTimeContext(final Schedule schedule, final LongSupplier clock) {
+      this.schedule = schedule;
+      this.clock = clock;
+    }
+
+    @Override
+    public void setNow(final long nowTs) {
+      now = nowTs;
+    }
+
+    @Override
+    public void scheduleAt(final long timestamp, final PaneManager.WindowCallback callback) {
+      final long offset = Math.max(0, timestamp - now);
+      final TimerFunction timerFun = () -> {
+        final long calledAt = clock.getAsLong();
+        callback.runEvent(timestamp, calledAt);
+      };
+      schedule.setTimer(offset, timerFun);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/KeyedWindowConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/KeyedWindowConduit.java
@@ -21,12 +21,12 @@ import swim.collections.HashTrieMap;
 import swim.concurrent.Schedule;
 import swim.concurrent.TimerFunction;
 import swim.dataflow.connector.AbstractMapJunction;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.MapConduit;
 import swim.dataflow.connector.MapView;
 import swim.dataflow.graph.persistence.SetPersister;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
 import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.util.Deferred;
 
 public class KeyedWindowConduit<K, V, W, U> extends AbstractMapJunction<K, U> implements MapConduit<K, K, V, U> {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/MapPaneUpdater.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/MapPaneUpdater.java
@@ -1,0 +1,51 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.collections.BTreeMap;
+import swim.dataflow.graph.windows.eviction.EvictionCriterionFunction;
+
+/**
+ * Window pane updater that stores the values keyed by their eviction criterion. Additionally allows an aggregation
+ * to be stored in the tree nodes of the map.
+ * @param <T> The type of the values.
+ * @param <W> The type of the window.
+ * @param <K> The type of the criterion.
+ * @param <U> The state type of the map.
+ */
+public class MapPaneUpdater<T, W, K, U> implements PaneUpdater<T, W, BTreeMap<K, T, U>> {
+
+  private final EvictionCriterionFunction<T, K> keyExtractor;
+
+  /**
+   *  @param keys Assigns the eviction criterion to the values.
+   */
+  public MapPaneUpdater(final EvictionCriterionFunction<T, K> keys) {
+    keyExtractor = keys;
+  }
+
+  @Override
+  public BTreeMap<K, T, U> createPane(final W window) {
+    return BTreeMap.empty();
+  }
+
+  @Override
+  public BTreeMap<K, T, U> addContribution(final BTreeMap<K, T, U> state,
+                                           final W window,
+                                           final T data,
+                                           final long timestamp) {
+    return state.updated(keyExtractor.apply(data, timestamp), data);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/MapWindowAccumulators.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/MapWindowAccumulators.java
@@ -1,0 +1,62 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Optional;
+import java.util.Set;
+import swim.collections.HashTrieMap;
+
+/**
+ * {@link WindowAccumulators} backed by a simple map.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the states.
+ */
+public class MapWindowAccumulators<W, S> implements WindowAccumulators<W, S> {
+
+  private HashTrieMap<W, S> accumulators;
+
+  public MapWindowAccumulators(final HashTrieMap<W, S> map) {
+    accumulators = map;
+  }
+
+  public MapWindowAccumulators() {
+    this(HashTrieMap.empty());
+  }
+
+  @Override
+  public Optional<S> getForWindow(final W window) {
+    return Optional.ofNullable(accumulators.get(window));
+  }
+
+  @Override
+  public void updateWindow(final W window, final S state) {
+    accumulators = accumulators.updated(window, state);
+  }
+
+  @Override
+  public void removeWindow(final W window) {
+    accumulators = accumulators.removed(window);
+  }
+
+  @Override
+  public Set<W> windows() {
+    return accumulators.keySet();
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/NoOpEvictor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/NoOpEvictor.java
@@ -1,0 +1,39 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Trivial window pane evictor that never evicts anything.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <S> The state type of the pane.
+ */
+public final class NoOpEvictor<T, W, S> implements PaneEvictor<T, W, S> {
+
+  private NoOpEvictor() {
+  }
+
+  @Override
+  public S evict(final S state, final W window, final T data, final long timestamp) {
+    return state;
+  }
+
+  private static final NoOpEvictor<Object, Object, Object> INSTANCE = new NoOpEvictor<>();
+
+  @SuppressWarnings("unchecked")
+  public static <T, W, S> NoOpEvictor<T, W, S> instance() {
+    return (NoOpEvictor<T, W, S>) INSTANCE;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneEvaluator.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneEvaluator.java
@@ -1,0 +1,55 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Evaluates the state of a window pane when the window fires.
+ * @param <S> The type of the state of the pane.
+ * @param <W> The type of the windows.
+ * @param <U> The output type.
+ */
+@FunctionalInterface
+public interface PaneEvaluator<S, W, U> {
+
+  /**
+   * Evaluate the current state of the pane.
+   * @param window The window.
+   * @param state The state.
+   * @return The result of the evaluation.
+   */
+  U evaluate(W window, S state);
+
+  /**
+   * Get an identity evaluator.
+   * @param <T> The type of the state and the output.
+   * @param <W> The type of the window.
+   * @return The identity evaluator.
+   */
+  static <T, W> PaneEvaluator<T, W, T> identity() {
+    return new IdentityPaneEvaluator<>();
+  }
+}
+
+/**
+ * Returns the state as it is.
+ * @param <S> The state type.
+ * @param <W> The window type.
+ */
+final class IdentityPaneEvaluator<S, W> implements PaneEvaluator<S, W, S> {
+  @Override
+  public S evaluate(final W window, final S state) {
+    return state;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneEvictor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneEvictor.java
@@ -1,0 +1,35 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Implementation of an eviction strategy for a particular type of window pane state.
+ * @param <T> The type of the values in the window.
+ * @param <W> The type of the window.
+ * @param <S> The type of the state.
+ */
+@FunctionalInterface
+public interface PaneEvictor<T, W, S> {
+
+  /**
+   * Evict values from the window pane.
+   * @param state The window pane state.
+   * @param window The window.
+   * @param data The last element added to the window.
+   * @param timestamp The timestamp fo the last element added to the window.
+   * @return The new window pane state after the eviction.
+   */
+  S evict(S state, W window, T data, long timestamp);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneManager.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneManager.java
@@ -1,0 +1,58 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Manages the window panes for a stream.
+ * @param <T> The type of the values in the window.
+ * @param <W> The type of the window.
+ * @param <U> The result type when a window trigger fires.
+ */
+public interface PaneManager<T, W, U> {
+
+  void setListener(Listener<W, U> listener);
+
+  /**
+   * Update with the next value.
+   * @param data The next value.
+   * @param timestamp The timestamp of the next value.
+   * @param context Event scheduler.
+   */
+  void update(T data, long timestamp, TimeContext context);
+
+  @FunctionalInterface
+  interface Listener<W, U> {
+
+    void accept(W window, U value);
+
+  }
+
+  @FunctionalInterface
+  interface WindowCallback {
+
+    void runEvent(long requested, long actual);
+
+  }
+
+  interface TimeContext {
+
+    void scheduleAt(long timestamp, WindowCallback callback);
+
+  }
+
+  void close();
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneUpdater.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PaneUpdater.java
@@ -1,0 +1,41 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+/**
+ * Update the state of a window pane with the next value.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the window pane state.
+ */
+public interface PaneUpdater<T, W, S> {
+
+  /**
+   * Create an emptu state for a window pane.
+   * @param window The window.
+   * @return The state.
+   */
+  S createPane(W window);
+
+  /**
+   * Add a value to the state of a window pane.
+   * @param state The current state.
+   * @param window The window.
+   * @param data The value.
+   * @param timestamp The timestamp of the value.
+   * @return The new state of the window pane.
+   */
+  S addContribution(S state, W window, T data, long timestamp);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PersisterAccumulators.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/PersisterAccumulators.java
@@ -1,0 +1,58 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Optional;
+import java.util.Set;
+import swim.dataflow.graph.persistence.MapPersister;
+
+/**
+ * {@link WindowAccumulators} backed by a {@link MapPersister} state store.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the states.
+ */
+public class PersisterAccumulators<W, S> implements WindowAccumulators<W, S> {
+
+  private final MapPersister<W, S> persister;
+
+  public PersisterAccumulators(final MapPersister<W, S> persister) {
+    this.persister = persister;
+  }
+
+  @Override
+  public Optional<S> getForWindow(final W window) {
+    return Optional.ofNullable(persister.get(window));
+  }
+
+  @Override
+  public void updateWindow(final W window, final S state) {
+    persister.put(window, state);
+  }
+
+  @Override
+  public void removeWindow(final W window) {
+    persister.remove(window);
+  }
+
+  @Override
+  public Set<W> windows() {
+    return persister.keys();
+  }
+
+  @Override
+  public void close() {
+    persister.close();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ReducePaneUpdater.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ReducePaneUpdater.java
@@ -1,0 +1,49 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.dataflow.graph.windows.WindowBinOp;
+
+/**
+ * Updates the state of a reduction operation by applying a binary operator.
+ * @param <T> The type of the values and the state.
+ * @param <W> The type of the windows.
+ */
+public class ReducePaneUpdater<T, W> implements PaneUpdater<T, W, T> {
+
+  private final WindowBinOp<T, W> operator;
+
+  /**
+   * @param op The operator to apply.
+   */
+  public ReducePaneUpdater(final WindowBinOp<T, W> op) {
+    operator = op;
+  }
+
+  @Override
+  public T createPane(final W window) {
+    //Initially the state is "nothing".
+    return null;
+  }
+
+  @Override
+  public T addContribution(final T state, final W window, final T data, final long timestamp) {
+    if (state == null) {
+      return data;
+    } else {
+      return operator.apply(window, state, data);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ReducingEvaluator.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ReducingEvaluator.java
@@ -1,0 +1,55 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Function;
+import swim.collections.BTreeMap;
+import swim.dataflow.graph.windows.WindowBinOp;
+import swim.dataflow.graph.windows.WindowFoldFunction;
+
+/**
+ * Evaluator which reduces over the contents of a map keyed by an eviction criterion. The result of the operation
+ * will be cached in the state.
+ * @param <K> The type of the criterion.
+ * @param <T> The type of the values.
+ * @param <W> The type of the widow.
+ * @param <U> The output type.
+ */
+public class ReducingEvaluator<K, T, W, U> implements PaneEvaluator<BTreeMap<K, T, U>, W, U> {
+
+  private final Function<W, U> seed;
+  private final WindowFoldFunction<T, W, U> accumulator;
+  private final WindowBinOp<U, W> combiner;
+
+  /**
+   * @param seedVal Seed value for the operation.
+   * @param accFun Function to combine a value with the state.
+   * @param combFun Function to merge two states.
+   */
+  public ReducingEvaluator(final Function<W, U> seedVal,
+                           final WindowFoldFunction<T, W, U> accFun,
+                           final WindowBinOp<U, W> combFun) {
+    seed = seedVal;
+    accumulator = accFun;
+    combiner = combFun;
+  }
+
+  @Override
+  public U evaluate(final W window, final BTreeMap<K, T, U> state) {
+    return state.reduced(seed.apply(window),
+        (acc, value) -> accumulator.apply(window, acc, value),
+        (acc1, acc2) -> combiner.apply(window, acc1, acc2));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/SequencePaneUpdater.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/SequencePaneUpdater.java
@@ -1,0 +1,39 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+
+/**
+ * Window pane updater for panes which store the state as a sequence of timestamped values.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+public class SequencePaneUpdater<T, W> implements PaneUpdater<T, W, FingerTrieSeq<WithTimestamp<T>>> {
+
+  @Override
+  public FingerTrieSeq<WithTimestamp<T>> createPane(final W window) {
+    return FingerTrieSeq.empty();
+  }
+
+  @Override
+  public FingerTrieSeq<WithTimestamp<T>> addContribution(final FingerTrieSeq<WithTimestamp<T>> state,
+                                                         final W window,
+                                                         final T data,
+                                                         final long timestamp) {
+    return state.appended(new WithTimestamp<>(data, timestamp));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/SequenceThresholdEvictor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/SequenceThresholdEvictor.java
@@ -1,0 +1,77 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.eviction.EvictionCriterionFunction;
+import swim.dataflow.graph.windows.eviction.EvictionThresholdFunction;
+
+/**
+ * Evicts values from a window where the state is stored as an sequence of timestamped values.
+ * @param <T> The type of the values.
+ * @param <K> The type of the eviction criterion.
+ * @param <W> The type of the windows.
+ */
+public class SequenceThresholdEvictor<T, K extends Comparable<K>, W>
+        implements PaneEvictor<T, W, FingerTrieSeq<WithTimestamp<T>>> {
+
+  private final EvictionCriterionFunction<T, K> criterion;
+  private final EvictionThresholdFunction<T, W, K> threshold;
+  private final boolean assumeOrdered;
+
+  /**
+   * @param criterion Gets the eviction criterion from each value.
+   * @param threshold Gets the eviction threshold for the pane.
+   * @param assumeOrdered If this is set it will be assumed that the elements in the state are ordered by the criterion
+   *                      and the fold will stop when an item that is at least at the threshold is encountered.
+   */
+  public SequenceThresholdEvictor(final EvictionCriterionFunction<T, K> criterion,
+                                  final EvictionThresholdFunction<T, W, K> threshold,
+                                  final boolean assumeOrdered) {
+    this.criterion = criterion;
+    this.threshold = threshold;
+    this.assumeOrdered = assumeOrdered;
+  }
+
+  @Override
+  public FingerTrieSeq<WithTimestamp<T>> evict(final FingerTrieSeq<WithTimestamp<T>> state,
+                                               final W window,
+                                               final T data,
+                                               final long timestamp) {
+    final K expiry = threshold.apply(data, window, timestamp);
+
+    FingerTrieSeq<WithTimestamp<T>> newState;
+    if (assumeOrdered) {
+      newState = state;
+      while (!newState.isEmpty() && checkForExpiry(newState.head(), expiry)) {
+        newState = newState.tail();
+      }
+    } else {
+      newState = FingerTrieSeq.empty();
+      //Iterate through the state an remove all expired records.
+      for (final WithTimestamp<T> item : state) {
+        if (!checkForExpiry(item, expiry)) {
+          newState = newState.appended(item);
+        }
+      }
+    }
+    return newState;
+  }
+
+  private boolean checkForExpiry(final WithTimestamp<T> current, final K expiry) {
+    return criterion.apply(current.getData(), current.getTimestamp()).compareTo(expiry) < 0;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ThresholdEvictor.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/ThresholdEvictor.java
@@ -1,0 +1,52 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.collections.BTreeMap;
+import swim.dataflow.graph.Iterables;
+import swim.dataflow.graph.windows.eviction.EvictionThresholdFunction;
+
+/**
+ * Evicts values from a window, where the state is stored in a map by eviction criterion, usig a threshold function.
+ * @param <T> The type of the values.
+ * @param <K> The type of the criterion.
+ * @param <W> The type of the widow.
+ * @param <U> The type of the state cached in the map.
+ */
+public class ThresholdEvictor<T, K extends Comparable<K>, W, U> implements PaneEvictor<T, W, BTreeMap<K, T, U>> {
+
+  private final EvictionThresholdFunction<T, W, K> theshold;
+
+  /**
+   * @param theshold Function to determine the eviction threshold for the pane.
+   */
+  public ThresholdEvictor(final EvictionThresholdFunction<T, W, K> theshold) {
+    this.theshold = theshold;
+  }
+
+  @Override
+  public BTreeMap<K, T, U> evict(final BTreeMap<K, T, U> state,
+                                 final W window,
+                                 final T data,
+                                 final long timestamp) {
+    final K expiry = theshold.apply(data, window, timestamp);
+    final int boundary = Iterables.findFirstIndex(state.keyIterator(), k -> k.compareTo(expiry) >= 0);
+    if (boundary < 0) {
+      return BTreeMap.empty();
+    } else {
+      return state.drop(boundary);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowAccumulators.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowAccumulators.java
@@ -1,0 +1,56 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Interface for stores that manage the state of all open windows for an stream element.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the states.
+ */
+public interface WindowAccumulators<W, S> {
+
+  /**
+   * Get the state for a window.
+   * @param window The window.
+   * @return The state, if it has been created.
+   */
+  Optional<S> getForWindow(W window);
+
+  /**
+   * Update the state for a window.
+   * @param window The window.
+   * @param state The new state.
+   */
+  void updateWindow(W window, S state);
+
+  /**
+   * Remove the state for a window.
+   * @param window The window.
+   */
+  void removeWindow(W window);
+
+  /**
+   * @return The set of all windows with states defined.
+   */
+  Set<W> windows();
+
+  /**
+   * Close the store (it should not be used following this).
+   */
+  void close();
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowConduit.java
@@ -1,0 +1,86 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
+import swim.concurrent.Schedule;
+import swim.concurrent.TimerFunction;
+import swim.dataflow.connector.AbstractJunction;
+import swim.dataflow.connector.Conduit;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+
+public class WindowConduit<T, W, U> extends AbstractJunction<U> implements Conduit<T, U> {
+
+  private final PaneManager<T, W, U> pane;
+  private final ToLongFunction<T> timestamps;
+  private final InternalTimeContext timeContext;
+
+  /**
+   * @param paneManager The window pane manager.
+   * @param ts          Assigns timestamps to values.
+   */
+  public WindowConduit(final Schedule schedule,
+                       final PaneManager<T, W, U> paneManager,
+                       final TimestampAssigner<T> ts) {
+    pane = paneManager;
+    pane.setListener(this::propagateOutput);
+    timeContext = ts.match(fromData -> new DataTimeContext(), fromClock -> new ScheduleTimeContext(schedule, fromClock));
+    timestamps = ts.match(fromData -> fromData, fromClock -> ts);
+  }
+
+  private void propagateOutput(final W window, final U output) {
+    emit(Deferred.value(output));
+  }
+
+  @Override
+  public void notifyChange(final Deferred<T> value) {
+    final T val = value.get();
+    final long timestamp = timestamps.applyAsLong(val);
+    timeContext.setNow(timestamp);
+    pane.update(val, timestamp, timeContext);
+  }
+
+  /**
+   * Time context that uses a {@link Schedule} to trigger events, using clock time.
+   */
+  private final class ScheduleTimeContext implements InternalTimeContext {
+
+    private final Schedule schedule;
+    private long now = Long.MIN_VALUE;
+    private final LongSupplier clock;
+
+    private ScheduleTimeContext(final Schedule schedule, final LongSupplier clock) {
+      this.schedule = schedule;
+      this.clock = clock;
+    }
+
+    @Override
+    public void setNow(final long nowTs) {
+      now = nowTs;
+    }
+
+    @Override
+    public void scheduleAt(final long timestamp, final PaneManager.WindowCallback callback) {
+      final long offset = Math.max(0, timestamp - now);
+      final TimerFunction timerFun = () -> {
+        final long calledAt = clock.getAsLong();
+        callback.runEvent(timestamp, calledAt);
+      };
+      schedule.setTimer(offset, timerFun);
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowConduit.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowConduit.java
@@ -20,8 +20,8 @@ import swim.concurrent.Schedule;
 import swim.concurrent.TimerFunction;
 import swim.dataflow.connector.AbstractJunction;
 import swim.dataflow.connector.Conduit;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.util.Deferred;
 
 public class WindowConduit<T, W, U> extends AbstractJunction<U> implements Conduit<T, U> {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowFunctionEvaluator.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/impl/windows/WindowFunctionEvaluator.java
@@ -1,0 +1,43 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.Iterables;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.WindowFunction;
+
+/**
+ * Evaluate an arbitrary function over the contents of a window pane stored as a sequence of values.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <U> The type of the results.
+ */
+public class WindowFunctionEvaluator<T, W, U> implements PaneEvaluator<FingerTrieSeq<WithTimestamp<T>>, W, U> {
+
+  private final WindowFunction<T, W, U> winFun;
+
+  /**
+   * @param fun Function to evaluate over the pane.
+   */
+  public WindowFunctionEvaluator(final WindowFunction<T, W, U> fun) {
+    winFun = fun;
+  }
+
+  @Override
+  public U evaluate(final W window, final FingerTrieSeq<WithTimestamp<T>> state) {
+    return winFun.apply(window, Iterables.mapIterable(state, WithTimestamp::getData));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/BTreeMapForm.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/BTreeMapForm.java
@@ -1,0 +1,95 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import java.util.Map;
+import swim.collections.BTreeMap;
+import swim.structure.Field;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Form for {@link BTreeMap} collections.
+ * @param <K> The type of the map keys.
+ * @param <V> The type of the map values.
+ * @param <U> The aggregation type.
+ */
+public class BTreeMapForm<K, V, U> extends Form<BTreeMap<K, V, U>> {
+
+  private final Form<K> keyForm;
+  private final Form<V> valForm;
+
+  public BTreeMapForm(final Form<K> keyForm, final Form<V> valForm) {
+    this.keyForm = keyForm;
+    this.valForm = valForm;
+  }
+
+  @Override
+  public Class<?> type() {
+    return BTreeMap.class;
+  }
+
+  @Override
+  public Item mold(final BTreeMap<K, V, U> map, Item item) {
+    if (map != null) {
+      for (final Map.Entry<K, V> entry : map.entrySet()) {
+        final Value key = this.keyForm.mold(entry.getKey()).toValue();
+        final Value val = this.valForm.mold(entry.getValue()).toValue();
+        item = item.updatedSlot(key, val);
+      }
+      return item;
+    } else {
+      return Item.extant();
+    }
+  }
+
+  @Override
+  public Item mold(final BTreeMap<K, V, U> map) {
+    if (map != null) {
+      final Record record = Record.create();
+      for (final Map.Entry<K, V> entry : map.entrySet()) {
+        final Value key = this.keyForm.mold(entry.getKey()).toValue();
+        final Value val = this.valForm.mold(entry.getValue()).toValue();
+        record.slot(key, val);
+      }
+      return record;
+    } else {
+      return Item.extant();
+    }
+  }
+
+  @Override
+  public BTreeMap<K, V, U> cast(final Item item) {
+    final Value value = item.toValue();
+    if (value instanceof Record) {
+      BTreeMap<K, V, U> map = BTreeMap.empty();
+      for (final Item child : value) {
+        if (child instanceof Field) {
+          final K key = this.keyForm.cast(child.key());
+          if (key != null) {
+            final V val = this.valForm.cast(child.toValue());
+            if (val != null) {
+              map = map.updated(key, val);
+            }
+          }
+        }
+      }
+      return map;
+    }
+    return null;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/FingerTrieSeqForm.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/FingerTrieSeqForm.java
@@ -1,0 +1,86 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import swim.collections.FingerTrieSeq;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Form for {@link FingerTrieSeq} collections.
+ * @param <T> The type of the elements.
+ */
+public class FingerTrieSeqForm<T> extends Form<FingerTrieSeq<T>> {
+
+  private final Form<T> form;
+
+  public FingerTrieSeqForm(final Form<T> form) {
+    this.form = form;
+  }
+
+  @Override
+  public Class<?> type() {
+    return FingerTrieSeq.class;
+  }
+
+  @Override
+  public Item mold(final FingerTrieSeq<T> seq, Item item) {
+    if (seq != null) {
+      for (final T elem : seq) {
+        item = item.appended(this.form.mold(elem));
+      }
+      return item;
+    } else {
+      return Item.extant();
+    }
+  }
+
+  @Override
+  public Item mold(final FingerTrieSeq<T> seq) {
+    if (seq != null) {
+      final Record record = Record.create();
+      for (final T elem : seq) {
+        record.add(this.form.mold(elem));
+      }
+      return record;
+    } else {
+      return Item.extant();
+    }
+  }
+
+  @Override
+  public FingerTrieSeq<T> cast(final Item item) {
+    final Value value = item.toValue();
+    final int n = value.length();
+    if (n > 0) {
+      FingerTrieSeq<T> seq = FingerTrieSeq.empty();
+      for (final Item child : value) {
+        final T elem = form.cast(child);
+        if (elem != null) {
+          seq = seq.appended(elem);
+        }
+      }
+      return seq;
+    } else if (value.isDefined()) {
+      final T elem = this.form.cast(value);
+      if (elem != null) {
+        return FingerTrieSeq.<T>empty().appended(elem);
+      }
+    }
+    return null;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/ListPersister.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/ListPersister.java
@@ -1,0 +1,81 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import java.util.List;
+
+/**
+ * Provides durable persistence for a list.
+ * @param <T> The type of the elments.
+ */
+public interface ListPersister<T> {
+
+  /**
+   * Retreive the value at the given index.
+   * @param index The index.
+   * @return The value, if it exists.
+   */
+  T get(int index);
+
+  /**
+   * @param value Append this value to the list.
+   */
+  void append(T value);
+
+  /**
+   * @param value Prepend this value to the list.
+   */
+  void prepend(T value);
+
+  /**
+   * @return The size of the list.
+   */
+  int size();
+
+  /**
+   * @param n Drop the first {@code n} elements of the list.
+   */
+  void drop(int n);
+
+  /**
+   * @param n Retain only the first {@code n} elements of the list.
+   */
+  void take(int n);
+
+  /**
+   * @param n Drop the last {@code n} elements of the list.
+   */
+  default void dropEnd(final int n) {
+    take(size() - n);
+  }
+
+  /**
+   * @param n Retain only the last {@code n} elements of the list.
+   */
+  default void takeEnd(final int n) {
+    drop(size() - n);
+  }
+
+  /**
+   * @return A snapshot of the state of the list.
+   */
+  List<T> get();
+
+  /**
+   * Close this persister. It should not be used afterwards.
+   */
+  void close();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/MapPersister.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/MapPersister.java
@@ -1,0 +1,76 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import java.util.Set;
+import swim.dataflow.connector.MapView;
+
+/**
+ * Provides durable persistence for a map.
+ * @param <K> The type of the keys.
+ * @param <V> The type of the values.
+ */
+public interface MapPersister<K, V> {
+
+  /**
+   * Get the value for a key.
+   * @param key The key.
+   * @return The value for the key.
+   */
+  V get(K key);
+
+  /**
+   * Get the value for a key or a configured default.
+   * @param key The key.
+   * @return The value or the configured default.
+   */
+  V getOrDefault(K key);
+
+  /**
+   * Determine whether the key is in the state.
+   *
+   * @param key The key.
+   * @return Whether the key has an entry in the state.
+   */
+  boolean containsKey(K key);
+
+  /**
+   * @return A view of the state.
+   */
+  MapView<K, V> get();
+
+  /**
+   * @return All keys currently in the state.
+   */
+  Set<K> keys();
+
+  /**
+   * Change the value for a given key.
+   * @param key The key.
+   * @param value The new value.
+   */
+  void put(K key, V value);
+
+  /**
+   * Remove the value associated with a key.
+   * @param key The key.
+   */
+  void remove(K key);
+
+  /**
+   * Close the persister. It should be be used again afterwards.
+   */
+  void close();
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/PersistenceProvider.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/PersistenceProvider.java
@@ -1,0 +1,176 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import swim.structure.Form;
+import swim.structure.Text;
+import swim.structure.Value;
+
+/**
+ * Provides persistence of values for data-flow components.
+ */
+public interface PersistenceProvider {
+
+  /**
+   * Get a persister for a simple value.
+   *
+   * @param name The unique name for the persister.
+   * @param form The form of the type of the value.
+   * @param <T>  The type of the value.
+   * @return The persister.
+   */
+  default <T> ValuePersister<T> forValue(final String name, final Form<T> form) {
+    return forValue(Text.from(name), form);
+  }
+
+  /**
+   * Get a persister for a simple value.
+   *
+   * @param key  The unique key for the persister.
+   * @param form The form of the type of the value.
+   * @param <T>  The type of the value.
+   * @return The persister.
+   */
+  <T> ValuePersister<T> forValue(Value key, Form<T> form);
+
+  /**
+   * Get a persister for a simple value.
+   *
+   * @param key  The unique key for the persister.
+   * @param form The form of the type of the value.
+   * @param init The initial value.
+   * @param <T>  The type of the value.
+   * @return The persister.
+   */
+  default <T> ValuePersister<T> forValue(final Value key, final Form<T> form, final T init) {
+    return forValue(key, form.unit(init));
+  }
+
+  /**
+   * Get a persister for a simple value.
+   *
+   * @param name The unique name for the persister.
+   * @param form The form of the type of the value.
+   * @param init The initial value.
+   * @param <T>  The type of the values.
+   * @return The persister.
+   */
+  default <T> ValuePersister<T> forValue(final String name, final Form<T> form, final T init) {
+    return forValue(name, form.unit(init));
+  }
+
+  /**
+   * Get a persister for a list of values.
+   *
+   * @param name The unique name for the persister.
+   * @param form The form of the type of the elements.
+   * @param <T>  The type of the values.
+   * @return The persister.
+   */
+  default <T> ListPersister<T> forList(final String name, final Form<T> form) {
+    return forList(Text.from(name), form);
+  }
+
+  /**
+   * Get a persister for a set of values.
+   *
+   * @param key  The unique key for the persister.
+   * @param form The form of the type of the elements.
+   * @param <T>  The type of the valuse.
+   * @return The persister.
+   */
+  <T> SetPersister<T> forSet(Value key, Form<T> form);
+
+  /**
+   * Get a persister for a set of values.
+   *
+   * @param name The unique name for the persister.
+   * @param form The form of the type of the elements.
+   * @param <T>  The type of the value.
+   * @return The persister.
+   */
+  default <T> SetPersister<T> forSet(final String name, final Form<T> form) {
+    return forSet(Text.from(name), form);
+  }
+
+  /**
+   * Get a persister for a list of values.
+   *
+   * @param key  The unique key for the persister.
+   * @param form The form of the type of the elements.
+   * @param <T>  The type of the value.
+   * @return The persister.
+   */
+  <T> ListPersister<T> forList(Value key, Form<T> form);
+
+  /**
+   * Get a persister for a map.
+   *
+   * @param key     The unique key for the persister.
+   * @param keyForm The form of the type of the keys.
+   * @param valForm The form of the type of the values.
+   * @param <K>     The type of the keys.
+   * @param <V>     The type of the values.
+   * @return The persister.
+   */
+  <K, V> MapPersister<K, V> forMap(Value key, Form<K> keyForm, Form<V> valForm);
+
+  /**
+   * Get a persister for a map.
+   *
+   * @param key     The unique key for the persister.
+   * @param keyForm The form of the type of the keys.
+   * @param valForm The form of the type of the values.
+   * @param init    The initial value.
+   * @param <K>     The type of the keys.
+   * @param <V>     The type of the values.
+   * @return The persister.
+   */
+  default <K, V> MapPersister<K, V> forMap(final Value key,
+                                           final Form<K> keyForm, final Form<V> valForm, final V init) {
+    return forMap(key, keyForm, valForm.unit(init));
+  }
+
+  /**
+   * Get a persister for a map.
+   *
+   * @param name    The unique name for the persister.
+   * @param keyForm The form of the type of the keys.
+   * @param valForm The form of the type of the values.
+   * @param <K>     The type of the keys.
+   * @param <V>     The type of the values.
+   * @return The persister.
+   */
+  default <K, V> MapPersister<K, V> forMap(final String name, final Form<K> keyForm, final Form<V> valForm) {
+    return forMap(Text.from(name), keyForm, valForm);
+  }
+
+  /**
+   * Get a persister for a map.
+   *
+   * @param name    The unique name for the persister.
+   * @param keyForm The form of the type of the keys.
+   * @param valForm The form of the type of the values.
+   * @param init    The initial value.
+   * @param <K>     The type of the keys.
+   * @param <V>     The type of the values.
+   * @return The persister.
+   */
+  default <K, V> MapPersister<K, V> forMap(final String name,
+                                           final Form<K> keyForm, final Form<V> valForm, final V init) {
+    return forMap(name, keyForm, valForm.unit(init));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/SetPersister.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/SetPersister.java
@@ -1,0 +1,58 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+
+import java.util.Set;
+
+/**
+ * Provides durable persistence for a set.
+ *
+ * @param <T> The type of the values.
+ */
+public interface SetPersister<T> {
+
+  /**
+   * Determine whether the value is in the state.
+   *
+   * @param val The value.
+   * @return Whether the value is in the state.
+   */
+  boolean contains(T val);
+
+  /**
+   * @return A view of the state.
+   */
+  Set<T> get();
+
+  /**
+   * Add a value to the sate.
+   *
+   * @param value The new value.
+   */
+  void add(T value);
+
+  /**
+   * Remove A value from the state.
+   *
+   * @param value The key.
+   */
+  void remove(T value);
+
+  /**
+   * Close the persister. It should be be used again afterwards.
+   */
+  void close();
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/TrivialPersistenceProvider.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/TrivialPersistenceProvider.java
@@ -1,0 +1,221 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+import java.util.List;
+import java.util.Set;
+import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.MapView;
+import swim.structure.Form;
+import swim.structure.Value;
+
+/**
+ * Trivial implementation of {@link PersistenceProvider} that stores values in simple variables/maps.
+ */
+public final class TrivialPersistenceProvider implements PersistenceProvider {
+
+  private HashTrieSet<Value> keys = HashTrieSet.empty();
+
+  private void checkKey(final Value key) {
+    if (key == null) {
+      throw new IllegalArgumentException("A key must be provided.");
+    } else if (keys.contains(key)) {
+      throw new IllegalArgumentException(String.format("The storage key %s has already been used.", key));
+    } else {
+      keys = keys.added(key);
+    }
+  }
+
+  @Override
+  public <T> ValuePersister<T> forValue(final Value key, final Form<T> form) {
+    checkKey(key);
+    return new TrivialValuePersister<>(form.unit());
+  }
+
+  @Override
+  public <T> SetPersister<T> forSet(final Value key, final Form<T> form) {
+    return new TrivialSetPersisiter<>();
+  }
+
+  @Override
+  public <T> ListPersister<T> forList(final Value key, final Form<T> form) {
+    checkKey(key);
+    return new TrivialListPersister<>();
+  }
+
+  @Override
+  public <K, V> MapPersister<K, V> forMap(final Value key, final Form<K> keyForm, final Form<V> valForm) {
+    checkKey(key);
+    return new TrivialMapPersister<>(valForm);
+  }
+
+  public static class TrivialValuePersister<T> implements ValuePersister<T> {
+
+    private T value;
+
+    public TrivialValuePersister(final T initial) {
+      value = initial;
+    }
+
+    @Override
+    public T get() {
+      return value;
+    }
+
+    @Override
+    public void set(final T value) {
+      this.value = value;
+    }
+
+    @Override
+    public void close() {
+      value = null;
+    }
+  }
+
+  public static class TrivialMapPersister<K, V> implements MapPersister<K, V> {
+
+    private final Form<V> valForm;
+    private HashTrieMap<K, V> map;
+
+    public TrivialMapPersister(final Form<V> valForm) {
+      this.valForm = valForm;
+      map = HashTrieMap.empty();
+    }
+
+    @Override
+    public V get(final K key) {
+      return map.get(key);
+    }
+
+    @Override
+    public V getOrDefault(final K key) {
+      return map.getOrDefault(key, valForm.unit());
+    }
+
+    @Override
+    public boolean containsKey(final K key) {
+      return map.containsKey(key);
+    }
+
+    @Override
+    public MapView<K, V> get() {
+      return MapView.wrapSimple(map);
+    }
+
+    @Override
+    public Set<K> keys() {
+      return map.keySet();
+    }
+
+    @Override
+    public void put(final K key, final V value) {
+      if (key == null || value == null) {
+        throw new IllegalArgumentException("Key and value must both be non-null.");
+      }
+      map = map.updated(key, value);
+    }
+
+    @Override
+    public void remove(final K key) {
+      if (key == null) {
+        throw new IllegalArgumentException("Key must be non-null.");
+      }
+      map = map.removed(key);
+    }
+
+    @Override
+    public void close() {
+      map = HashTrieMap.empty();
+    }
+  }
+
+  public static class TrivialListPersister<T> implements ListPersister<T> {
+
+    private FingerTrieSeq<T> list = FingerTrieSeq.empty();
+
+    @Override
+    public T get(final int index) {
+      return list.get(index);
+    }
+
+    @Override
+    public void append(final T value) {
+      list = list.appended(value);
+    }
+
+    @Override
+    public void prepend(final T value) {
+      list = list.prepended(value);
+    }
+
+    @Override
+    public int size() {
+      return list.size();
+    }
+
+    @Override
+    public void drop(final int n) {
+      list = list.drop(n);
+    }
+
+    @Override
+    public void take(final int n) {
+      list = list.take(n);
+    }
+
+    @Override
+    public List<T> get() {
+      return list;
+    }
+
+    @Override
+    public void close() {
+      list = FingerTrieSeq.empty();
+    }
+  }
+
+  public static class TrivialSetPersisiter<T> implements SetPersister<T> {
+
+    private HashTrieSet<T> set = HashTrieSet.empty();
+
+    @Override
+    public boolean contains(final T val) {
+      return set.contains(val);
+    }
+
+    @Override
+    public Set<T> get() {
+      return set;
+    }
+
+    @Override
+    public void add(final T value) {
+      set = set.added(value);
+    }
+
+    @Override
+    public void remove(final T value) {
+      set = set.removed(value);
+    }
+
+    @Override
+    public void close() {
+      set = HashTrieSet.empty();
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/ValuePersister.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/persistence/ValuePersister.java
@@ -1,0 +1,38 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.persistence;
+
+/**
+ * Provides durable persistence for a single value.
+ * @param <T> The type of the value.
+ */
+public interface ValuePersister<T> {
+
+  /**
+   * @return The current value.
+   */
+  T get();
+
+  /**
+   * @param value Replace the value.
+   */
+  void set(T value);
+
+  /**
+   * Close the persister. It should be be used again afterwards.
+   */
+  void close();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/DelaySpecifier.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/DelaySpecifier.java
@@ -1,0 +1,59 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sampling;
+
+import java.time.Duration;
+import java.util.function.Function;
+import swim.dataflow.graph.Require;
+import swim.dataflow.graph.SwimStream;
+
+public interface DelaySpecifier extends Sampling {
+
+  /**
+   * Periodic sampling with a constant time interval.
+   *
+   * @param interval The time interval.
+   * @return Periodic sampling.
+   */
+  static Sampling constant(final Duration interval) {
+    Require.that(interval != null, "Sample interval must be non-null.");
+    return new StaticSampling(interval);
+  }
+
+  /**
+   * Periodic sampling with a dynamic time interval.
+   *
+   * @param initial The initial time interval.
+   * @param after   Stream of new intervals.
+   * @param isTransient Whether the current duration is persisted durably.
+   * @return Dynamic sampling instance.
+   */
+  static Sampling dynamic(final Duration initial, final SwimStream<Duration> after, final boolean isTransient) {
+    Require.that(initial != null, "Initial interval must be non-null.");
+    Require.that(after != null, "Interval stream must be non-null.");
+    return new DynamicSampling(initial, after, isTransient);
+  }
+
+  /**
+   * Distinguish between different sampling strategies.
+   *
+   * @param onStatic  Called for a static strategy.
+   * @param onDynamic Called for a dynamic strategy.
+   * @param <T>       The type of the result.
+   * @return The result.
+   */
+  <T> T matchDelay(Function<StaticSampling, T> onStatic,
+                   Function<DynamicSampling, T> onDynamic);
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/DynamicSampling.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/DynamicSampling.java
@@ -1,0 +1,82 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sampling;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import swim.dataflow.graph.SwimStream;
+import swim.util.Murmur3;
+
+public class DynamicSampling implements DelaySpecifier {
+
+  private final Duration initial;
+  private final SwimStream<Duration> intervals;
+  private final boolean isTransient;
+
+  DynamicSampling(final Duration init, final SwimStream<Duration> following, final boolean isTransient) {
+    initial = init;
+    intervals = following;
+    this.isTransient = isTransient;
+  }
+
+  public Duration getInitial() {
+    return initial;
+  }
+
+  public SwimStream<Duration> getIntervalStream() {
+    return intervals;
+  }
+
+  public boolean isTransient() {
+    return isTransient;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof DynamicSampling) {
+      final DynamicSampling other = (DynamicSampling) obj;
+      return initial.equals(other.initial) && intervals.equals(other.intervals);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashSeed == 0) {
+      hashSeed = Murmur3.seed(DynamicSampling.class);
+    }
+    int hash = Murmur3.mix(hashSeed, Murmur3.hash(initial));
+    hash = Murmur3.mix(hash, Murmur3.hash(intervals.id()));
+    hash = Murmur3.mix(hash, Murmur3.hash(isTransient));
+    return Murmur3.mash(hash);
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public <T> T matchDelay(final Function<StaticSampling, T> onStatic, final Function<DynamicSampling, T> onDynamic) {
+    return onDynamic.apply(this);
+  }
+
+  @Override
+  public <T> T match(final Supplier<T> onEager, final Function<StaticSampling, T> onStatic,
+                     final Function<DynamicSampling, T> onDynamic) {
+    return onDynamic.apply(this);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/Eager.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/Eager.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sampling;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class Eager implements Sampling {
+
+  private Eager() {
+  }
+
+  public static final Eager INSTANCE = new Eager();
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other instanceof Eager) {
+      return other == this;
+    } else {
+      return false;
+    }
+  }
+
+  private static final int HASH = 13;
+
+  @Override
+  public int hashCode() {
+    return HASH;
+  }
+
+  @Override
+  public <T> T match(final Supplier<T> onEager, final Function<StaticSampling, T> onStatic,
+                     final Function<DynamicSampling, T> onDynamic) {
+    return onEager.get();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/Sampling.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/Sampling.java
@@ -1,0 +1,81 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sampling;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import swim.dataflow.graph.SwimStream;
+
+/**
+ * Sampling strategy for the links between to nodes in a flow graph. Instances can be compared for equality but dynamic
+ * sampling instances will only be equal if they are the same object (due to the difficulty of checking equality
+ * of streams).
+ */
+public interface Sampling {
+
+  /**
+   * Eager sampling: data is consumed as soon as it is available.
+   *
+   * @return The eager sampling strategy.
+   */
+  static Sampling eager() {
+    return Eager.INSTANCE;
+  }
+
+  /**
+   * Periodic sampling with a constant time interval.
+   *
+   * @param interval The time interval.
+   * @return Periodic sampling.
+   */
+  static Sampling constant(final Duration interval) {
+    return DelaySpecifier.constant(interval);
+  }
+
+  /**
+   * Periodic sampling with a dynamic time interval.
+   *
+   * @param initial The initial time interval.
+   * @param after   Stream of new intervals.
+   * @param isTransient Whether the current value of the delay should be persisted durably.
+   * @return Dynamic sampling instance.
+   */
+  static Sampling dynamic(final Duration initial, final SwimStream<Duration> after, final boolean isTransient) {
+    return DelaySpecifier.dynamic(initial, after, isTransient);
+  }
+
+  /**
+   * Distinguish between different sampling strategies.
+   *
+   * @param onEager   Called for the eager strategy.
+   * @param onStatic  Called for a static strategy.
+   * @param onDynamic Called for a dynamic strategy.
+   * @param <T>       The type of the result.
+   * @return The result.
+   */
+  <T> T match(Supplier<T> onEager,
+              Function<StaticSampling, T> onStatic,
+              Function<DynamicSampling, T> onDynamic);
+
+}
+
+
+
+
+
+
+
+

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/StaticSampling.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sampling/StaticSampling.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sampling;
+
+import java.time.Duration;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public class StaticSampling implements DelaySpecifier {
+
+  private final Duration interval;
+
+  StaticSampling(final Duration dur) {
+    interval = dur;
+  }
+
+  public Duration getInterval() {
+    return interval;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof StaticSampling) {
+      final StaticSampling other = (StaticSampling) obj;
+      return interval.equals(other.interval);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return interval.hashCode();
+  }
+
+
+  @Override
+  public <T> T matchDelay(final Function<StaticSampling, T> onStatic, final Function<DynamicSampling, T> onDynamic) {
+    return onStatic.apply(this);
+  }
+
+  @Override
+  public <T> T match(final Supplier<T> onEager, final Function<StaticSampling, T> onStatic,
+                     final Function<DynamicSampling, T> onDynamic) {
+    return onStatic.apply(this);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/InletSink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/InletSink.java
@@ -1,0 +1,78 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sinks;
+
+import java.util.function.Supplier;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.Receptacle;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.streamlet.AbstractOutlet;
+import swim.streamlet.Inlet;
+
+/**
+ * Sink based on an external inlet.
+ *
+ * @param <T> The type of the inlet.
+ */
+public class InletSink<T> implements Sink<T> {
+
+  private final Supplier<Inlet<T>> inlet;
+
+  public InletSink(final Supplier<Inlet<T>> inletSupp) {
+    inlet = inletSupp;
+  }
+
+  public InletSink(final Inlet<T> in) {
+    this(() -> in);
+  }
+
+  @Override
+  public Receptacle<T> instantiate(final SwimStreamContext.InitContext context) {
+    final Inlet<T> target = inlet.get();
+    final BridgeOutlet<T> bridge = new BridgeOutlet<>();
+    target.bindInput(bridge);
+    return bridge.getReceptacle();
+  }
+
+}
+
+final class BridgeOutlet<T> extends AbstractOutlet<T> {
+
+  private Deferred<T> current;
+
+  private final Receptacle<T> receptacle = new Receptacle<T>() {
+    @Override
+    public void notifyChange(final Deferred<T> value) {
+      current = value;
+      invalidateInput();
+      System.out.println(String.format("Output produced: %s", current.get()));
+      reconcileInput(1);
+    }
+  };
+
+  Receptacle<T> getReceptacle() {
+    return receptacle;
+  }
+
+  @Override
+  public T get() {
+    if (current != null) {
+      return current.get();
+    } else {
+      return null;
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/InletSink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/InletSink.java
@@ -15,12 +15,12 @@
 package swim.dataflow.graph.sinks;
 
 import java.util.function.Supplier;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.Receptacle;
 import swim.dataflow.graph.Sink;
 import swim.dataflow.graph.SwimStreamContext;
 import swim.streamlet.AbstractOutlet;
 import swim.streamlet.Inlet;
+import swim.util.Deferred;
 
 /**
  * Sink based on an external inlet.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/MapInletSink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/MapInletSink.java
@@ -18,7 +18,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Supplier;
 import swim.collections.HashTrieMap;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.MapReceptacle;
 import swim.dataflow.connector.MapView;
 import swim.dataflow.graph.MapSink;
@@ -26,6 +25,7 @@ import swim.dataflow.graph.SwimStreamContext;
 import swim.streamlet.AbstractMapOutlet;
 import swim.streamlet.KeyEffect;
 import swim.streamlet.MapInlet;
+import swim.util.Deferred;
 
 /**
  * Sink based on an external map inlet.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/MapInletSink.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/sinks/MapInletSink.java
@@ -1,0 +1,111 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.sinks;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Supplier;
+import swim.collections.HashTrieMap;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.graph.MapSink;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.streamlet.AbstractMapOutlet;
+import swim.streamlet.KeyEffect;
+import swim.streamlet.MapInlet;
+
+/**
+ * Sink based on an external map inlet.
+ *
+ * @param <K> The key type of the inlet.
+ * @param <V> The value type of the inlet.
+ */
+public class MapInletSink<K, V> implements MapSink<K, V> {
+
+  private final Supplier<MapInlet<K, V, Map<K, V>>> inlet;
+
+  public MapInletSink(final Supplier<MapInlet<K, V, Map<K, V>>> inletSupp) {
+    inlet = inletSupp;
+  }
+
+  public MapInletSink(final MapInlet<K, V, Map<K, V>> in) {
+    this(() -> in);
+  }
+
+  @Override
+  public MapReceptacle<K, V> instantiateReceptacle(final SwimStreamContext.InitContext context) {
+    final BridgeMapOutlet<K, V> bridge = new BridgeMapOutlet<>();
+    inlet.get().bindInput(bridge);
+    return bridge.getReceptacle();
+  }
+}
+
+final class BridgeMapOutlet<K, V> extends AbstractMapOutlet<K, V, Map<K, V>> {
+
+  private MapView<K, V> view;
+  private int count = 0;
+
+  private final MapReceptacle<K, V> receptacle = new MapReceptacle<K, V>() {
+
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      view = map.get();
+      invalidateInputKey(key, KeyEffect.UPDATE);
+      reconcileInputKey(key, count);
+      ++count;
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+      view = map.get();
+      invalidateInputKey(key, KeyEffect.REMOVE);
+      reconcileInputKey(key, count);
+      ++count;
+    }
+  };
+
+  public MapReceptacle<K, V> getReceptacle() {
+    return receptacle;
+  }
+
+  @Override
+  public boolean containsKey(final K key) {
+    return view != null && view.containsKey(key);
+  }
+
+  @Override
+  public V get(final K key) {
+    return view == null ? null : view.get(key).get();
+  }
+
+  @Override
+  public Map<K, V> get() {
+    if (view != null) {
+      HashTrieMap<K, V> map = HashTrieMap.empty();
+      for (final Map.Entry<K, Deferred<V>> entry : view) {
+        map = map.updated(entry.getKey(), entry.getValue().get());
+      }
+      return map;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Iterator<K> keyIterator() {
+    return view == null ? null : view.keys().iterator();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/StreamStatistics.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/StreamStatistics.java
@@ -1,0 +1,284 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.statistics;
+
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.MapWindowedSwimStream;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.WindowedSwimStream;
+import swim.dataflow.graph.sampling.Sampling;
+import swim.dataflow.graph.statistics.model.Mean;
+import swim.dataflow.graph.statistics.model.SummaryStatistics;
+import swim.dataflow.graph.windows.KeyedWindowFoldFunction;
+import swim.structure.Form;
+
+/**
+ * Simple statistical transforms for streams.
+ */
+public final class StreamStatistics {
+
+  private StreamStatistics() {
+  }
+
+  public static SwimStream<Mean> mean(final SwimStream<Double> values) {
+    return values.fold(Mean.ZERO, Mean::add, Mean.FORM);
+  }
+
+  public static SwimStream<Mean> mean(final SwimStream<Double> values, final Sampling sampling) {
+    return values.fold(Mean.ZERO, Mean::add, Mean.FORM, sampling);
+  }
+
+  public static <W> SwimStream<Mean> mean(final WindowedSwimStream<Double, W> values) {
+    return values.fold(Mean.ZERO, (w, m, v) -> m.add(v), (w, m1, m2) -> m1.combine(m2), Mean.FORM);
+  }
+
+  public static <T, W> SwimStream<Mean> mean(final WindowedSwimStream<T, W> values, final ToDoubleFunction<T> transform) {
+    return values.fold(Mean.ZERO, (w, m, v) -> m.add(transform.applyAsDouble(v)), (w, m1, m2) -> m1.combine(m2), Mean.FORM);
+  }
+
+  public static <K, W> MapSwimStream<K, Mean> mean(final MapWindowedSwimStream<K, Double, W> keyedValues) {
+    final KeyedWindowFoldFunction<K, Double, W, Mean> winFun = (k, w, m, v) -> m.add(v);
+    return keyedValues.fold(Mean.ZERO, winFun, (m1, m2) -> m1.combine(m2), Mean.FORM);
+  }
+
+  public static <K, T, W> MapSwimStream<K, Mean> mean(final MapWindowedSwimStream<K, T, W> keyedValues, final ToDoubleFunction<T> transform) {
+    final KeyedWindowFoldFunction<K, T, W, Mean> winFun = (k, w, m, v) -> m.add(transform.applyAsDouble(v));
+    return keyedValues.fold(Mean.ZERO, winFun, (m1, m2) -> m1.combine(m2), Mean.FORM);
+  }
+
+  public static SwimStream<SummaryStatistics> summaryStatistics(final SwimStream<Double> values) {
+    return values.fold(SummaryStatistics.ZERO, SummaryStatistics::add, SummaryStatistics.FORM);
+  }
+
+  public static SwimStream<SummaryStatistics> summaryStatistics(final SwimStream<Double> values, final Sampling sampling) {
+    return values.fold(SummaryStatistics.ZERO, SummaryStatistics::add, SummaryStatistics.FORM, sampling);
+  }
+
+  public static <W> SwimStream<SummaryStatistics> summaryStatistics(final WindowedSwimStream<Double, W> values) {
+    return values.fold(SummaryStatistics.ZERO, (w, m, v) -> m.add(v), (w, m1, m2) -> m1.combine(m2), SummaryStatistics.FORM);
+  }
+
+  public static <T, W> SwimStream<SummaryStatistics> summaryStatistics(final WindowedSwimStream<T, W> values,
+                                                                       final ToDoubleFunction<T> transform) {
+    return values.fold(SummaryStatistics.ZERO, (w, m, v) -> m.add(transform.applyAsDouble(v)),
+        (w, m1, m2) -> m1.combine(m2), SummaryStatistics.FORM);
+  }
+
+  public static <K, W> MapSwimStream<K, SummaryStatistics> summaryStatistics(final MapWindowedSwimStream<K, Double, W> keyedValues) {
+    final KeyedWindowFoldFunction<K, Double, W, SummaryStatistics> winFun = (k, w, m, v) -> m.add(v);
+    return keyedValues.fold(SummaryStatistics.ZERO, winFun, (s1, s2) -> s1.combine(s2), SummaryStatistics.FORM);
+  }
+
+  public static <K, T, W> MapSwimStream<K, SummaryStatistics> summaryStatistics(final MapWindowedSwimStream<K, T, W> keyedValues,
+                                                                   final ToDoubleFunction<T> transform) {
+    final KeyedWindowFoldFunction<K, T, W, SummaryStatistics> winFun = (k, w, m, v) -> m.add(transform.applyAsDouble(v));
+    return keyedValues.fold(SummaryStatistics.ZERO, winFun, (m1, m2) -> m1.combine(m2), SummaryStatistics.FORM);
+  }
+
+  public static SwimStream<Double> minDouble(final SwimStream<Double> values) {
+    return values.reduce(Math::min);
+  }
+
+  public static SwimStream<Double> minDouble(final SwimStream<Double> values, final Sampling sampling) {
+    return values.reduce(Math::min, sampling);
+  }
+
+  public static <W> SwimStream<Double> minDouble(final WindowedSwimStream<Double, W> values) {
+    return values.reduce((w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Double> minDouble(final WindowedSwimStream<T, W> values, final ToDoubleFunction<T> transform) {
+    return values.fold(Double.POSITIVE_INFINITY, (w, u, v) -> Math.min(u, transform.applyAsDouble(v)), Form.forDouble());
+  }
+
+  public static <K, W> MapSwimStream<K, Double> minDouble(final MapWindowedSwimStream<K, Double, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Double> minDouble(final MapWindowedSwimStream<K, T, W> values, final ToDoubleFunction<T> transform) {
+    return values.fold(Double.POSITIVE_INFINITY, (k, w, u, v) -> Math.min(u, transform.applyAsDouble(v)), Form.forDouble());
+  }
+
+  public static SwimStream<Double> maxDouble(final SwimStream<Double> values) {
+    return values.reduce(Math::max);
+  }
+
+  public static SwimStream<Double> maxDouble(final SwimStream<Double> values, final Sampling sampling) {
+    return values.reduce(Math::max, sampling);
+  }
+
+  public static <W> SwimStream<Double> maxDouble(final WindowedSwimStream<Double, W> values) {
+    return values.reduce((w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Double> maxDouble(final WindowedSwimStream<T, W> values, final ToDoubleFunction<T> transform) {
+    return values.fold(Double.NEGATIVE_INFINITY, (w, u, v) -> Math.max(u, transform.applyAsDouble(v)), Form.forDouble());
+  }
+
+  public static <K, W> MapSwimStream<K, Double> maxDouble(final MapWindowedSwimStream<K, Double, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Double> maxDouble(final MapWindowedSwimStream<K, T, W> values, final ToDoubleFunction<T> transform) {
+    return values.fold(Double.NEGATIVE_INFINITY, (k, w, u, v) -> Math.max(u, transform.applyAsDouble(v)), Form.forDouble());
+  }
+
+  public static SwimStream<Integer> minInt(final SwimStream<Integer> values) {
+    return values.reduce(Math::min);
+  }
+
+  public static SwimStream<Integer> minInt(final SwimStream<Integer> values, final Sampling sampling) {
+    return values.reduce(Math::min, sampling);
+  }
+
+  public static <W> SwimStream<Integer> minInt(final WindowedSwimStream<Integer, W> values) {
+    return values.reduce((w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Integer> minInt(final WindowedSwimStream<T, W> values, final ToIntFunction<T> transform) {
+    return values.fold(Integer.MAX_VALUE, (w, u, v) -> Math.min(u, transform.applyAsInt(v)), Form.forInteger());
+  }
+
+  public static <K, W> MapSwimStream<K, Integer> minInt(final MapWindowedSwimStream<K, Integer, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Integer> minInt(final MapWindowedSwimStream<K, T, W> values, final ToIntFunction<T> transform) {
+    return values.fold(Integer.MAX_VALUE, (k, w, u, v) -> Math.min(u, transform.applyAsInt(v)), Form.forInteger());
+  }
+
+  public static SwimStream<Integer> maxInt(final SwimStream<Integer> values) {
+    return values.reduce(Math::max);
+  }
+
+  public static SwimStream<Integer> maxInt(final SwimStream<Integer> values, final Sampling sampling) {
+    return values.reduce(Math::max, sampling);
+  }
+
+  public static <W> SwimStream<Integer> maxInt(final WindowedSwimStream<Integer, W> values) {
+    return values.reduce((w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Integer> maxInt(final WindowedSwimStream<T, W> values, final ToIntFunction<T> transform) {
+    return values.fold(Integer.MIN_VALUE, (w, u, v) -> Math.max(u, transform.applyAsInt(v)), Form.forInteger());
+  }
+
+  public static <K, W> MapSwimStream<K, Integer> maxInt(final MapWindowedSwimStream<K, Integer, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Integer> maxInt(final MapWindowedSwimStream<K, T, W> values, final ToIntFunction<T> transform) {
+    return values.fold(Integer.MIN_VALUE, (k, w, u, v) -> Math.max(u, transform.applyAsInt(v)), Form.forInteger());
+  }
+
+  public static SwimStream<Long> minLong(final SwimStream<Long> values) {
+    return values.reduce(Math::min);
+  }
+
+  public static SwimStream<Long> minLong(final SwimStream<Long> values, final Sampling sampling) {
+    return values.reduce(Math::min, sampling);
+  }
+
+  public static <W> SwimStream<Long> minLong(final WindowedSwimStream<Long, W> values) {
+    return values.reduce((w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Long> minLong(final WindowedSwimStream<T, W> values, final ToLongFunction<T> transform) {
+    return values.fold(Long.MAX_VALUE, (w, u, v) -> Math.min(u, transform.applyAsLong(v)), Form.forLong());
+  }
+
+  public static <K, W> MapSwimStream<K, Long> minLong(final MapWindowedSwimStream<K, Long, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.min(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Long> minLong(final MapWindowedSwimStream<K, T, W> values, final ToLongFunction<T> transform) {
+    return values.fold(Long.MAX_VALUE, (k, w, u, v) -> Math.min(u, transform.applyAsLong(v)), Form.forLong());
+  }
+
+  public static SwimStream<Long> maxLong(final SwimStream<Long> values) {
+    return values.reduce(Math::max);
+  }
+
+  public static SwimStream<Long> maxLong(final SwimStream<Long> values, final Sampling sampling) {
+    return values.reduce(Math::max, sampling);
+  }
+
+  public static <W> SwimStream<Long> maxLong(final WindowedSwimStream<Long, W> values) {
+    return values.reduce((w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <T, W> SwimStream<Long> maxLong(final WindowedSwimStream<T, W> values, final ToLongFunction<T> transform) {
+    return values.fold(Long.MIN_VALUE, (w, u, v) -> Math.max(u, transform.applyAsLong(v)), Form.forLong());
+  }
+
+  public static <K, W> MapSwimStream<K, Long> maxLong(final MapWindowedSwimStream<K, Long, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> Math.max(v1, v2));
+  }
+
+  public static <K, T, W> MapSwimStream<K, Long> maxLong(final MapWindowedSwimStream<K, T, W> values, final ToLongFunction<T> transform) {
+    return values.fold(Long.MIN_VALUE, (k, w, u, v) -> Math.min(u, transform.applyAsLong(v)), Form.forLong());
+  }
+
+  static <T extends Comparable<T>> T min(final T left, final T right) {
+    if (left.compareTo(right) <= 0) {
+      return left;
+    } else {
+      return  right;
+    }
+  }
+
+  static <T extends Comparable<T>> T max(final T left, final T right) {
+    if (left.compareTo(right) >= 0) {
+      return left;
+    } else {
+      return  right;
+    }
+  }
+
+  public static <T extends Comparable<T>> SwimStream<T> min(final SwimStream<T> values) {
+    return values.reduce(StreamStatistics::min);
+  }
+
+  public static <T extends Comparable<T>> SwimStream<T> min(final SwimStream<T> values, final Sampling sampling) {
+    return values.reduce(StreamStatistics::min, sampling);
+  }
+
+  public static <T extends Comparable<T>, W> SwimStream<T> min(final WindowedSwimStream<T, W> values) {
+    return values.reduce((w, v1, v2) -> StreamStatistics.min(v1, v2));
+  }
+
+  public static <K, T extends Comparable<T>, W> MapSwimStream<K, T> min(final MapWindowedSwimStream<K, T, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> StreamStatistics.min(v1, v2));
+  }
+
+  public static <T extends Comparable<T>> SwimStream<T> max(final SwimStream<T> values) {
+    return values.reduce(StreamStatistics::max);
+  }
+
+  public static <T extends Comparable<T>> SwimStream<T> max(final SwimStream<T> values, final Sampling sampling) {
+    return values.reduce(StreamStatistics::max, sampling);
+  }
+
+  public static <T extends Comparable<T>, W> SwimStream<T> max(final WindowedSwimStream<T, W> values) {
+    return values.reduce((w, v1, v2) -> StreamStatistics.max(v1, v2));
+  }
+
+  public static <K, T extends Comparable<T>, W> MapSwimStream<K, T> max(final MapWindowedSwimStream<K, T, W> values) {
+    return values.reduceByKey((k, w, v1, v2) -> StreamStatistics.max(v1, v2));
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/model/Mean.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/model/Mean.java
@@ -1,0 +1,150 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.statistics.model;
+
+import swim.dataflow.graph.Require;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Type to reduce the mean of a stream of values.
+ */
+public final class Mean {
+
+  private final double mean;
+
+  private final long count;
+
+  /**
+   * @param meanAc The accumulated mean.
+   * @param n The number of observations.
+   */
+  private Mean(final double meanAc, final long n) {
+    mean = meanAc;
+    count = n;
+  }
+
+  /**
+   * Create a mean object.
+   * @param sumValues The sum of the observations.
+   * @param n The number of observations.
+   * @return The mean.
+   */
+  public static Mean of(final double sumValues, final long n) {
+    Require.that(n >= 0, "Count for a mean must be non-negative.");
+    Require.that(n > 0 || sumValues == 0, "Sum of no values must be 0.0.");
+    return new Mean(sumValues / n, n);
+  }
+
+  public static Mean of(final double value) {
+    return new Mean(value, 1);
+  }
+
+  /**
+   * @return The mean value.
+   */
+  public double get() {
+    return mean;
+  }
+
+  /**
+   * @return The sum of the observations.
+   */
+  public double getSum() {
+    return mean * count;
+  }
+
+  /**
+   * @return The count of observations.
+   */
+  public long getCount() {
+    return count;
+  }
+
+  /**
+   * Add a value into the mean.
+   * @param value The value.
+   * @return The new mean.
+   */
+  public Mean add(final double value) {
+    final double delta = value - mean;
+    final double newMean = mean + (delta / (count + 1));
+    return new Mean(newMean, count + 1);
+  }
+
+  /**
+   * Combine together two means.
+   * @param m1 The first mean.
+   * @param m2 The second mean.
+   * @return The combined mean.
+   */
+  public static Mean combine(final Mean m1, final Mean m2) {
+    final double delta = m2.mean - m1.mean;
+    final long newCount = m1.count + m2.count;
+    final double newMean = m1.mean + delta * ((double) m2.count / (double) newCount);
+
+    return new Mean(newMean, newCount);
+  }
+
+  /**
+   * Combine this mean with another.
+   * @param other The other mean.
+   * @return The combined mean.
+   */
+  public Mean combine(final Mean other) {
+    return combine(this, other);
+  }
+
+
+  public static final Form<Mean> FORM = new Form<Mean>() {
+    @Override
+    public Class<?> type() {
+      return Mean.class;
+    }
+
+    @Override
+    public String tag() {
+      return "mean";
+    }
+
+    @Override
+    public Item mold(final Mean mean) {
+      if (mean != null) {
+        return Record.create(1).attr(tag(), Record.create(2)
+            .item(mean.mean).item(mean.count));
+      } else {
+        return Item.absent();
+      }
+    }
+
+    @Override
+    public Mean cast(final Item item) {
+      final Value header = item.toValue().header(tag());
+      if (header.isDefined()) {
+        final double meanAcc = header.getItem(0).doubleValue();
+        final long count = header.getItem(1).longValue();
+        return Mean.of(meanAcc, count);
+      } else {
+        return null;
+      }
+    }
+
+  };
+
+  public static final Mean ZERO = new Mean(0.0, 0);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/model/SummaryStatistics.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/statistics/model/SummaryStatistics.java
@@ -1,0 +1,196 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.statistics.model;
+
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Accumulation type for very simple summary statistics.
+ */
+public final class SummaryStatistics {
+
+  private final double mean;
+
+  private final double var;
+
+  private final long count;
+
+  private final double min;
+
+  private final double max;
+
+  /**
+   * @param meanVal Current value of the mean.
+   * @param varAcc Current accumulated variance.
+   * @param n Current count of observations.
+   * @param minVal The minimum observed value.
+   * @param maxVal The maximum observed value.
+   */
+  private SummaryStatistics(final double meanVal, final double varAcc, final long n, final double minVal, final double maxVal) {
+    mean = meanVal;
+    var = varAcc;
+    count = n;
+    min = minVal;
+    max = maxVal;
+  }
+
+  public double getMean() {
+    return mean;
+  }
+
+  public long getCount() {
+    return count;
+  }
+
+  /**
+   * @return Population variance of observed values.
+   */
+  public double getVariance() {
+    return var;
+  }
+
+  /**
+   * @return Population standard deviation of observed values.
+   */
+  public double getStdDev() {
+    return Math.sqrt(getVariance());
+  }
+
+  /**
+   * @return Sample variance based on observed data.
+   */
+  public double getSampleVariance() {
+    return count < 2 ? 0.0 : var * ((double) count / (double) (count - 1));
+  }
+
+  /**
+   * @return Sample variance based on observed data.
+   */
+  public double getSampleStdDev() {
+    return Math.sqrt(getSampleVariance());
+  }
+
+  public double getMin() {
+    return min;
+  }
+
+  public double getMax() {
+    return max;
+  }
+
+  /**
+   * Create a record based on a single vale.
+   * @param value The value.
+   * @return The trivial statistics object.
+   */
+  public static SummaryStatistics of(final double value) {
+    return new SummaryStatistics(value, 0.0, 1, value, value);
+  }
+
+  /**
+   * Combine together two summaries.
+   * @param s1 The first summary.
+   * @param s2 The second summary.
+   * @return The combined summary.
+   */
+  public static SummaryStatistics combine(final SummaryStatistics s1, final SummaryStatistics s2) {
+    final double m1 = s1.mean;
+
+    final long n1 = s1.count;
+    final long n2 = s2.count;
+
+    final long newCount = n1 + n2;
+
+    final double delta = s2.mean - m1;
+
+    final double newMean = m1 + (delta * n2) / newCount;
+
+    final double varDelta = s2.var - s1.var;
+
+    final double c1 = delta * ((double) n1 / (double) newCount);
+    final double c2 = delta * ((double) n2 / (double) newCount);
+
+    final double newM2Acc = s1.var + varDelta * ((double) n2 / (double) newCount) + c1 * c2;
+
+    return new SummaryStatistics(newMean, newM2Acc, newCount, Math.min(s1.min, s2.min), Math.max(s1.max, s2.max));
+  }
+
+  /**
+   * Combine this summary with another.
+   * @param other The other summary.
+   * @return The combined summary.
+   */
+  public SummaryStatistics combine(final SummaryStatistics other) {
+    return combine(this, other);
+  }
+
+  /**
+   * Add a value into this summary.
+   * @param value The value.
+   * @return The new summary.
+   */
+  public SummaryStatistics add(final double value) {
+    return combine(this, SummaryStatistics.of(value));
+  }
+
+  public static final SummaryStatistics ZERO = new SummaryStatistics(
+      0.0, 0.0, 0, 0.0, 0.0);
+
+  public static final  Form<SummaryStatistics> FORM = new Form<SummaryStatistics>() {
+
+    @Override
+    public Class<?> type() {
+      return SummaryStatistics.class;
+    }
+
+    @Override
+    public String tag() {
+      return "summaryStatistics";
+    }
+
+    @Override
+    public Item mold(final SummaryStatistics stats) {
+      if (stats != null) {
+        return Record.create(1).attr(tag(), Record.create(5)
+            .item(stats.mean)
+            .item(stats.count)
+            .item(stats.var)
+            .item(stats.min)
+            .item(stats.max));
+      } else {
+        return Item.absent();
+      }
+    }
+
+    @Override
+    public SummaryStatistics cast(final Item item) {
+      final Value header = item.toValue().header(tag());
+      if (header.isDefined()) {
+        final double mean = header.getItem(0).doubleValue();
+        final long count = header.getItem(1).longValue();
+        final double var = header.getItem(2).doubleValue();
+        final double min = header.getItem(3).doubleValue();
+        final double max = header.getItem(4).doubleValue();
+        return new SummaryStatistics(mean, var, count, min, max);
+      } else {
+        return null;
+      }
+    }
+  };
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/TimestampAssigner.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/TimestampAssigner.java
@@ -1,0 +1,101 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.timestamps;
+
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
+
+/**
+ * Assignment of timestamps to records. This can either be based on the content of values of the type or drawn from
+ * an external clock.
+ * @param <T> The type of the records.
+ */
+public interface TimestampAssigner<T> extends ToLongFunction<T> {
+
+  /**
+   * Distinguish between record based timestamp assignment and clock based.
+   * @param fromData Function to call for record timestamps.
+   * @param fromClock Function to call for clock timestamps.
+   * @param <U> The output type.
+   * @return The result.
+   */
+  <U> U match(Function<ToLongFunction<T>, U> fromData, Function<LongSupplier, U> fromClock);
+
+  /**
+   * Record based time stamps.
+   * @param ts The timestamp assignment function.
+   * @param <T> The type of the records.
+   * @return The timestamp assigner.
+   */
+  static <T> TimestampAssigner<T> fromData(final ToLongFunction<T> ts) {
+    return new DataTimestampAssigner<>(ts);
+  }
+
+  /**
+   * Clock based time stamps.
+   * @param <T> The type of the records.
+   * @return The clock.
+   */
+  static <T> TimestampAssigner<T> fromClock() {
+    return SystemClockAssigner.instance();
+  }
+}
+
+final class DataTimestampAssigner<T> implements TimestampAssigner<T> {
+
+  private final ToLongFunction<T> ts;
+
+  DataTimestampAssigner(final ToLongFunction<T> ts) {
+    this.ts = ts;
+  }
+
+  @Override
+  public long applyAsLong(final T value) {
+    return ts.applyAsLong(value);
+  }
+
+  @Override
+  public <U> U match(final Function<ToLongFunction<T>, U> fromData, final Function<LongSupplier, U> fromClock) {
+    return fromData.apply(ts);
+  }
+}
+
+final class SystemClockAssigner<T> implements TimestampAssigner<T>, LongSupplier {
+
+  private SystemClockAssigner() { }
+
+  private static final SystemClockAssigner<Object> INSTANCE = new SystemClockAssigner<>();
+
+  @SuppressWarnings("unchecked")
+  static <T> SystemClockAssigner<T> instance() {
+    return (SystemClockAssigner<T>) INSTANCE;
+  }
+
+  @Override
+  public long getAsLong() {
+    return System.currentTimeMillis();
+  }
+
+  @Override
+  public long applyAsLong(final T value) {
+    return getAsLong();
+  }
+
+  @Override
+  public <U> U match(final Function<ToLongFunction<T>, U> fromData, final Function<LongSupplier, U> fromClock) {
+    return fromClock.apply(this);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/TimestampContext.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/TimestampContext.java
@@ -1,0 +1,36 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.timestamps;
+
+/**
+ * A clock for managing events relative to a timescale.
+ */
+public interface TimestampContext {
+
+  /**
+   * Get the current timestamp, according to the clock, in ms.
+   *
+   * @return The timestamp.
+   */
+  long currentTimestamp();
+
+  /**
+   * Schedule a callback after the clock reaches a specified timestamp.
+   *
+   * @param ts The timestamp.
+   */
+  void scheduleAt(long ts);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/Timestamps.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/Timestamps.java
@@ -1,0 +1,37 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.timestamps;
+
+import java.util.function.ToLongFunction;
+
+/**
+ * Timestamp utility methods.
+ */
+public final class Timestamps {
+
+  private Timestamps() {
+  }
+
+  /**
+   * Timestamps based on the system clock.
+   *
+   * @param <T> The type of the values.
+   * @return The timestamp assigner.
+   */
+  public static <T> ToLongFunction<T> fromClock() {
+    return val -> System.currentTimeMillis();
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/WithTimestamp.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/timestamps/WithTimestamp.java
@@ -1,0 +1,112 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.timestamps;
+
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+import swim.util.Murmur3;
+
+public class WithTimestamp<T> {
+
+  private final T data;
+  private final long timestamp;
+
+  public WithTimestamp(final T item, final long ts) {
+    data = item;
+    timestamp = ts;
+  }
+
+  public T getData() {
+    return data;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof WithTimestamp)) {
+      return false;
+    } else {
+      final WithTimestamp<?> other = (WithTimestamp<?>) obj;
+      return data.equals(other.data) && timestamp == other.timestamp;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashSeed == 0) {
+      hashSeed = Murmur3.seed(WithTimestamp.class);
+    }
+    return Murmur3.mash(Murmur3.mix(data.hashCode(), Murmur3.mix(Murmur3.hash(timestamp), hashSeed)));
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public String toString() {
+    return String.format("WithTimestamp[item=%s, timestamp=%d]", data, timestamp);
+  }
+
+  public static <T> Form<WithTimestamp<T>> form(final Form<T> form) {
+    return new WithTimestampForm<>(form);
+  }
+
+  private static final class WithTimestampForm<T> extends Form<WithTimestamp<T>> {
+
+    private final Form<T> form;
+
+    WithTimestampForm(final Form<T> form) {
+      this.form = form;
+    }
+
+    @Override
+    public String tag() {
+      return "withTimestamp";
+    }
+
+    @Override
+    public Class<?> type() {
+      return WithTimestamp.class;
+    }
+
+    @Override
+    public Item mold(final WithTimestamp<T> rec) {
+      if (rec != null) {
+        return Record.create(1).attr(tag(), Record.create(2)
+            .item(form.mold(rec.data)).item(rec.timestamp));
+      } else {
+        return Item.absent();
+      }
+    }
+
+    @Override
+    public WithTimestamp<T> cast(final Item item) {
+      final Value header = item.toValue().header(tag());
+      if (header.isDefined()) {
+        final T data = form.cast(header.getItem(0));
+        final long ts = header.getItem(1).longValue();
+        return new WithTimestamp<>(data, ts);
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/CombinedState.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/CombinedState.java
@@ -1,0 +1,36 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Set;
+
+/**
+ * A combined store for partition and window labels.
+ *
+ * @param <P> The type of the partitions.
+ * @param <W> The type of the windows.
+ * @param <Self> The type of the implementing class.
+ */
+public interface CombinedState<P, W, Self> extends PartitionState<P, Self> {
+
+  /**
+   * Get the open windows in a partition.
+   *
+   * @param part The partition.
+   * @return The set of open windows.
+   */
+  Set<W> openWindows(P part);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/CombinedWindowAssigner.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/CombinedWindowAssigner.java
@@ -1,0 +1,68 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import swim.dataflow.graph.timestamps.TimestampContext;
+
+/**
+ * Assigns both partitions and windows to values of a stream.
+ *
+ * @param <T> The type of the stream values.
+ * @param <P> The type of the partitions.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the partition/window state store.
+ */
+public interface CombinedWindowAssigner<T, P, W, S extends CombinedState<P, W, S>> {
+
+  /**
+   * @return A factory for empty partition/window states.
+   */
+  Supplier<S> stateFactory();
+
+  /**
+   * Get the partition and window assignment for an value.
+   *
+   * @param value       The value.
+   * @param time        The timestamp of the value.
+   * @param openWindows Currently open windows and partitions.
+   * @return The assignment of partitions and windows.
+   */
+  Assignment<P, W, S> partitionWindowsFor(T value, TimestampContext time, S openWindows);
+
+  /**
+   * An assignment of partition and windows for an element.
+   *
+   * @param <P> The type of the partitions.
+   * @param <W> The type of the windows.
+   * @param <S> The type of the partition/window state store.
+   */
+  interface Assignment<P, W, S> {
+
+    /**
+     * @return Windows for each assigned partition.
+     */
+    Map<P, Set<W>> partitionedWindows();
+
+    /**
+     * @return The new state store.
+     */
+    S updatedState();
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/Group.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/Group.java
@@ -1,0 +1,32 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Interface for an algebraic group operation.
+ *
+ * @param <T> The type of the values.
+ */
+public interface Group<T> {
+
+  T zero();
+
+  T add(T first, T second);
+
+  T subtract(T first, T second);
+
+  T negate(T value);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/IntervalWindow.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/IntervalWindow.java
@@ -1,0 +1,27 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * A window that covers a (possibly moving) interval of time.
+ */
+public interface IntervalWindow {
+
+  /**
+   * @return The length of the window in ms.
+   */
+  long length();
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/InvertibleFolder.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/InvertibleFolder.java
@@ -1,0 +1,31 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * A fold operation that can be inverted.
+ *
+ * @param <T> The type of the contributing elements.
+ * @param <U> The type of the result.
+ */
+public interface InvertibleFolder<T, U> {
+
+  U zero();
+
+  U add(U state, T data);
+
+  U subtract(U state, T data);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowBinOp.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowBinOp.java
@@ -1,0 +1,27 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Binary operation for aggregating keyed, windowed streams.
+ *
+ * @param <K> The type of the keys.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+@FunctionalInterface
+public interface KeyedWindowBinOp<K, T, W> extends KeyedWindowFoldFunction<K, T, W, T> {
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowFoldFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowFoldFunction.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Operation for folding keyed, windowed streams.
+ *
+ * @param <K> The type of the keys.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <U> The result type.
+ */
+@FunctionalInterface
+public interface KeyedWindowFoldFunction<K, T, W, U> {
+
+  U apply(K key, W window, U state, T data);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowFunction.java
@@ -1,0 +1,30 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Function to collapse the content of a keyed window.
+ *
+ * @param <K> The type of the keys.
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <U> The type of the result.
+ */
+@FunctionalInterface
+public interface KeyedWindowFunction<K, T, W, U> {
+
+  U apply(K key, W window, Iterable<T> contents);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/KeyedWindowSpec.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.function.Function;
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+public final class KeyedWindowSpec<K, V, W, S extends WindowState<W, S>> {
+
+  private final Function<K, TemporalWindowAssigner<V, W, S>> assigner;
+  private final Function<K, Trigger<V, W>> trigger;
+  private final Function<K, EvictionStrategy<V, W>> eviction;
+  private final Form<W> windowForm;
+  private final boolean isTransient;
+
+  public KeyedWindowSpec(final Function<K, TemporalWindowAssigner<V, W, S>> assigner,
+                         final Function<K, Trigger<V, W>> trigger,
+                         final Function<K, EvictionStrategy<V, W>> strategy,
+                         final Form<W> windowForm,
+                         final boolean isTransient) {
+    this.assigner = assigner;
+    this.trigger = trigger;
+    eviction = strategy;
+    this.windowForm = windowForm;
+    this.isTransient = isTransient;
+  }
+
+  public Function<K, TemporalWindowAssigner<V, W, S>> getAssigner() {
+    return assigner;
+  }
+
+  public Function<K, Trigger<V, W>> getTrigger() {
+    return trigger;
+  }
+
+  public Function<K, EvictionStrategy<V, W>> getEvictionStrategy() {
+    return eviction;
+  }
+
+  public Form<W> getWindowForm() {
+    return windowForm;
+  }
+
+  public boolean isTransient() {
+    return isTransient;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/PartitionAssigner.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/PartitionAssigner.java
@@ -1,0 +1,56 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * Assigns partitions to elements of a stream.
+ *
+ * @param <T> The type of the elements.
+ * @param <P> The type of the partitions.
+ * @param <S> The type of the state store for the active partitions.
+ */
+public interface PartitionAssigner<T, P, S extends PartitionState<P, S>> {
+
+  /**
+   * @return A factory for empty partition state stores.
+   */
+  Supplier<S> stateFactory();
+
+  /**
+   * Get the partitions for an element.
+   *
+   * @param data The element.
+   * @param activePartitions Currently active partitions.
+   * @return The partition assignment.
+   */
+  Assignment<P, S> partitionsFor(T data, S activePartitions);
+
+  interface Assignment<P, S> {
+
+    /**
+     * @return The set of partitions.
+     */
+    Set<P> partitions();
+
+    /**
+     * @return The updated partition state store.
+     */
+    S updatedState();
+
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/PartitionState.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/PartitionState.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Set;
+
+/**
+ * State store of open partitions.
+ *
+ * @param <P> The type of the partitions.
+ * @param <Self> The type of the implementing class.
+ */
+public interface PartitionState<P, Self> {
+
+  /**
+   * @return The set of currently open partitions.
+   */
+  Set<P> activePartitions();
+
+  /**
+   * Remove a partition from the store.
+   *
+   * @param partititon The partition to remove.
+   * @return The new store formed by removing the window.
+   */
+  Self removePartition(P partititon);
+
+  /**
+   * Add a window to the store.
+   *
+   * @param partition The partition to add.
+   * @return The new store formed by adding the window.
+   */
+  Self addPartition(P partition);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SeqWindowStore.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SeqWindowStore.java
@@ -1,0 +1,71 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import swim.collections.FingerTrieSeq;
+
+/**
+ * Store that holds windows in a linear sequence.
+ *
+ * @param <W> The type of the windows.
+ */
+public class SeqWindowStore<W> implements WindowState<W, SeqWindowStore<W>> {
+
+  /**
+   * The sequence of the windows.
+   */
+  private final FingerTrieSeq<W> windows;
+
+  public SeqWindowStore() {
+    this(FingerTrieSeq.empty());
+  }
+
+  /**
+   * @param init The sequence of windows for the store.
+   */
+  public SeqWindowStore(final FingerTrieSeq<W> init) {
+    windows = init;
+  }
+
+  /**
+   * @return The contents of the store.
+   */
+  public FingerTrieSeq<W> getWindows() {
+    return windows;
+  }
+
+  @Override
+  public Set<W> openWindows() {
+    final HashSet<W> winSet = new HashSet<>(windows);
+    return Collections.unmodifiableSet(winSet);
+  }
+
+  @Override
+  public SeqWindowStore<W> removeWindow(final W window) {
+    return new SeqWindowStore<>(windows.removed(window));
+  }
+
+  @Override
+  public SeqWindowStore<W> addWindow(final W window) {
+    if (windows.contains(window)) {
+      return this;
+    } else {
+      return new SeqWindowStore<>(windows.appended(window));
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SingletonWindowStore.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SingletonWindowStore.java
@@ -1,0 +1,53 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Window store with a single, fixed window.
+ *
+ * @param <W> The type of the window.
+ */
+public class SingletonWindowStore<W> implements WindowState<W, SingletonWindowStore<W>> {
+
+  /**
+   * The single window.
+   */
+  private final W window;
+
+  /**
+   * @param content The fixed window.
+   */
+  public SingletonWindowStore(final W content) {
+    window = content;
+  }
+
+  @Override
+  public Set<W> openWindows() {
+    return Collections.singleton(window);
+  }
+
+  @Override
+  public SingletonWindowStore<W> removeWindow(final W window) {
+    return this;
+  }
+
+  @Override
+  public SingletonWindowStore<W> addWindow(final W window) {
+    return this;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SlidingInterval.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SlidingInterval.java
@@ -1,0 +1,98 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import swim.dataflow.graph.Require;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+import swim.util.Murmur3;
+
+/**
+ * A fixed length window that slides with the data that is added to it, having no fixed beginning and end.
+ */
+public class SlidingInterval implements IntervalWindow {
+
+  /**
+   * The length of the window in ms.
+   */
+  private final long len;
+
+  public SlidingInterval(final long windowLen) {
+    Require.that(windowLen > 0, "The length of the window must be positive.");
+    len = windowLen;
+  }
+
+  @Override
+  public long length() {
+    return len;
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashSeed == 0) {
+      hashSeed = Murmur3.seed(TimeInterval.class);
+    }
+    return Murmur3.mash(Murmur3.mix(Murmur3.hash(len), hashSeed));
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof SlidingInterval) {
+      final SlidingInterval other = (SlidingInterval) obj;
+      return len == other.len;
+    } else {
+      return false;
+    }
+  }
+
+  public static final Form<SlidingInterval> FORM = new Form<SlidingInterval>() {
+    @Override
+    public Class<?> type() {
+      return SlidingInterval.class;
+    }
+
+    @Override
+    public String tag() {
+      return "slidingInterval";
+    }
+
+    @Override
+    public Item mold(final SlidingInterval interval) {
+      if (interval != null) {
+        return Record.create(1).attr(tag(), Record.create(1)
+            .item(interval.len));
+      } else {
+        return Item.absent();
+      }
+    }
+
+    @Override
+    public SlidingInterval cast(final Item item) {
+      final Value header = item.toValue().header(tag());
+      if (header.isDefined()) {
+        final long len = header.getItem(0).longValue();
+        return new SlidingInterval(len);
+      } else {
+        return null;
+      }
+    }
+  };
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SmoothSlidingWindows.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/SmoothSlidingWindows.java
@@ -1,0 +1,69 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Assigner of smoothly sliding, fixed length widows. Values will reduce into the window until the fixed length
+ * is reached.  The assigner assigns the same window to every value.
+ *
+ * @param <T> The type of the values.
+ */
+public class SmoothSlidingWindows<T> implements TemporalWindowAssigner<T, SlidingInterval, SingletonWindowStore<SlidingInterval>> {
+
+  private final SlidingInterval window;
+
+  /**
+   * @param window The fixed window.
+   */
+  public SmoothSlidingWindows(final SlidingInterval window) {
+    this.window = window;
+  }
+
+  @Override
+  public Function<Set<SlidingInterval>, SingletonWindowStore<SlidingInterval>> stateInitializer() {
+    return windows -> {
+      if (windows.size() > 2) {
+        throw new IllegalStateException("A maximum of one window is permissible.");
+      }
+      for (final SlidingInterval w : windows) {
+        if (!window.equals(w)) {
+          throw new IllegalStateException(String.format("Singleton window mismatch %s != %s.", w, window));
+        }
+      }
+      return new SingletonWindowStore<>(window);
+    };
+  }
+
+  @Override
+  public Assignment<SlidingInterval, SingletonWindowStore<SlidingInterval>> windowsFor(final T value,
+                                                                                       final long timestamp,
+                                                                                       final SingletonWindowStore<SlidingInterval> openWindows) {
+    return new Assignment<SlidingInterval, SingletonWindowStore<SlidingInterval>>() {
+      @Override
+      public Set<SlidingInterval> windows() {
+        return Collections.singleton(window);
+      }
+
+      @Override
+      public SingletonWindowStore<SlidingInterval> updatedState() {
+        return openWindows;
+      }
+    };
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TemporalWindowAssigner.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TemporalWindowAssigner.java
@@ -1,0 +1,56 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Divides a stream of values into windows by time.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the state tracking open windows.
+ */
+public interface TemporalWindowAssigner<T, W, S extends WindowState<W, S>> {
+
+  /**
+   * @return A factory for state stores.
+   */
+  Function<Set<W>, S> stateInitializer();
+
+  Assignment<W, S> windowsFor(T value, long timestamp, S openWindows);
+
+  /**
+   * An assignment of a value to windows.
+   *
+   * @param <W> The type of the windows.
+   * @param <S> The type of the state tracking open windows.
+   */
+  interface Assignment<W, S> {
+
+    /**
+     * @return Windows to which the value contributes.
+     */
+    Set<W> windows();
+
+    /**
+     * @return The new value of the state store.
+     */
+    S updatedState();
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TimeInterval.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TimeInterval.java
@@ -1,0 +1,127 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import swim.dataflow.graph.Require;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Kind;
+import swim.structure.Record;
+import swim.structure.Value;
+import swim.util.Murmur3;
+
+/**
+ * Window representing a fixed time interval.
+ */
+public class TimeInterval implements IntervalWindow {
+
+  private final long start, end;
+
+  /**
+   * @param startTime The start of the interval in epoch ms (inclusive).
+   * @param endTime   The end of the interval in epoch ms (exclusive).
+   */
+  public TimeInterval(final long startTime, final long endTime) {
+    Require.that(endTime > startTime, String.format("End time %d is not after start time %d.", startTime, endTime));
+    start = startTime;
+    end = endTime;
+  }
+
+  /**
+   * @return The start of the interval in epoch ms (inclusive).
+   */
+  public long getStart() {
+    return start;
+  }
+
+  /**
+   * @return The end of the interval in epoch ms (exclusive).
+   */
+  public long getEnd() {
+    return end;
+  }
+
+  @Override
+  public long length() {
+    return end - start;
+  }
+
+  /**
+   * Determine if this interval contains a time stamp.
+   *
+   * @param t The time stamp in epoch ms.
+   * @return Whether the timestamp is in the interval.
+   */
+  public boolean contains(final long t) {
+    return t >= start && t < end;
+  }
+
+  @Override
+  public int hashCode() {
+    if (hashSeed == 0) {
+      hashSeed = Murmur3.seed(TimeInterval.class);
+    }
+    return Murmur3.mash(Murmur3.mix(Murmur3.hash(end), Murmur3.mix(Murmur3.hash(start), hashSeed)));
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj instanceof TimeInterval) {
+      final TimeInterval other = (TimeInterval) obj;
+      return start == other.start && end == other.end;
+    } else {
+      return false;
+    }
+  }
+
+  @Kind
+  public static final Form<TimeInterval> FORM = new Form<TimeInterval>() {
+    @Override
+    public Class<?> type() {
+      return TimeInterval.class;
+    }
+
+    @Override
+    public String tag() {
+      return "timeInterval";
+    }
+
+    @Override
+    public Item mold(final TimeInterval interval) {
+      if (interval != null) {
+        return Record.create(1).attr(tag(), Record.create(2)
+                .item(interval.start).item(interval.end));
+      } else {
+        return Item.absent();
+      }
+    }
+
+    @Override
+    public TimeInterval cast(final Item item) {
+      final Value header = item.toValue().header(tag());
+      if (header.isDefined()) {
+        final long start = header.getItem(0).longValue();
+        final long end = header.getItem(1).longValue();
+        return new TimeInterval(start, end);
+      } else {
+        return null;
+      }
+    }
+  };
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TumblingWindows.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/TumblingWindows.java
@@ -1,0 +1,127 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.Iterables;
+
+/**
+ * Assigns tumbling, mutually exclusive windows of a fixed length. A given value will belong to exactly one window.
+ *
+ * @param <T> The type of the values.
+ */
+public class TumblingWindows<T> implements TemporalWindowAssigner<T, TimeInterval, SeqWindowStore<TimeInterval>> {
+
+  private final Instant origin;
+  private final Duration length;
+
+  /**
+   * @param origin Origin for the windows (all windows will be aligned to this point).
+   * @param length The length of the windows.
+   */
+  public TumblingWindows(final Instant origin, final Duration length) {
+    this.origin = origin;
+    this.length = length;
+  }
+
+
+  @Override
+  public Function<Set<TimeInterval>, SeqWindowStore<TimeInterval>> stateInitializer() {
+    return windows -> {
+      for (final TimeInterval window : windows) {
+        validateWindow(window);
+      }
+      return new SeqWindowStore<>(FingerTrieSeq.from(windows));
+    };
+  }
+
+  private void validateWindow(final TimeInterval window) {
+    final TimeInterval aligned = alignWindow(origin, length, window.getStart());
+    if (!window.equals(aligned)) {
+      throw new IllegalStateException(String.format(
+          "Window %s is not compatible with this assignment strategy.", window));
+    }
+  }
+
+  @Override
+  public Assignment<TimeInterval, SeqWindowStore<TimeInterval>> windowsFor(final T value,
+                                                                           final long timestamp,
+                                                                           final SeqWindowStore<TimeInterval> openWindows) {
+
+    final Optional<TimeInterval> selected = Iterables.findFirst(openWindows.getWindows(), w -> w.contains(timestamp));
+
+    final TimeInterval window;
+    final SeqWindowStore<TimeInterval> newStore;
+    if (selected.isPresent()) {
+      window = selected.get();
+      newStore = openWindows;
+    } else {
+      window = alignWindow(origin, length, timestamp);
+      newStore = openWindows.addWindow(window);
+    }
+
+    return new Assignment<TimeInterval, SeqWindowStore<TimeInterval>>() {
+      @Override
+      public Set<TimeInterval> windows() {
+        return Collections.singleton(window);
+      }
+
+      @Override
+      public SeqWindowStore<TimeInterval> updatedState() {
+        return newStore;
+      }
+    };
+  }
+
+  /**
+   * Find the correctly aligned window containing a timestamp.
+   *
+   * @param origin Origin for the windows (all windows will be aligned to this point).
+   * @param length The length of the windows.
+   * @param timestamp The timestamp.
+   * @return The window containing the timestamp.
+   */
+  static TimeInterval alignWindow(final Instant origin, final Duration length, final long timestamp) {
+    final TimeInterval window;
+    final Instant time = Instant.ofEpochMilli(timestamp);
+    final Duration sinceOrigin = Duration.between(origin, time);
+
+    final long numDurations = dividedBy(sinceOrigin, length);
+
+    Instant windowStart = origin.plus(length.multipliedBy(numDurations));
+    //Handle case for negative offsets where rounding is in the wrong direction.
+    if (windowStart.isAfter(time)) {
+      windowStart = windowStart.minus(length);
+    }
+
+    final Instant windowEnd = windowStart.plus(length);
+    window = new TimeInterval(windowStart.toEpochMilli(), windowEnd.toEpochMilli());
+    return window;
+  }
+
+  private static long dividedBy(final Duration dur, final Duration divisor) {
+
+    final BigInteger num = BigInteger.valueOf(dur.toNanos());
+    final BigInteger div = BigInteger.valueOf(divisor.toNanos());
+    return num.divide(div).longValueExact();
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowBinOp.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowBinOp.java
@@ -1,0 +1,26 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Binary operation to reduce the contents of a window.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+@FunctionalInterface
+public interface WindowBinOp<T, W> extends WindowFoldFunction<T, W, T> {
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowFoldFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowFoldFunction.java
@@ -1,0 +1,29 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Operation to fold the contents of a window.
+ *
+ * @param <T> The type of the items in the window.
+ * @param <W> The type of the window.
+ * @param <U> The type of the result.
+ */
+@FunctionalInterface
+public interface WindowFoldFunction<T, W, U> {
+
+  U apply(W window, U state, T data);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowFunction.java
@@ -1,0 +1,29 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+/**
+ * Function to collapse the contents of a window.
+ *
+ * @param <T> The type of the window contents.
+ * @param <W> The type of the window.
+ * @param <U> The type of the result.
+ */
+@FunctionalInterface
+public interface WindowFunction<T, W, U> {
+
+  U apply(W window, Iterable<T> contents);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowSpec.java
@@ -1,0 +1,67 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import swim.dataflow.graph.windows.eviction.EvictionStrategy;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.structure.Form;
+
+/**
+ * Complete description of windowing for a stream.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ * @param <S> The type of the open windows state store.
+ */
+public final class WindowSpec<T, W, S extends WindowState<W, S>> {
+
+  private final TemporalWindowAssigner<T, W, S> assigner;
+  private final Trigger<T, W> trigger;
+  private final EvictionStrategy<T, W> eviction;
+  private final Form<W> windowForm;
+  private final boolean isTransient;
+
+  public WindowSpec(final TemporalWindowAssigner<T, W, S> assigner,
+                    final Trigger<T, W> trigger,
+                    final EvictionStrategy<T, W> strategy,
+                    final Form<W> windowForm,
+                    final boolean isTransient) {
+    this.assigner = assigner;
+    this.trigger = trigger;
+    eviction = strategy;
+    this.windowForm = windowForm;
+    this.isTransient = isTransient;
+  }
+
+  public TemporalWindowAssigner<T, W, S> getAssigner() {
+    return assigner;
+  }
+
+  public Trigger<T, W> getTrigger() {
+    return trigger;
+  }
+
+  public EvictionStrategy<T, W> getEvictionStrategy() {
+    return eviction;
+  }
+
+  public Form<W> getWindowForm() {
+    return windowForm;
+  }
+
+  public boolean isTransient() {
+    return isTransient;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowState.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/WindowState.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Set;
+
+/**
+ * Interface for state stores that track the windows that are currently open for a windowed stream.
+ *
+ * @param <W>    The type of the windows.
+ * @param <Self> The type of the state store (should be the class that ultimately implements this interface).
+ */
+public interface WindowState<W, Self> {
+
+  /**
+   * @return The set of open windows.
+   */
+  Set<W> openWindows();
+
+  /**
+   * Remove a window from the store.
+   *
+   * @param window The window to remove.
+   * @return The new store formed by removing the window.
+   */
+  Self removeWindow(W window);
+
+  /**
+   * Add a window to the store.
+   *
+   * @param window The window to add.
+   * @return The new store formed by adding the window.
+   */
+  Self addWindow(W window);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/Windows.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/Windows.java
@@ -1,0 +1,120 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import swim.dataflow.graph.windows.eviction.NoEviction;
+import swim.dataflow.graph.windows.eviction.ThresholdEviction;
+import swim.dataflow.graph.windows.triggers.TimeIntervalTrigger;
+import swim.dataflow.graph.windows.triggers.UnboundedTrigger;
+
+/**
+ * Utility class to create window specifications.
+ */
+public final class Windows {
+
+  private Windows() {
+  }
+
+  /**
+   * Tumbling, mutually exclusive fixed length windows. Each window will only fire when the timestamp passes beyond its
+   * end. Data will never be evicted and the window is purged after firing.
+   *
+   * @param length The length of the generated windows.
+   * @param <T>    The type of the values.
+   * @return The window specification.
+   */
+  public static <T> WindowSpec<T, TimeInterval, SeqWindowStore<TimeInterval>> tumbling(final Duration length) {
+    return tumbling(defaultOrigin(length), length);
+  }
+
+  /**
+   * Tumbling, mutually exclusive fixed length windows. Each window will only fire when the timestamp passes beyond its
+   * end. Data will never be evicted and the window is purged after firing.
+   *
+   * @param origin The origin to which windows should be aligned.
+   * @param length The length of the generated windows.
+   * @param <T>    The type of the values.
+   * @return The window specification.
+   */
+  public static <T> WindowSpec<T, TimeInterval, SeqWindowStore<TimeInterval>> tumbling(final Instant origin,
+                                                                                       final Duration length) {
+    return tumbling(origin, length, false);
+  }
+
+  /**
+   * Tumbling, mutually exclusive fixed length windows. Each window will only fire when the timestamp passes beyond its
+   * end. Data will never be evicted and the window is purged after firing.
+   *
+   * @param origin      The origin to which windows should be aligned.
+   * @param length      The length of the generated windows.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <T>         The type of the values.
+   * @return The window specification.
+   */
+  public static <T> WindowSpec<T, TimeInterval, SeqWindowStore<TimeInterval>> tumbling(final Instant origin,
+                                                                                       final Duration length,
+                                                                                       final boolean isTransient) {
+    return new WindowSpec<>(new TumblingWindows<>(origin, length),
+        new TimeIntervalTrigger<>(),
+        NoEviction.instance(),
+        TimeInterval.FORM, isTransient);
+  }
+
+  /**
+   * By default, windows will be aligned to 00:00 of the current day.
+   *
+   * @param length The length of the windows.
+   * @return The default origin.
+   */
+  private static Instant defaultOrigin(final Duration length) {
+    return Instant.now().truncatedTo(ChronoUnit.DAYS);
+  }
+
+  /**
+   * Assigns all values to a single smoothly sliding window. The window will fire after every values is added and
+   * data that has passed before the start of the window will be evicted. The window will never be purged.
+   *
+   * @param length The length of the window.
+   * @param <T>    The type of the values.
+   * @return The window specification.
+   */
+  public static <T> WindowSpec<T, SlidingInterval, SingletonWindowStore<SlidingInterval>> smoothSliding(final Duration length) {
+    return smoothSliding(length, false);
+  }
+
+  /**
+   * Assigns all values to a single smoothly sliding window. The window will fire after every values is added and
+   * data that has passed before the start of the window will be evicted. The window will never be purged.
+   *
+   * @param length      The length of the window.
+   * @param isTransient Whether the state of this stream is stored persistently.
+   * @param <T>         The type of the values.
+   * @return The window specification.
+   */
+  public static <T> WindowSpec<T, SlidingInterval, SingletonWindowStore<SlidingInterval>> smoothSliding(final Duration length,
+                                                                                                        final boolean isTransient) {
+    return new WindowSpec<>(new SmoothSlidingWindows<>(
+        new SlidingInterval(length.toMillis())),
+        new UnboundedTrigger<>(),
+        ThresholdEviction.byTimestamp(),
+        SlidingInterval.FORM,
+        isTransient);
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionCriterionFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionCriterionFunction.java
@@ -1,0 +1,35 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.eviction;
+
+/**
+ * Selects the criterion by which eviction of an element from a window should be assessed.
+ *
+ * @param <T> The type of the elements.
+ * @param <K> The type of the criterion.
+ */
+@FunctionalInterface
+public interface EvictionCriterionFunction<T, K> {
+
+  /**
+   * Determine the criterion.
+   *
+   * @param value     The element in the window.
+   * @param timestamp The timestamp of the element in the window.
+   * @return The criterion.
+   */
+  K apply(T value, long timestamp);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionStrategy.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionStrategy.java
@@ -1,0 +1,37 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.eviction;
+
+import java.util.function.Function;
+
+/**
+ * Strategy to determine when elements should be removed from a window, independently of when it fires.
+ *
+ * @param <T> The type of the elements.
+ * @param <W> The type of the window.
+ */
+public interface EvictionStrategy<T, W> {
+
+  /**
+   * Distinguish between the implementations.
+   *
+   * @param none      Called for no eviction.
+   * @param threshold Called for threshold based eviction.
+   * @param <U>       The type of the result.
+   * @return Result of the operation.
+   */
+  <U> U match(Function<NoEviction<T, W>, U> none, Function<ThresholdEviction<T, ?, W>, U> threshold);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionThresholdFunction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/EvictionThresholdFunction.java
@@ -1,0 +1,37 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.eviction;
+
+/**
+ * Threshold determination function for eviction. Anything in the window below this threshold will be evicted.
+ *
+ * @param <T> The type of the elements in teh window.
+ * @param <W> The type of the window.
+ * @param <K> The type of the eviction criterion.
+ */
+@FunctionalInterface
+public interface EvictionThresholdFunction<T, W, K> {
+
+  /**
+   * Determine the threshold for the window.
+   *
+   * @param value     The element that was added to the window most recently.
+   * @param window    The window.
+   * @param timestamp The timestamp fo the element that was added to the window most recently.
+   * @return The threshold value.
+   */
+  K apply(T value, W window, long timestamp);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/NoEviction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/NoEviction.java
@@ -1,0 +1,51 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.eviction;
+
+import java.util.function.Function;
+
+/**
+ * Specifies that no eviction from windows should take place.
+ *
+ * @param <T> The type of the elements in the window.
+ * @param <W> The type of the window.
+ */
+public final class NoEviction<T, W> implements EvictionStrategy<T, W> {
+
+  private NoEviction() {
+  }
+
+  /**
+   * Canonical instance.
+   */
+  private static final NoEviction<Object, Object> INSTANCE = new NoEviction<>();
+
+  /**
+   * Get the instance a specified type (the type parameters are both covariant so this is fine).
+   *
+   * @param <T> The type of the elements in the window.
+   * @param <W> The type of the window.
+   * @return The no eviction strategy.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T, W> NoEviction<T, W> instance() {
+    return (NoEviction<T, W>) INSTANCE;
+  }
+
+  @Override
+  public <U> U match(final Function<NoEviction<T, W>, U> none, final Function<ThresholdEviction<T, ?, W>, U> threshold) {
+    return none.apply(this);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/ThresholdEviction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/eviction/ThresholdEviction.java
@@ -1,0 +1,87 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.eviction;
+
+import java.util.function.Function;
+import swim.dataflow.graph.windows.IntervalWindow;
+import swim.structure.Form;
+
+/**
+ * Evict elements from the window by judging some criterion against a threshold.
+ *
+ * @param <T> The type of the elements in the window.
+ * @param <K> The type of the threshold criterion.
+ * @param <W> The type of the window.
+ */
+public final class ThresholdEviction<T, K extends Comparable<K>, W> implements EvictionStrategy<T, W> {
+
+  private final EvictionCriterionFunction<T, K> criterion;
+
+  private final EvictionThresholdFunction<T, W, K> threshold;
+
+  private final Form<K> criterionForm;
+
+  private final boolean assumeOrdered;
+
+  /**
+   * @param criterion     Determines the criterion from a value in the window.
+   * @param threshold     Determines the threshold for a window using the most recently added element.
+   * @param criterionForm The form of type of the criterion values.
+   * @param assumeOrdered Whether to assume that the state is ordered.
+   */
+  private ThresholdEviction(final EvictionCriterionFunction<T, K> criterion,
+                            final EvictionThresholdFunction<T, W, K> threshold,
+                            final Form<K> criterionForm, final boolean assumeOrdered) {
+    this.criterion = criterion;
+    this.threshold = threshold;
+    this.criterionForm = criterionForm;
+    this.assumeOrdered = assumeOrdered;
+  }
+
+  /**
+   * @param criterion     Determines the criterion from a value in the window.
+   * @param threshold     Determines the threshold for a window using the most recently added element.
+   * @param criterionForm The form of type of the criterion values.
+   */
+  public ThresholdEviction(final EvictionCriterionFunction<T, K> criterion,
+                           final EvictionThresholdFunction<T, W, K> threshold, final Form<K> criterionForm) {
+    this(criterion, threshold, criterionForm, false);
+  }
+
+  public EvictionCriterionFunction<T, K> getCriterion() {
+    return criterion;
+  }
+
+  public EvictionThresholdFunction<T, W, K> getThreshold() {
+    return threshold;
+  }
+
+  public Form<K> getCriterionForm() {
+    return criterionForm;
+  }
+
+  public boolean assumeStateOrdered() {
+    return assumeOrdered;
+  }
+
+  public static <T, W extends IntervalWindow> ThresholdEviction<T, Long, W> byTimestamp() {
+    return new ThresholdEviction<>((val, ts) -> ts, (val, win, ts) -> ts - win.length(), Form.forLong(), true);
+  }
+
+  @Override
+  public <U> U match(final Function<NoEviction<T, W>, U> none, final Function<ThresholdEviction<T, ?, W>, U> threshold) {
+    return threshold.apply(this);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/TimeIntervalTrigger.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/TimeIntervalTrigger.java
@@ -1,0 +1,49 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.triggers;
+
+import swim.dataflow.graph.timestamps.TimestampContext;
+import swim.dataflow.graph.windows.TimeInterval;
+
+/**
+ * A trigger that fires and purges the window after the end of a fixed time interval.
+ *
+ * @param <T> The type of the values.
+ */
+public class TimeIntervalTrigger<T> implements Trigger<T, TimeInterval> {
+
+  @Override
+  public TriggerAction onNewValue(final T data, final TimeInterval window, final TimestampContext time) {
+    time.scheduleAt(window.getEnd());
+    return TriggerAction.NONE;
+  }
+
+  @Override
+  public TriggerAction onTimer(final TimeInterval window, final TimestampContext time) {
+    return TriggerAction.TRIGGER_AND_PURGE;
+  }
+
+  @Override
+  public TriggerAction onRestore(final TimeInterval window, final TimestampContext time) {
+    final long current = time.currentTimestamp();
+    if (current >= window.getEnd()) {
+      return TriggerAction.PURGE;
+    } else {
+      time.scheduleAt(window.getEnd());
+      return TriggerAction.NONE;
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/Trigger.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/Trigger.java
@@ -1,0 +1,55 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.triggers;
+
+import swim.dataflow.graph.timestamps.TimestampContext;
+
+/**
+ * Strategy to determine when then contents of windows should be emitted. Triggers must be stateless.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+public interface Trigger<T, W> {
+
+  /**
+   * Determine what do do when a new value is added to a window.
+   *
+   * @param data   The new value.
+   * @param window The window.
+   * @param time   Clock for handling timestamps and events.
+   * @return Action to perform.
+   */
+  TriggerAction onNewValue(T data, W window, TimestampContext time);
+
+  /**
+   * Determine what to do when a timer event fires.
+   *
+   * @param window The window.
+   * @param time   Clock for handling timestamps and events.
+   * @return Action to perform.
+   */
+  TriggerAction onTimer(W window, TimestampContext time);
+
+  /**
+   * Determine what to do with a window that has been restored from a previous run.
+   *
+   * @param window The window.
+   * @param time   Clock for handling timestamps and events.
+   * @return Action to perform.
+   */
+  TriggerAction onRestore(W window, TimestampContext time);
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/TriggerAction.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/TriggerAction.java
@@ -1,0 +1,39 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.triggers;
+
+/**
+ * Action to perform when an window related event occurs.
+ */
+public enum TriggerAction {
+
+  /**
+   * No action required.
+   */
+  NONE,
+  /**
+   * Emit the contents of the window.
+   */
+  TRIGGER,
+  /**
+   * Dump the contents of the window and emit nothing.
+   */
+  PURGE,
+  /**
+   * Emit the contents of the window and dump the contents.
+   */
+  TRIGGER_AND_PURGE
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/UnboundedTrigger.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph/windows/triggers/UnboundedTrigger.java
@@ -1,0 +1,40 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows.triggers;
+
+import swim.dataflow.graph.timestamps.TimestampContext;
+
+/**
+ * A trigger that fires every time an element is added and never purges the window.
+ *
+ * @param <T> The type of the values.
+ * @param <W> The type of the windows.
+ */
+public class UnboundedTrigger<T, W> implements Trigger<T, W> {
+  @Override
+  public TriggerAction onNewValue(final T data, final W window, final TimestampContext time) {
+    return TriggerAction.TRIGGER;
+  }
+
+  @Override
+  public TriggerAction onTimer(final W window, final TimestampContext time) {
+    return TriggerAction.NONE;
+  }
+
+  @Override
+  public TriggerAction onRestore(final W window, final TimestampContext time) {
+    return TriggerAction.NONE;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/CollectionToMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/CollectionToMapConduitSpec.java
@@ -1,0 +1,215 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.structure.Form;
+import static swim.dataflow.graph.Pair.pair;
+
+public class CollectionToMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void initializeFromNothing(final boolean withState) {
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, String> persister = provider.forMap(
+          "state", Form.forInteger(), Form.forString());
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, persister);
+
+      initializeFromNothing(conduit);
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(1, 2, 3));
+      Assert.assertEquals(persister.get(1), "1");
+      Assert.assertEquals(persister.get(2), "2");
+      Assert.assertEquals(persister.get(3), "3");
+    } else {
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, Form.forString());
+
+      initializeFromNothing(conduit);
+    }
+  }
+
+  private void initializeFromNothing(final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit) {
+    final ArrayList<MapAction<Integer, String>> results = ConnectorTestUtil.pushData(
+        conduit, HashTrieSet.of(1, 2, 3));
+
+    Assert.assertEquals(results.size(), 3);
+
+    final HashSet<Integer> keys = new HashSet<>();
+    for (final MapAction<Integer, String> action : results) {
+      ConnectorTestUtil.expectUpdate(action, (k, v, m) -> {
+        keys.add(k);
+        Assert.assertEquals(v, k.toString());
+        Assert.assertEquals(m.size(), keys.size());
+        for (final Integer key : keys) {
+          Assert.assertTrue(m.containsKey(key));
+          Assert.assertEquals(m.get(key).get(), key.toString());
+        }
+      });
+    }
+  }
+
+  @Test(dataProvider = "withState")
+  public void addAdditionalEntry(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, String> persister = provider.forMap(
+          "state", Form.forInteger(), Form.forString());
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, persister);
+
+      addAdditionalEntry(conduit);
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(1, 2, 3, 4));
+      Assert.assertEquals(persister.get(1), "1");
+      Assert.assertEquals(persister.get(2), "2");
+      Assert.assertEquals(persister.get(3), "3");
+      Assert.assertEquals(persister.get(4), "4");
+    } else {
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, Form.forString());
+
+      addAdditionalEntry(conduit);
+    }
+
+  }
+
+  private void addAdditionalEntry(final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit) {
+    ConnectorTestUtil.pushData(
+        conduit, HashTrieSet.of(1, 2, 3));
+
+    final ArrayList<MapAction<Integer, String>> results = ConnectorTestUtil.pushData(
+        conduit, HashTrieSet.of(1, 2, 3, 4));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v, k.toString());
+      Assert.assertEquals(m.size(), 4);
+      for (int key = 1; key <= 4; ++key) {
+        Assert.assertTrue(m.containsKey(key));
+        Assert.assertEquals(m.get(key).get(), Integer.toString(key));
+      }
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void alterExistingEntry(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final MapPersister<Integer, String> persister = provider.forMap(
+          "state", Form.forInteger(), Form.forString());
+
+      final CollectionToMapConduit<Pair<Integer, String>, List<Pair<Integer, String>>, Integer, String> conduit =
+          new CollectionToMapConduit<>(Pair::getFirst, Pair::getSecond, persister);
+
+      alterExistingEntry(conduit);
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(1, 2, 3));
+      Assert.assertEquals(persister.get(1), "a");
+      Assert.assertEquals(persister.get(2), "NEW!");
+      Assert.assertEquals(persister.get(3), "c");
+    } else {
+      final CollectionToMapConduit<Pair<Integer, String>, List<Pair<Integer, String>>, Integer, String> conduit =
+          new CollectionToMapConduit<>(Pair::getFirst, Pair::getSecond, Form.forString());
+
+      alterExistingEntry(conduit);
+    }
+
+
+  }
+
+  private void alterExistingEntry(final CollectionToMapConduit<Pair<Integer, String>, List<Pair<Integer, String>>, Integer, String> conduit) {
+    ConnectorTestUtil.pushData(
+        conduit, Arrays.asList(pair(1, "a"), pair(2, "b"), pair(3, "c")));
+
+    final ArrayList<MapAction<Integer, String>> results = ConnectorTestUtil.pushData(
+        conduit, Arrays.asList(pair(1, "a"), pair(2, "NEW!"), pair(3, "c")));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v, "NEW!");
+      Assert.assertEquals(m.size(), 3);
+      Assert.assertEquals(m.get(1).get(), "a");
+      Assert.assertEquals(m.get(2).get(), "NEW!");
+      Assert.assertEquals(m.get(3).get(), "c");
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void removeExistingEntry(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, String> persister = provider.forMap(
+          "state", Form.forInteger(), Form.forString());
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, persister);
+
+      removeExistingEntry(conduit);
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(1, 3));
+      Assert.assertEquals(persister.get(1), "1");
+      Assert.assertEquals(persister.get(3), "3");
+    } else {
+      final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit =
+          new CollectionToMapConduit<>(n -> n, Object::toString, Form.forString());
+
+      removeExistingEntry(conduit);
+    }
+
+  }
+
+  private void removeExistingEntry(final CollectionToMapConduit<Integer, Set<Integer>, Integer, String> conduit) {
+    ConnectorTestUtil.pushData(
+        conduit, HashTrieSet.of(1, 2, 3));
+
+    final ArrayList<MapAction<Integer, String>> results = ConnectorTestUtil.pushData(
+        conduit, HashTrieSet.of(1, 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(1).get(), "1");
+      Assert.assertEquals(m.get(3).get(), "3");
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ConnectorTestUtil.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ConnectorTestUtil.java
@@ -24,6 +24,7 @@ import swim.concurrent.TimerFunction;
 import swim.concurrent.TimerRef;
 import swim.dataflow.graph.Either;
 import swim.dataflow.graph.Unit;
+import swim.util.Deferred;
 
 public final class ConnectorTestUtil {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ConnectorTestUtil.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ConnectorTestUtil.java
@@ -1,0 +1,426 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import swim.collections.HashTrieMap;
+import swim.concurrent.AbstractTimer;
+import swim.concurrent.Schedule;
+import swim.concurrent.TimerContext;
+import swim.concurrent.TimerFunction;
+import swim.concurrent.TimerRef;
+import swim.dataflow.graph.Either;
+import swim.dataflow.graph.Unit;
+
+public final class ConnectorTestUtil {
+
+  private ConnectorTestUtil() {
+  }
+
+  @SafeVarargs
+  public static <In, Out> ArrayList<Out> pushData(final Conduit<In, Out> conduit, final In... values) {
+    final ArrayList<Out> output = new ArrayList<>(values.length);
+    final Receptacle<Out> receptacle = x -> output.add(x.get());
+    conduit.subscribe(receptacle);
+    for (final In val : values) {
+      conduit.notifyChange(Deferred.value(val));
+    }
+    return output;
+  }
+
+  public interface MapAction<K, V> {
+
+    void push(MapReceptacle<K, V> receptacle);
+
+  }
+
+  @FunctionalInterface
+  public interface UpdateHandler<K, V> {
+
+    void onUpdate(K key, V value, MapView<K, V> map);
+
+  }
+
+  @FunctionalInterface
+  public interface RemovalHandler<K, V> {
+
+    void onRemove(K key, MapView<K, V> map);
+
+  }
+
+  private static class ExpectUpdate<K, V> implements MapReceptacle<K, V> {
+
+    private final UpdateHandler<K, V> handler;
+
+    ExpectUpdate(final UpdateHandler<K, V> handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      handler.onUpdate(key, value.get(), map.get());
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+      Assert.fail("Update expected.");
+    }
+  }
+
+  private static class ExpectRemove<K, V> implements MapReceptacle<K, V> {
+
+    private final RemovalHandler<K, V> handler;
+
+    ExpectRemove(final RemovalHandler<K, V> handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+      Assert.fail("Removal expected.");
+    }
+
+    @Override
+    public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+      handler.onRemove(key, map.get());
+    }
+  }
+
+  public static <K, V> void expectUpdate(final MapAction<K, V> action, final UpdateHandler<K, V> handler) {
+    action.push(new ExpectUpdate<>(handler));
+  }
+
+  public static <K, V> void expectRemoval(final MapAction<K, V> action, final RemovalHandler<K, V> handler) {
+    action.push(new ExpectRemove<>(handler));
+  }
+
+  public static final class Update<K, V> implements MapAction<K, V> {
+
+    private final K key;
+    private final V value;
+    private final MapView<K, V> state;
+
+    Update(final K key, final V value) {
+      this.key = key;
+      this.value = value;
+      state = MapView.wrap(HashTrieMap.<K, V>empty().updated(key, value));
+    }
+
+    Update(final K key, final V value, final MapView<K, V> state) {
+      this.key = key;
+      this.value = value;
+      this.state = state;
+    }
+
+    @Override
+    public void push(final MapReceptacle<K, V> receptacle) {
+      receptacle.notifyChange(key, Deferred.value(value), Deferred.value(state));
+    }
+  }
+
+  public static final class Remove<K, V> implements  MapAction<K, V> {
+
+    private final K key;
+    private final MapView<K, V> state;
+
+    Remove(final K key) {
+      this.key = key;
+      state = MapView.wrap(HashTrieMap.empty());
+    }
+
+    Remove(final K key, final MapView<K, V> state) {
+      this.key = key;
+      this.state = state;
+    }
+
+    @Override
+    public void push(final MapReceptacle<K, V> receptacle) {
+      receptacle.notifyRemoval(key, Deferred.value(state));
+    }
+  }
+
+  public static final class ActionAccumulator<K, V> {
+
+    private HashTrieMap<K, V> map = HashTrieMap.empty();
+
+    public Update<K, V> update(final K key, final V value) {
+      final Update<K, V> upd = ConnectorTestUtil.update(key, value, map);
+      map = map.updated(key, value);
+      return upd;
+    }
+
+    public Remove<K, V> remove(final K key) {
+      final Remove<K, V> rem = ConnectorTestUtil.remove(key, map);
+      map = map.removed(key);
+      return rem;
+    }
+
+  }
+
+  public static <K, V> Update<K, V> update(final K key, final V value) {
+    return new Update<>(key, value);
+  }
+
+  public static <K, V> Update<K, V> update(final K key, final V value, final MapView<K, V> state) {
+    return new Update<>(key, value, state);
+  }
+
+  public static <K, V> Update<K, V> update(final K key, final V value, final HashTrieMap<K, V> state) {
+    return new Update<>(key, value, MapView.wrap(state.updated(key, value)));
+  }
+
+  public static <K, V> Remove<K, V> remove(final K key) {
+    return new Remove<>(key);
+  }
+
+  public static <K, V> Remove<K, V> remove(final K key, final HashTrieMap<K, V> state) {
+    return new Remove<>(key, MapView.wrap(state.removed(key)));
+  }
+
+  public static <K, V> Remove<K, V> remove(final K key, final MapView<K, V> state) {
+    return new Remove<>(key, state);
+  }
+
+  @SafeVarargs
+  public static <K, V, Out> ArrayList<Out> pushData(final MapToValueConduit<K, V, Out> conduit, final MapAction<K, V>... actions) {
+    final ArrayList<Out> output = new ArrayList<>(actions.length);
+    final Receptacle<Out> receptacle = x -> output.add(x.get());
+    conduit.subscribe(receptacle);
+    for (final MapAction<K, V> action : actions) {
+      action.push(conduit);
+    }
+    return output;
+  }
+
+  @SafeVarargs
+  public static <In, KOut, VOut> ArrayList<MapAction<KOut, VOut>> pushData(final ValueToMapConduit<In, KOut, VOut> conduit, final In... values) {
+    final ArrayList<MapAction<KOut, VOut>> output = new ArrayList<>(values.length);
+    final MapReceptacle<KOut, VOut> receptacle = new MapReceptacle<KOut, VOut>() {
+      @Override
+      public void notifyChange(final KOut key, final Deferred<VOut> value, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final KOut key, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Remove<>(key, map.get()));
+      }
+    };
+    conduit.subscribe(receptacle);
+    for (final In value : values) {
+      conduit.notifyChange(Deferred.value(value));
+    }
+    return output;
+  }
+
+  @SafeVarargs
+  public static <KIn, VIn, KOut, VOut> ArrayList<MapAction<KOut, VOut>> pushData(final MapConduit<KIn, KOut, VIn, VOut> conduit, final MapAction<KIn, VIn>... actions) {
+    final ArrayList<MapAction<KOut, VOut>> output = new ArrayList<>(actions.length);
+    final MapReceptacle<KOut, VOut> receptacle = new MapReceptacle<KOut, VOut>() {
+      @Override
+      public void notifyChange(final KOut key, final Deferred<VOut> value, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final KOut key, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Remove<>(key, map.get()));
+      }
+    };
+    conduit.subscribe(receptacle);
+    for (final MapAction<KIn, VIn> action : actions) {
+      action.push(conduit);
+    }
+    return output;
+  }
+
+  @SafeVarargs
+  public static <KIn, VIn, KOut, VOut, T> ArrayList<MapAction<KOut, VOut>> pushData(
+      final MapJunction2<KIn, KOut, VIn, VOut, T> conduit,
+      final Either<MapAction<KIn, VIn>, T>... events) {
+
+    final ArrayList<MapAction<KOut, VOut>> output = new ArrayList<>(events.length);
+    final MapReceptacle<KOut, VOut> receptacle = new MapReceptacle<KOut, VOut>() {
+      @Override
+      public void notifyChange(final KOut key, final Deferred<VOut> value, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final KOut key, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Remove<>(key, map.get()));
+      }
+    };
+    conduit.subscribe(receptacle);
+    for (final Either<MapAction<KIn, VIn>, T> event : events) {
+      event.match(
+          action -> {
+            action.push(conduit.first());
+            return Unit.INSTANCE;
+          },
+          val -> {
+            conduit.second().notifyChange(Deferred.value(val));
+            return Unit.INSTANCE;
+          });
+    }
+    return output;
+  }
+
+  @SafeVarargs
+  public static <KIn, VIn1, VIn2, KOut, VOut> ArrayList<MapAction<KOut, VOut>> pushData(
+      final MapJoinJunction<KIn, VIn1, VIn2, KOut, VOut> conduit,
+      final Either<MapAction<KIn, VIn1>, MapAction<KIn, VIn2>>... events) {
+
+    final ArrayList<MapAction<KOut, VOut>> output = new ArrayList<>(events.length);
+    final MapReceptacle<KOut, VOut> receptacle = new MapReceptacle<KOut, VOut>() {
+      @Override
+      public void notifyChange(final KOut key, final Deferred<VOut> value, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final KOut key, final Deferred<MapView<KOut, VOut>> map) {
+        output.add(new Remove<>(key, map.get()));
+      }
+    };
+    conduit.subscribe(receptacle);
+    for (final Either<MapAction<KIn, VIn1>, MapAction<KIn, VIn2>> event : events) {
+      event.match(
+          action -> {
+            action.push(conduit.first());
+            return Unit.INSTANCE;
+          },
+          action -> {
+            action.push(conduit.second());
+            return Unit.INSTANCE;
+          });
+    }
+    return output;
+  }
+
+  @SafeVarargs
+  public static <In1, In2, Out> ArrayList<Out> pushData(final Junction2<In1, In2, Out> conduit,
+                                                        final Either<In1, In2>... values) {
+    final ArrayList<Out> output = new ArrayList<>(values.length);
+    final Receptacle<Out> receptacle = x -> output.add(x.get());
+    conduit.subscribe(receptacle);
+    for (final Either<In1, In2> val : values) {
+      val.match(
+          in -> {
+            conduit.first().notifyChange(Deferred.value(in));
+            return Unit.INSTANCE;
+          },
+          in -> {
+            conduit.second().notifyChange(Deferred.value(in));
+            return Unit.INSTANCE;
+          });
+
+    }
+    return output;
+  }
+
+  public static final class FakeSchedule implements Schedule {
+
+    private HashTrieMap<Long, TimerFunction> scheduled = HashTrieMap.empty();
+
+    public HashTrieMap<Long, TimerFunction> getScheduled() {
+      return scheduled;
+    }
+
+    public void runScheduled(final long time) {
+      if (scheduled.containsKey(time)) {
+        final TimerFunction f = scheduled.get(time);
+        scheduled = scheduled.removed(time);
+        f.runTimer();
+      }
+    }
+
+    @Override
+    public TimerRef timer(final TimerFunction timer) {
+      final Context context = new Context(-1, timer);
+      if (timer instanceof AbstractTimer) {
+        ((AbstractTimer) timer).setTimerContext(context);
+      }
+      return context;
+    }
+
+    @Override
+    public TimerRef setTimer(final long millis, final TimerFunction timer) {
+      scheduled = scheduled.updated(millis, timer);
+      final Context context = new Context(millis, timer);
+      if (timer instanceof AbstractTimer) {
+        ((AbstractTimer) timer).setTimerContext(context);
+      }
+      return context;
+    }
+
+    private final class Context implements TimerContext {
+
+      private final long time;
+      private final TimerFunction f;
+
+      private Context(final long time, final TimerFunction f) {
+        this.time = time;
+        this.f = f;
+      }
+
+      @Override
+      public Schedule schedule() {
+        return FakeSchedule.this;
+      }
+
+      @Override
+      public boolean isScheduled() {
+        return scheduled.containsKey(time);
+      }
+
+      @Override
+      public void reschedule(final long millis) {
+        if (scheduled.containsKey(time)) {
+          scheduled = scheduled.removed(time);
+        }
+        scheduled = scheduled.updated(millis, f);
+      }
+
+      @Override
+      public boolean cancel() {
+        scheduled = scheduled.removed(time);
+        return true;
+      }
+    }
+  }
+
+  enum Multiple {
+    DOUBLE(2),
+    TRIPLE(3);
+
+    private final int factor;
+
+    public int getFactor() {
+      return factor;
+    }
+
+    Multiple(final int fac) {
+      factor = fac;
+    }
+  }
+
+  enum Parity {
+    EVEN,
+    ODD
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/DelayConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/DelayConduitSpec.java
@@ -1,0 +1,89 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+
+public class DelayConduitSpec {
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForZeroDelay() {
+    new DelayConduit<>(0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForNegativeDelay() {
+    new DelayConduit<>(-1);
+  }
+
+  @Test
+  public void emitsNothingOnIntialInput() {
+    final DelayConduit<Integer> conduit = new DelayConduit<>(1);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 7);
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void emitsPreviousValues() {
+    final DelayConduit<Integer> conduit = new DelayConduit<>(1);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(conduit, 7);
+    Assert.assertTrue(results1.isEmpty());
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, 5);
+    Assert.assertEquals(results2.size(), 1);
+    Assert.assertEquals(results2.get(0).intValue(), 7);
+    final ArrayList<Integer> results3 = ConnectorTestUtil.pushData(conduit, 2);
+    Assert.assertEquals(results3.size(), 1);
+    Assert.assertEquals(results3.get(0).intValue(), 5);
+  }
+
+  @Test
+  public void emitsWithLongerDelay() {
+    final DelayConduit<Integer> conduit = new DelayConduit<>(3);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(conduit, 6, 5, 98);
+    Assert.assertTrue(results1.isEmpty());
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, 76);
+    Assert.assertEquals(results2.size(), 1);
+    Assert.assertEquals(results2.get(0).intValue(), 6);
+  }
+
+  @Test
+  public void storesBufferInState() {
+    final ListPersister<Integer> state = new TrivialListPersister<>();
+    final DelayConduit<Integer> conduit = new DelayConduit<>(state, 2);
+    ConnectorTestUtil.pushData(conduit, 1, 2, 3, 4);
+    Assert.assertEquals(state.size(), 3);
+    Assert.assertEquals(state.get(0).intValue(), 2);
+    Assert.assertEquals(state.get(1).intValue(), 3);
+    Assert.assertEquals(state.get(2).intValue(), 4);
+
+  }
+
+  @Test
+  public void restoreBufferFromState() {
+    final ListPersister<Integer> state = new TrivialListPersister<>();
+    state.append(1);
+    state.append(2);
+    state.append(3);
+    final DelayConduit<Integer> conduit = new DelayConduit<>(state, 2);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 4);
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/DelayMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/DelayMapConduitSpec.java
@@ -1,0 +1,216 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialSetPersisiter;
+import static swim.dataflow.connector.ConnectorTestUtil.remove;
+import static swim.dataflow.connector.ConnectorTestUtil.update;
+
+public class DelayMapConduitSpec {
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForZeroDelay() {
+    new DelayMapConduit<>(0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForNegativeDelay() {
+    new DelayMapConduit<>(-1);
+  }
+
+  @Test
+  public void emitsNothingOnIntialInput() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void emitsPreviousValuesForAKey() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3), update("a", 5));
+
+    Assert.assertEquals(results.size(), 1);
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+  }
+
+  @Test
+  public void emitsWithLongerDelay() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(3);
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        conduit, update("a", 3), update("a", 5), update("a", -4));
+    Assert.assertTrue(results.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(
+        conduit, update("a", 10));
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+  }
+
+  @Test
+  public void ignoresOtherKeysWithUnderfullBuffers() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit,
+        update("a", 3), update("b", -2), update("b", 4));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), -2);
+    });
+  }
+
+  @Test
+  public void remembersPreviousKeys() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit,
+        update("a", 3), update("b", -2), update("a", 12), update("b", 4));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -2);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+      Assert.assertEquals(m.get("b").get().intValue(), -2);
+    });
+  }
+
+  @Test
+  public void restoreFromState() {
+    final SetPersister<String> keys = new TrivialSetPersisiter<>();
+    keys.add("a");
+    keys.add("b");
+
+    final HashTrieMap<String, ListPersister<Integer>> buffers = HashTrieMap.<String, ListPersister<Integer>>empty()
+        .updated("a", new TrivialListPersister<>())
+        .updated("b", new TrivialListPersister<>());
+
+    final ListPersister<Integer> forA = buffers.get("a");
+    final ListPersister<Integer> forB = buffers.get("b");
+    Assert.assertNotNull(forA);
+    Assert.assertNotNull(forB);
+    forA.append(1);
+    forA.append(2);
+    forB.append(-1);
+
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(buffers::get, keys, 1);
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("b", 7));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -1);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), -1);
+    });
+  }
+
+  private static final class BufferFactory implements Function<String, ListPersister<Integer>> {
+    HashTrieMap<String, ListPersister<Integer>> persisters = HashTrieMap.empty();
+
+    @Override
+    public ListPersister<Integer> apply(final String s) {
+      final ListPersister<Integer> existing = persisters.get(s);
+      if (existing != null) {
+        return existing;
+      } else {
+        final TrivialListPersister<Integer> fresh = new TrivialListPersister<>();
+        persisters = persisters.updated(s, fresh);
+        return fresh;
+      }
+    }
+  }
+
+  @Test
+  public void storeKeysAndBuffersInState() {
+    final SetPersister<String> keys = new TrivialSetPersisiter<>();
+    final BufferFactory fac = new BufferFactory();
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(fac, keys, 1);
+
+    ConnectorTestUtil.pushData(conduit, update("a", 1), update("b", 2), update("b", 3), update("b", 4));
+
+    Assert.assertEquals(keys.get(), HashTrieSet.of("a", "b"));
+
+    final HashTrieMap<String, ListPersister<Integer>> buffers = fac.persisters;
+
+    Assert.assertEquals(buffers.keySet(), keys.get());
+
+    final ListPersister<Integer> forA = buffers.get("a");
+    Assert.assertNotNull(forA);
+    Assert.assertEquals(forA.size(), 1);
+    Assert.assertEquals(forA.get(0).intValue(), 1);
+
+    final ListPersister<Integer> forB = buffers.get("b");
+    Assert.assertNotNull(forB);
+    Assert.assertEquals(forB.size(), 2);
+    Assert.assertEquals(forB.get(0).intValue(), 3);
+    Assert.assertEquals(forB.get(1).intValue(), 4);
+  }
+
+  @Test
+  public void removalResetsBuffers() {
+    final DelayMapConduit<String, Integer> conduit = new DelayMapConduit<>(1);
+    ConnectorTestUtil.pushData(
+        conduit, update("a", 3), update("a", 5));
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        conduit, remove("a"), update("a", 7));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results.get(0), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FilteredConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FilteredConduitSpec.java
@@ -1,0 +1,32 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class FilteredConduitSpec {
+
+  @Test
+  public void correctlyFilterInput() {
+    final FilteredConduit<Integer> conduit = new FilteredConduit<>(n -> (n % 2) == 0);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 6, 13, 7, 20);
+    assertEquals(results.size(), 2);
+    assertEquals(results.get(0).intValue(), 6);
+    assertEquals(results.get(1).intValue(), 20);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FilteredMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FilteredMapConduitSpec.java
@@ -1,0 +1,73 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.ActionAccumulator;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+
+public class FilteredMapConduitSpec {
+
+  @Test
+  public void filterOutInputData() {
+    final FilteredMapConduit<Integer, String> conduit =
+        new FilteredMapConduit<>((k, v) -> v.length() <= k);
+
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, String>> results =
+        ConnectorTestUtil.pushData(conduit, acc.update(2, "a"));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(k).get(), "a");
+    });
+
+    final ArrayList<MapAction<Integer, String>> results2 =
+        ConnectorTestUtil.pushData(conduit,
+            acc.update(1, "aaa"));
+
+    Assert.assertEquals(results2.size(), 0);
+  }
+
+  @Test
+  public void filterPreviouslyAdmittedKey() {
+    final FilteredMapConduit<Integer, String> conduit =
+        new FilteredMapConduit<>((k, v) -> v.length() <= k);
+
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(conduit, acc.update(2, "a"));
+
+    final ArrayList<MapAction<Integer, String>> results =
+        ConnectorTestUtil.pushData(conduit, acc.update(2, "aaa"));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FirstValueConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FirstValueConduitSpec.java
@@ -1,0 +1,69 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+
+public class FirstValueConduitSpec {
+
+  @Test
+  public void emitsTheFirstValue() {
+    final FirstValueConduit<Integer> conduit = new FirstValueConduit<>();
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 2);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+  }
+
+  @Test
+  public void doesNotEmitValuesAfterFirst() {
+    final FirstValueConduit<Integer> conduit = new FirstValueConduit<>();
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 2);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, 5, 6);
+
+    Assert.assertTrue(results2.isEmpty());
+  }
+
+  @Test
+  public void restoresFromState() {
+    final FirstValueConduit<Integer> conduit = new FirstValueConduit<>(new TrivialValuePersister<>(8));
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 6, 4, 5);
+
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void storesInState() {
+    final ValuePersister<Integer> state = new TrivialValuePersister<>(null);
+    final FirstValueConduit<Integer> conduit = new FirstValueConduit<>(state);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 2);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+
+    Assert.assertEquals(state.get().intValue(), 2);
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FirstValueMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FirstValueMapConduitSpec.java
@@ -1,0 +1,202 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialMapPersister;
+import swim.structure.Form;
+import static swim.dataflow.connector.ConnectorTestUtil.remove;
+import static swim.dataflow.connector.ConnectorTestUtil.update;
+
+public class FirstValueMapConduitSpec {
+
+  @DataProvider(name = "resetOnRemoval")
+  public Object[][] restOnRemoval() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "resetOnRemoval")
+  public void emitsTheFirstValueForAKey(final boolean resetOnRemoval) {
+
+    final FirstValueMapConduit<String, Integer> conduit =
+        new FirstValueMapConduit<>(resetOnRemoval, Form.forInteger());
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+  }
+
+  @Test(dataProvider = "resetOnRemoval")
+  public void doesNotEmitValuesAfterFirstForAKey(final boolean resetOnRemoval) {
+    final FirstValueMapConduit<String, Integer> conduit =
+        new FirstValueMapConduit<>(resetOnRemoval, Form.forInteger());
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(conduit, update("a", 5));
+
+    Assert.assertTrue(results2.isEmpty());
+  }
+
+  @Test(dataProvider = "resetOnRemoval")
+  public void remembersValuesForPastKeys(final boolean resetOnRemoval) {
+    final FirstValueMapConduit<String, Integer> conduit =
+        new FirstValueMapConduit<>(resetOnRemoval, Form.forInteger());
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(conduit, update("b", 7));
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+  }
+
+  @Test
+  public void ignoresRemovalsInNoResetMode() {
+    final FirstValueMapConduit<String, Integer> conduit =
+        new FirstValueMapConduit<>(false, Form.forInteger());
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(conduit, remove("a"));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results3 = ConnectorTestUtil.pushData(conduit, update("a", 5));
+
+    Assert.assertTrue(results3.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results4 = ConnectorTestUtil.pushData(conduit, update("b", 7));
+
+    Assert.assertEquals(results4.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results4.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+  }
+
+  @Test
+  public void removesFirstValueInResetMode() {
+    final FirstValueMapConduit<String, Integer> conduit =
+        new FirstValueMapConduit<>(true, Form.forInteger());
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(conduit, remove("a"));
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results2.get(0), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+
+    final ArrayList<MapAction<String, Integer>> results3 = ConnectorTestUtil.pushData(conduit, update("b", 7));
+
+    Assert.assertEquals(results3.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+    final ArrayList<MapAction<String, Integer>> results4 = ConnectorTestUtil.pushData(conduit, update("a", 5));
+
+    Assert.assertEquals(results4.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results4.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 5);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 5);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+  }
+
+  @Test(dataProvider = "resetOnRemoval")
+  public void storesFirstValuesInState(final boolean resetOnRemoval) {
+    final MapPersister<String, Integer> persister = new TrivialMapPersister<>(Form.forInteger());
+
+    final FirstValueMapConduit<String, Integer> conduit = new FirstValueMapConduit<>(resetOnRemoval, persister);
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit, update("a", 3));
+
+    Assert.assertEquals(results.size(), 1);
+
+    Assert.assertEquals(persister.keys(), HashTrieSet.of("a"));
+    Assert.assertEquals(persister.get("a").intValue(), 3);
+  }
+
+  @Test(dataProvider = "resetOnRemoval")
+  public void restoresFromState(final boolean resetOnRemoval) {
+    final MapPersister<String, Integer> persister = new TrivialMapPersister<>(Form.forInteger());
+    persister.put("a", 3);
+
+    final FirstValueMapConduit<String, Integer> conduit = new FirstValueMapConduit<>(resetOnRemoval, persister);
+
+    final ArrayList<MapAction<String, Integer>> results1 = ConnectorTestUtil.pushData(conduit, update("a", 5));
+
+    Assert.assertTrue(results1.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(conduit, update("b", 7));
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapConduitSpec.java
@@ -1,0 +1,55 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FlatMapConduitSpec {
+
+  @Test
+  public void emitOutputsOnSchedule() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+
+    final FlatMapConduit<Integer, Integer> conduit = new FlatMapConduit<>(n -> Arrays.asList(n, n + 1, n + 2, n + 3),
+        schedule, Duration.ofSeconds(2));
+
+    final ArrayList<Integer> results = new ArrayList<>(4);
+
+    final Receptacle<Integer> receptacle = n -> results.add(n.get());
+
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    conduit.notifyChange(Deferred.value(1));
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 1);
+
+    for (int i = 0; i < 3; ++i) {
+      Assert.assertEquals(schedule.getScheduled().size(), 1);
+      Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+      schedule.runScheduled(2000L);
+      Assert.assertEquals(results.size(), i + 2);
+      Assert.assertEquals(results.get(i + 1).intValue(), i + 2);
+    }
+
+    Assert.assertEquals(schedule.getScheduled().size(), 0);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapConduitSpec.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import swim.util.Deferred;
 
 public class FlatMapConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapEntriesConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/FlatMapEntriesConduitSpec.java
@@ -1,0 +1,113 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.ActionAccumulator;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.Pair;
+import static swim.dataflow.connector.ConnectorTestUtil.update;
+import static swim.dataflow.graph.Pair.pair;
+
+public class FlatMapEntriesConduitSpec {
+
+  @Test
+  public void transformEntries() {
+    final FlatMapEntriesConduit<Integer, Integer, Integer, Integer> conduit = new FlatMapEntriesConduit<>(
+        FlatMapEntriesConduitSpec::nonTrivialFactors, k -> Collections.emptySet());
+
+    final ArrayList<MapAction<Integer, Integer>> results =
+        ConnectorTestUtil.pushData(conduit, update(1, 6));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(2).get().intValue(), 1);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(2).get().intValue(), 1);
+      Assert.assertEquals(m.get(3).get().intValue(), 1);
+    });
+  }
+
+  @Test
+  public void removeEntries() {
+    final FlatMapEntriesConduit<Integer, Integer, Integer, Integer> conduit = new FlatMapEntriesConduit<>(
+        FlatMapEntriesConduitSpec::id, FlatMapEntriesConduitSpec::lessThan);
+
+    final ActionAccumulator<Integer, Integer> acc =
+        new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(conduit, acc.update(1, 6), acc.update(3, 4), acc.update(7, 7));
+
+    final ArrayList<MapAction<Integer, Integer>> results =
+        ConnectorTestUtil.pushData(conduit, acc.remove(3));
+
+    Assert.assertEquals(results.size(), 2);
+
+    final HashSet<Integer> expectedRemovals = new HashSet<>();
+    expectedRemovals.add(1);
+    expectedRemovals.add(3);
+
+    for (final MapAction<Integer, Integer> result : results) {
+      ConnectorTestUtil.expectRemoval(result, (k, m) -> {
+        Assert.assertTrue(expectedRemovals.contains(k));
+        Assert.assertEquals(m.size(), expectedRemovals.size());
+        expectedRemovals.remove(k);
+        Assert.assertEquals(m.get(7).get().intValue(), 7);
+        for (final Integer remaining : expectedRemovals) {
+          Assert.assertTrue(m.containsKey(remaining));
+        }
+      });
+    }
+
+  }
+
+  public static Iterable<Pair<Integer, Integer>> id(final Integer key, final Integer value) {
+    return Collections.singletonList(pair(key, value));
+  }
+
+  public static Iterable<Pair<Integer, Integer>> nonTrivialFactors(final Integer key, final Integer value) {
+    final ArrayList<Pair<Integer, Integer>> out = new ArrayList<>();
+    for (int i = 2; i < value; ++i) {
+      if (value % i == 0) {
+        out.add(pair(i, key));
+      }
+    }
+    return out;
+  }
+
+  public static Set<Integer> lessThan(final Integer key) {
+    HashTrieSet<Integer> toRemove = HashTrieSet.empty();
+    for (int i = 0; i <= key; ++i) {
+      toRemove = toRemove.added(i);
+    }
+    return toRemove;
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/IdentityConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/IdentityConduitSpec.java
@@ -1,0 +1,32 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class IdentityConduitSpec {
+
+  @Test
+  public void propagateInput() {
+    final IdentityConduit<String> conduit = new IdentityConduit<>();
+    final ArrayList<String> results = ConnectorTestUtil.pushData(conduit, "Hello", "world");
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals("Hello", results.get(0));
+    Assert.assertEquals("world", results.get(1));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/JoinOnKeyJunctionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/JoinOnKeyJunctionSpec.java
@@ -1,0 +1,317 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.ActionAccumulator;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.Pair;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class JoinOnKeyJunctionSpec {
+
+  @Test
+  public void innerJoin() {
+
+    final JoinOnKeyJunction<Integer, Long, String, Pair<Long, String>> junction =
+        new JoinOnKeyJunction<>(Pair::pair);
+
+    final ActionAccumulator<Integer, Long> leftAcc = new ActionAccumulator<>();
+    final ActionAccumulator<Integer, String> rightAcc = new ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs1 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(3, 1034L)),
+        right(rightAcc.update(5, "Hello")));
+
+    Assert.assertTrue(outputs1.isEmpty());
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs2 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(5, 2078L)),
+        right(rightAcc.update(3, "World")));
+
+    Assert.assertEquals(outputs2.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "World"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs3 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.remove(5)),
+        right(rightAcc.remove(3)));
+
+    Assert.assertEquals(outputs3.size(), 2);
+
+    ConnectorTestUtil.expectRemoval(outputs3.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs3.get(1), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test
+  public void leftJoin() {
+    final JoinOnKeyJunction<Integer, Long, String, Pair<Long, String>> junction =
+        new JoinOnKeyJunction<>(Pair::pair, v -> Pair.pair(v, "DEFAULT"), null);
+
+    final ActionAccumulator<Integer, Long> leftAcc = new ActionAccumulator<>();
+    final ActionAccumulator<Integer, String> rightAcc = new ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs1 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(3, 1034L)),
+        right(rightAcc.update(5, "Hello")));
+
+    Assert.assertEquals(outputs1.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(outputs1.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "DEFAULT"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs2 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(5, 2078L)),
+        right(rightAcc.update(3, "World")));
+
+    Assert.assertEquals(outputs2.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "World"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs3 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.remove(5)),
+        right(rightAcc.remove(3)));
+
+    Assert.assertEquals(outputs3.size(), 2);
+
+    ConnectorTestUtil.expectRemoval(outputs3.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs3.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "DEFAULT"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs4 = ConnectorTestUtil.pushData(
+        junction, left(leftAcc.remove(3)));
+
+    Assert.assertEquals(outputs4.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(outputs4.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test
+  public void rightJoin() {
+    final JoinOnKeyJunction<Integer, Long, String, Pair<Long, String>> junction =
+        new JoinOnKeyJunction<>(Pair::pair, null, v -> Pair.pair(-1L, v));
+
+    final ActionAccumulator<Integer, Long> leftAcc = new ActionAccumulator<>();
+    final ActionAccumulator<Integer, String> rightAcc = new ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs1 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(3, 1034L)),
+        right(rightAcc.update(5, "Hello")));
+
+    Assert.assertEquals(outputs1.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(outputs1.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs2 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(5, 2078L)),
+        right(rightAcc.update(3, "World")));
+
+    Assert.assertEquals(outputs2.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "World"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs3 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.remove(5)),
+        right(rightAcc.remove(3)));
+
+    Assert.assertEquals(outputs3.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs3.get(1), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs4 = ConnectorTestUtil.pushData(
+        junction, right(rightAcc.remove(5)));
+
+    Assert.assertEquals(outputs4.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(outputs4.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test
+  public void fullJoin() {
+    final JoinOnKeyJunction<Integer, Long, String, Pair<Long, String>> junction =
+        new JoinOnKeyJunction<>(Pair::pair, v -> Pair.pair(v, "DEFAULT"), v -> Pair.pair(-1L, v));
+
+    final ActionAccumulator<Integer, Long> leftAcc = new ActionAccumulator<>();
+    final ActionAccumulator<Integer, String> rightAcc = new ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs1 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(3, 1034L)),
+        right(rightAcc.update(5, "Hello")));
+
+    Assert.assertEquals(outputs1.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs1.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "DEFAULT"));
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+    ConnectorTestUtil.expectUpdate(outputs1.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs2 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.update(5, 2078L)),
+        right(rightAcc.update(3, "World")));
+
+    Assert.assertEquals(outputs2.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs2.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "World"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(2078L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs3 = ConnectorTestUtil.pushData(junction,
+        left(leftAcc.remove(5)),
+        right(rightAcc.remove(3)));
+
+    Assert.assertEquals(outputs3.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(v, Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "World"));
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs3.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v, Pair.pair(1034L, "DEFAULT"));
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(5).get(), Pair.pair(-1L, "Hello"));
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    final ArrayList<MapAction<Integer, Pair<Long, String>>> outputs4 = ConnectorTestUtil.pushData(
+        junction, right(rightAcc.remove(5)), left(leftAcc.remove(3)));
+
+    Assert.assertEquals(outputs4.size(), 2);
+
+    ConnectorTestUtil.expectRemoval(outputs4.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 5);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(3).get(), Pair.pair(1034L, "DEFAULT"));
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs4.get(1), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapCollectorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapCollectorSpec.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.Pair;
+import static swim.dataflow.graph.Pair.pair;
+
+public class MapCollectorSpec {
+
+  @Test
+  public void accumulateEntries() {
+
+    final MapCollector<Pair<Integer, Integer>, Integer, Integer> collector =
+        new MapCollector<>(Pair::getFirst, Pair::getSecond);
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, Integer>> results = ConnectorTestUtil.pushData(
+        collector, pair(1, 2), pair(3, 3), pair(4, 5));
+
+    Assert.assertEquals(results.size(), 3);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(v.intValue(), 2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+      Assert.assertEquals(m.get(3).get().intValue(), 3);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v.intValue(), 5);
+      Assert.assertEquals(m.size(), 3);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+      Assert.assertEquals(m.get(3).get().intValue(), 3);
+      Assert.assertEquals(m.get(4).get().intValue(), 5);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapExtractorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapExtractorSpec.java
@@ -1,0 +1,46 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+
+public class MapExtractorSpec {
+
+  @Test
+  public void extractStateAsEntries() {
+    final MapExtractor<Integer, Integer> extractor = new MapExtractor<>();
+
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<Map<Integer, Integer>> results = ConnectorTestUtil.pushData(
+        extractor, acc.update(1, 2), acc.update(2, 3), acc.update(3, 4), acc.remove(2));
+
+    Assert.assertEquals(results.size(), 4);
+    final HashTrieMap<Integer, Integer> expected1 = HashTrieMap.<Integer, Integer>empty().updated(1, 2);
+    Assert.assertEquals(results.get(0), expected1);
+    final HashTrieMap<Integer, Integer> expected2 = expected1.updated(2, 3);
+    Assert.assertEquals(results.get(1), expected2);
+    final HashTrieMap<Integer, Integer> expected3 = expected2.updated(3, 4);
+    Assert.assertEquals(results.get(2), expected3);
+    final HashTrieMap<Integer, Integer> expected4 = expected3.removed(2);
+    Assert.assertEquals(results.get(3), expected4);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapKeysCollectorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapKeysCollectorSpec.java
@@ -1,0 +1,46 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+
+public class MapKeysCollectorSpec {
+
+  @Test
+  public void extractStateAsKeys() {
+    final MapKeysCollector<Integer, Integer> extractor = new MapKeysCollector<>();
+
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<Set<Integer>> results = ConnectorTestUtil.pushData(
+        extractor, acc.update(1, 2), acc.update(2, 3), acc.update(3, 4), acc.remove(2));
+
+    Assert.assertEquals(results.size(), 4);
+    final HashTrieSet<Integer> expected1 = HashTrieSet.<Integer>empty().added(1);
+    Assert.assertEquals(results.get(0), expected1);
+    final HashTrieSet<Integer> expected2 = expected1.added(2);
+    Assert.assertEquals(results.get(1), expected2);
+    final HashTrieSet<Integer> expected3 = expected2.added(3);
+    Assert.assertEquals(results.get(2), expected3);
+    final HashTrieSet<Integer> expected4 = expected3.removed(2);
+    Assert.assertEquals(results.get(3), expected4);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapMemoizingConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapMemoizingConduitSpec.java
@@ -20,6 +20,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import swim.collections.HashTrieMap;
 import swim.dataflow.connector.ConnectorTestUtil.Update;
+import swim.util.Deferred;
 
 public class MapMemoizingConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapMemoizingConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MapMemoizingConduitSpec.java
@@ -1,0 +1,101 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.dataflow.connector.ConnectorTestUtil.Update;
+
+public class MapMemoizingConduitSpec {
+
+  @Test
+  public void singleComputationOfAllValues() {
+    final MapMemoizingConduit<Integer, String> conduit = new MapMemoizingConduit<>();
+
+    final CountingDeferred val1 = new CountingDeferred("a");
+    final CountingDeferred val2 = new CountingDeferred("b");
+
+    final HashTrieMap<Integer, Deferred<String>> map =
+        HashTrieMap.<Integer, Deferred<String>>empty().updated(1, val1);
+
+    final ArrayList<Update<Integer, String>> results = new ArrayList<>();
+
+    final MapReceptacle<Integer, String> receptacle = new MapReceptacle<Integer, String>() {
+
+      @Override
+      public void notifyChange(final Integer key, final Deferred<String> value, final Deferred<MapView<Integer, String>> map) {
+        value.get();
+        for (final Map.Entry<Integer, Deferred<String>> entry : map.get()) {
+          entry.getValue().get();
+        }
+        results.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final Integer key, final Deferred<MapView<Integer, String>> map) {
+        Assert.fail();
+      }
+    };
+
+    conduit.subscribe(receptacle);
+
+    conduit.notifyChange(1, val1, Deferred.value(MapView.wrap(map)));
+    conduit.notifyChange(2, val2, Deferred.value(MapView.wrap(map.updated(2, val2))));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(v, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(1).get(), "a");
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v, "b");
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(1).get(), "a");
+      Assert.assertEquals(m.get(2).get(), "b");
+    });
+
+    Assert.assertEquals(val1.getCount(), 1);
+    Assert.assertEquals(val2.getCount(), 1);
+  }
+
+  private static final class CountingDeferred implements Deferred<String> {
+
+    private int count = 0;
+    private final String value;
+
+    private CountingDeferred(final String value) {
+      this.value = value;
+    }
+
+    public int getCount() {
+      return count;
+    }
+
+    @Override
+    public String get() {
+      ++count;
+      return value;
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MemoizingConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MemoizingConduitSpec.java
@@ -16,6 +16,7 @@ package swim.dataflow.connector;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import swim.util.Deferred;
 
 public class MemoizingConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MemoizingConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/MemoizingConduitSpec.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MemoizingConduitSpec {
+
+  @Test
+  public void singleComputation() {
+    final MemoizingConduit<String> conduit = new MemoizingConduit<>();
+    final Receptacle<String> receptacle = value -> {
+      Assert.assertEquals("I'm Expensive", value.get());
+      Assert.assertEquals("I'm Expensive", value.get());
+      Assert.assertEquals("I'm Expensive", value.get());
+    };
+    conduit.subscribe(receptacle);
+
+    final CountingDeferred input = new CountingDeferred();
+
+    conduit.notifyChange(input);
+
+    Assert.assertEquals(input.getCount(), 1);
+  }
+
+  private static final class CountingDeferred implements Deferred<String> {
+
+    private int count = 0;
+
+    public int getCount() {
+      return count;
+    }
+
+    @Override
+    public String get() {
+      ++count;
+      return "I'm Expensive";
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFilteredConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFilteredConduitSpec.java
@@ -1,0 +1,63 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class ModalFilteredConduitSpec {
+
+  @Test
+  public void filterByMode() {
+    final ModalFilteredConduit<Integer, Parity> conduit = new ModalFilteredConduit<>(
+        Parity.EVEN, parity -> n -> n % 2 == parity.ordinal());
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(
+        conduit, left(2), left(7), right(Parity.ODD), left(2), left(13));
+
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+    Assert.assertEquals(results.get(1).intValue(), 13);
+  }
+
+  @Test
+  public void filterByModeWithState() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Parity> modePersister = provider.forValue("mode",
+        Form.forEnum(Parity.class), Parity.EVEN);
+
+    final ModalFilteredConduit<Integer, Parity> conduit = new ModalFilteredConduit<>(
+        modePersister, (Parity parity) -> (Integer n) -> n % 2 == parity.ordinal());
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(
+        conduit, left(2), left(7), right(Parity.ODD), left(2), left(13));
+
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+    Assert.assertEquals(results.get(1).intValue(), 13);
+
+    Assert.assertEquals(modePersister.get(), Parity.ODD);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFilteredMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFilteredMapConduitSpec.java
@@ -1,0 +1,197 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class ModalFilteredMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void changeFilterByMode(final boolean withState) {
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Parity> modePersister = provider.forValue("mode",
+          Form.forEnum(Parity.class), Parity.ODD);
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(
+          modePersister,
+          (Parity p) -> (Integer n, Integer s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      changeFilterByMode(modalFilter);
+
+      Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    } else {
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(Parity.ODD,
+          p -> (n, s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      changeFilterByMode(modalFilter);
+    }
+
+  }
+
+  private void changeFilterByMode(final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter) {
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Integer>> results = ConnectorTestUtil.pushData(modalFilter,
+        left(acc.update(1, 2)),
+        right(Parity.EVEN),
+        left(acc.update(4, 4)));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(v.intValue(), 2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+      Assert.assertEquals(m.get(4).get().intValue(), 4);
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void retroactivelyRemoveInvalidEntries(final boolean withState) {
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Parity> modePersister = provider.forValue("mode",
+          Form.forEnum(Parity.class), Parity.ODD);
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(
+          modePersister,
+          (Parity p) -> (Integer n, Integer s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      retroactivelyRemoveInvalidEntries(modalFilter);
+
+      Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    } else {
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(Parity.ODD,
+          p -> (n, s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      retroactivelyRemoveInvalidEntries(modalFilter);
+    }
+
+  }
+
+  private void retroactivelyRemoveInvalidEntries(final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter) {
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Integer>> results = ConnectorTestUtil.pushData(modalFilter,
+        left(acc.update(1, 2)),
+        right(Parity.EVEN),
+        left(acc.update(1, 1)));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(v.intValue(), 2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(1), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void retroactivelyRestoreValidKeys(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Parity> modePersister = provider.forValue("mode",
+          Form.forEnum(Parity.class), Parity.ODD);
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(
+          modePersister,
+          (Parity p) -> (Integer n, Integer s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      retroactivelyRestoreValidKeys(modalFilter);
+
+      Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    } else {
+      final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter = new ModalFilteredMapConduit<>(Parity.ODD,
+          p -> (n, s) -> (n % 2 == p.ordinal()) || (s % 2 == p.ordinal()));
+
+      retroactivelyRestoreValidKeys(modalFilter);
+    }
+
+
+  }
+
+  private void retroactivelyRestoreValidKeys(final ModalFilteredMapConduit<Integer, Integer, Parity> modalFilter) {
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<MapAction<Integer, Integer>> results1 = ConnectorTestUtil.pushData(modalFilter,
+        left(acc.update(2, 2)),
+        left(acc.update(6, 6)));
+
+    Assert.assertEquals(results1.size(), 0);
+
+    final ArrayList<MapAction<Integer, Integer>> results2 = ConnectorTestUtil.pushData(modalFilter, right(Parity.EVEN));
+
+    Assert.assertEquals(results2.size(), 2);
+
+    final HashSet<Integer> expectedAdditions = new HashSet<>();
+    expectedAdditions.add(2);
+    expectedAdditions.add(6);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertTrue(expectedAdditions.contains(k));
+      expectedAdditions.remove(k);
+      Assert.assertEquals(v, k);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(2).get().intValue(), 2);
+      Assert.assertEquals(m.get(6).get().intValue(), 6);
+    });
+
+    ConnectorTestUtil.expectUpdate(results2.get(1), (k, v, m) -> {
+      Assert.assertTrue(expectedAdditions.contains(k));
+      expectedAdditions.remove(k);
+      Assert.assertEquals(v, k);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(2).get().intValue(), 2);
+      Assert.assertEquals(m.get(6).get().intValue(), 6);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFlatMapConduitSpec.java
@@ -25,6 +25,7 @@ import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.Form;
 import swim.structure.form.DurationForm;
+import swim.util.Deferred;
 
 
 public class ModalFlatMapConduitSpec {

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalFlatMapConduitSpec.java
@@ -1,0 +1,115 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import swim.structure.form.DurationForm;
+
+
+public class ModalFlatMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void emitOutputsOnVariableSchedule(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Parity> modePersister = provider.forValue("mode",
+          Form.forEnum(Parity.class), Parity.ODD);
+
+      final ValuePersister<Duration> durationPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(2)));
+
+      final ModalFlatMapConduit<Integer, Integer, Parity> conduit = new ModalFlatMapConduit<>(
+          modePersister,
+          (Parity p) -> (Integer n) -> Arrays.asList(n, n + (p == Parity.ODD ? 1 : 2)),
+          schedule, durationPersister);
+
+      emitOutputOnVariableSchedule(schedule, conduit);
+
+      Assert.assertEquals(modePersister.get(), Parity.EVEN);
+      Assert.assertEquals(durationPersister.get(), Duration.ofSeconds(5));
+    } else {
+      final ModalFlatMapConduit<Integer, Integer, Parity> conduit = new ModalFlatMapConduit<>(
+          Parity.ODD, p -> n -> Arrays.asList(n, n + (p == Parity.ODD ? 1 : 2)),
+          schedule, Duration.ofSeconds(2));
+
+      emitOutputOnVariableSchedule(schedule, conduit);
+    }
+
+  }
+
+  private void emitOutputOnVariableSchedule(final ConnectorTestUtil.FakeSchedule schedule,
+                                            final ModalFlatMapConduit<Integer, Integer, Parity> conduit) {
+    final ArrayList<Integer> results = new ArrayList<>(2);
+
+    final Receptacle<Integer> receptacle = n -> results.add(n.get());
+
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    conduit.first().notifyChange(Deferred.value(1));
+
+    check(schedule, results, Parity.ODD, 2000, 1);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 0);
+
+    results.clear();
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(5)));
+    conduit.first().notifyChange(Deferred.value(3));
+
+    check(schedule, results, Parity.ODD, 5000, 3);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 0);
+
+    results.clear();
+
+    conduit.third().notifyChange(Deferred.value(Parity.EVEN));
+    conduit.first().notifyChange(Deferred.value(5));
+
+    check(schedule, results, Parity.EVEN, 5000, 5);
+  }
+
+  private void check(final ConnectorTestUtil.FakeSchedule schedule, final ArrayList<Integer> results,
+                     final Parity p,
+                     final long delay,
+                     final int start) {
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), start);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(delay));
+    schedule.runScheduled(delay);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1).intValue(), start + (p == Parity.ODD ? 1 : 2));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFetchConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFetchConduitSpec.java
@@ -22,6 +22,7 @@ import swim.collections.HashTrieMap;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 public class ModalKeyFetchConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFetchConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFetchConduitSpec.java
@@ -1,0 +1,148 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+
+public class ModalKeyFetchConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void selectNothingInitially(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), null);
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>(modePersister);
+
+      selectNothingInitially(selector);
+
+      Assert.assertNull(modePersister.get());
+    } else {
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>();
+
+      selectNothingInitially(selector);
+    }
+  }
+
+  private void selectNothingInitially(final ModalKeyFetchConduit<Integer, String> selector) {
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = value -> results.add(value.get());
+
+    selector.subscribe(receptacle);
+    selector.mapInput().notifyChange(1, Deferred.value("a"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "a"))));
+
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test(dataProvider = "withState")
+  public void outputForSelectedKey(final boolean withState) {
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), null);
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>(modePersister);
+
+      outputForSelectedKey(selector);
+
+      Assert.assertEquals(modePersister.get().intValue(), 2);
+    } else {
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>();
+
+      outputForSelectedKey(selector);
+    }
+
+  }
+
+  private void outputForSelectedKey(final ModalKeyFetchConduit<Integer, String> selector) {
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = value -> results.add(value.get());
+
+    selector.subscribe(receptacle);
+    selector.keySelector().notifyChange(Deferred.value(2));
+    selector.mapInput().notifyChange(1, Deferred.value("a"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "a"))));
+    selector.mapInput().notifyChange(2, Deferred.value("b"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "a").updated(2, "b"))));
+    selector.mapInput().notifyChange(3, Deferred.value("c"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "a").updated(2, "b").updated(3, "c"))));
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "b");
+  }
+
+  @Test(dataProvider = "withState")
+  public void alterSelectedKey(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), null);
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>(modePersister);
+
+      alterSelectedKey(selector);
+      Assert.assertEquals(modePersister.get().intValue(), 2);
+    } else {
+      final ModalKeyFetchConduit<Integer, String> selector = new ModalKeyFetchConduit<>();
+
+      alterSelectedKey(selector);
+    }
+
+  }
+
+  private void alterSelectedKey(final ModalKeyFetchConduit<Integer, String> selector) {
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = value -> results.add(value.get());
+
+    selector.subscribe(receptacle);
+    selector.keySelector().notifyChange(Deferred.value(1));
+    selector.mapInput().notifyChange(1, Deferred.value("a"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "a"))));
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "a");
+
+    results.clear();
+
+    selector.keySelector().notifyChange(Deferred.value(2));
+
+    selector.mapInput().notifyChange(1, Deferred.value("b"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "b"))));
+    selector.mapInput().notifyChange(2, Deferred.value("c"),
+        Deferred.value(MapView.wrap(HashTrieMap.<Integer, String>empty().updated(1, "b").updated(2, "c"))));
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "c");
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFilterConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalKeyFilterConduitSpec.java
@@ -1,0 +1,226 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.ActionAccumulator;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class ModalKeyFilterConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void filterOutInputData(final boolean withState) {
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Parity> modePersister = provider.forValue("mode",
+          Form.forEnum(Parity.class), Parity.EVEN);
+
+      final ModalKeyFilterConduit<Integer, String, Parity> conduit =
+          new ModalKeyFilterConduit<>(modePersister,
+              (Parity p) -> (Integer k) -> k % 2 == p.ordinal());
+
+      filterOutInputData(conduit);
+
+      Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    } else {
+      final ModalKeyFilterConduit<Integer, String, Parity> conduit =
+          new ModalKeyFilterConduit<>(Parity.EVEN, p -> k -> k % 2 == p.ordinal());
+
+      filterOutInputData(conduit);
+    }
+  }
+
+  private void filterOutInputData(final ModalKeyFilterConduit<Integer, String, Parity> conduit) {
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, String>> results =
+        ConnectorTestUtil.pushData(conduit, left(acc.update(2, "a")));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(k).get(), "a");
+    });
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, String>> results2 =
+        ConnectorTestUtil.pushData(conduit, left(acc.update(1, "aaa")));
+
+    Assert.assertEquals(results2.size(), 0);
+  }
+
+  @Test(dataProvider = "withState")
+  public void alterPredicate(final boolean withState) {
+
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), 3);
+
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(modePersister,
+              (Integer n) -> (Integer k) -> k % n == 0);
+
+      alterPredicate(conduit);
+      Assert.assertEquals(modePersister.get().intValue(), 2);
+
+    } else {
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(3, n -> k -> k % n == 0);
+
+      alterPredicate(conduit);
+    }
+  }
+
+  private void alterPredicate(final ModalKeyFilterConduit<Integer, String, Integer> conduit) {
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, String>> results = ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update(6, "a")),
+        left(acc.update(7, "b")),
+        right(2),
+        left(acc.update(4, "c")));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 6);
+      Assert.assertEquals(v, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(6).get(), "a");
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v, "c");
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(6).get(), "a");
+      Assert.assertEquals(m.get(4).get(), "c");
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void retroactivelyRemoveInvalidKeys(final boolean withState) {
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), 3);
+
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(modePersister,
+              (Integer n) -> (Integer k) -> k % n == 0);
+
+      retroactivelyRemoveInvalidKeys(conduit);
+      Assert.assertEquals(modePersister.get().intValue(), 2);
+
+    } else {
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(3, n -> k -> k % n == 0);
+
+      retroactivelyRemoveInvalidKeys(conduit);
+    }
+
+  }
+
+  private void retroactivelyRemoveInvalidKeys(final ModalKeyFilterConduit<Integer, String, Integer> conduit) {
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update(3, "a")),
+        left(acc.update(6, "b")));
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, String>> results =
+        ConnectorTestUtil.pushData(conduit, right(2));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results.get(0), (k, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(6).get(), "b");
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void retroactivelyRestoreValidKeys(final boolean withState) {
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Integer> modePersister = provider.forValue("mode",
+          Form.forInteger(), 3);
+
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(modePersister,
+              (Integer n) -> (Integer k) -> k % n == 0);
+
+      retroactivelyRestoreValidKeys(conduit);
+      Assert.assertEquals(modePersister.get().intValue(), 2);
+
+    } else {
+      final ModalKeyFilterConduit<Integer, String, Integer> conduit =
+          new ModalKeyFilterConduit<>(3, n -> k -> k % n == 0);
+
+      retroactivelyRestoreValidKeys(conduit);
+    }
+
+
+  }
+
+  private void retroactivelyRestoreValidKeys(final ModalKeyFilterConduit<Integer, String, Integer> conduit) {
+    final ActionAccumulator<Integer, String> acc =
+        new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update(6, "a")),
+        left(acc.update(8, "b")));
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, String>> results =
+        ConnectorTestUtil.pushData(conduit, right(2));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 8);
+      Assert.assertEquals(v, "b");
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(6).get(), "a");
+      Assert.assertEquals(m.get(8).get(), "b");
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalTransformConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ModalTransformConduitSpec.java
@@ -1,0 +1,66 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.Multiple;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class ModalTransformConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void transformByMode(final boolean withState) {
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Multiple> modePersister = provider.forValue("mode",
+          Form.forEnum(Multiple.class), Multiple.DOUBLE);
+
+      final ModalTransformConduit<Integer, Integer, Multiple> conduit = new ModalTransformConduit<>(
+          modePersister,
+          (Multiple m) -> (Integer n) -> m.getFactor() * n);
+
+      transformByMode(conduit);
+
+      Assert.assertEquals(modePersister.get(), Multiple.TRIPLE);
+    } else {
+      final ModalTransformConduit<Integer, Integer, Multiple> conduit = new ModalTransformConduit<>(
+          Multiple.DOUBLE, m -> n -> m.getFactor() * n);
+
+      transformByMode(conduit);
+    }
+  }
+
+  private void transformByMode(final ModalTransformConduit<Integer, Integer, Multiple> conduit) {
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, left(5), right(Multiple.TRIPLE), left(2));
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(0).intValue(), 10);
+    Assert.assertEquals(results.get(1).intValue(), 6);
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/PeriodicConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/PeriodicConduitSpec.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import swim.dataflow.graph.StreamInterpretation;
+import swim.util.Deferred;
 
 public class PeriodicConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/PeriodicConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/PeriodicConduitSpec.java
@@ -1,0 +1,118 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.StreamInterpretation;
+
+public class PeriodicConduitSpec {
+
+  @Test
+  public void limitRateOfOutput() {
+
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+
+    final PeriodicConduit<String> conduit = new PeriodicConduit<>(schedule,
+        Duration.ofSeconds(5), StreamInterpretation.DISCRETE);
+
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = w -> results.add(w.get());
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    conduit.notifyChange(Deferred.value("The"));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+    conduit.notifyChange(Deferred.value("cat"));
+    conduit.notifyChange(Deferred.value("sat"));
+
+    Assert.assertTrue(results.isEmpty());
+
+    schedule.runScheduled(5000L);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "sat");
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+
+    schedule.runScheduled(5000L);
+    Assert.assertEquals(results.size(), 1);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+
+    conduit.notifyChange(Deferred.value("on"));
+    conduit.notifyChange(Deferred.value("the"));
+    conduit.notifyChange(Deferred.value("mat."));
+
+    schedule.runScheduled(5000L);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1), "mat.");
+  }
+
+  @Test
+  public void sampleFromInput() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+
+    final PeriodicConduit<String> conduit = new PeriodicConduit<>(schedule,
+        Duration.ofSeconds(5), StreamInterpretation.CONTINUOUS);
+
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = w -> results.add(w.get());
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    conduit.notifyChange(Deferred.value("The"));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+    conduit.notifyChange(Deferred.value("cat"));
+    conduit.notifyChange(Deferred.value("sat"));
+
+    Assert.assertTrue(results.isEmpty());
+
+    schedule.runScheduled(5000L);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "sat");
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+
+    schedule.runScheduled(5000L);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1), "sat");
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+
+    conduit.notifyChange(Deferred.value("on"));
+    conduit.notifyChange(Deferred.value("the"));
+    conduit.notifyChange(Deferred.value("mat."));
+
+    schedule.runScheduled(5000L);
+    Assert.assertEquals(results.size(), 3);
+    Assert.assertEquals(results.get(2), "mat.");
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/RateLimitedMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/RateLimitedMapConduitSpec.java
@@ -26,6 +26,7 @@ import swim.dataflow.connector.ConnectorTestUtil.Update;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.form.DurationForm;
+import swim.util.Deferred;
 
 public class RateLimitedMapConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/RateLimitedMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/RateLimitedMapConduitSpec.java
@@ -1,0 +1,212 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.connector.ConnectorTestUtil.Remove;
+import swim.dataflow.connector.ConnectorTestUtil.Update;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.form.DurationForm;
+
+public class RateLimitedMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void limitRateOfOutput(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(2)));
+
+      final RateLimitedMapConduit<String, Integer> conduit = new RateLimitedMapConduit<>(
+          schedule, periodPersister);
+
+      limitRateOfOutput(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(2));
+    } else {
+      final RateLimitedMapConduit<String, Integer> conduit = new RateLimitedMapConduit<>(
+          schedule, Duration.ofSeconds(2));
+
+      limitRateOfOutput(schedule, conduit);
+    }
+  }
+
+  private void limitRateOfOutput(final ConnectorTestUtil.FakeSchedule schedule,
+                                 final RateLimitedMapConduit<String, Integer> conduit) {
+    final ArrayList<MapAction<String, Integer>> outputs = new ArrayList<>();
+    final MapReceptacle<String, Integer> receptacle = new MapReceptacle<String, Integer>() {
+      @Override
+      public void notifyChange(final String key, final Deferred<Integer> value,
+                               final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new Remove<>(key, map.get()));
+      }
+    };
+
+    conduit.subscribe(receptacle);
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    HashTrieMap<String, Integer> state = HashTrieMap.<String, Integer>empty().updated("a", 1);
+    conduit.first().notifyChange("a", Deferred.value(1), Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    state = state.updated("b", 2);
+    conduit.first().notifyChange("b", Deferred.value(2), Deferred.value(MapView.wrap(state)));
+    state = state.updated("a", 3);
+    conduit.first().notifyChange("a", Deferred.value(3), Deferred.value(MapView.wrap(state)));
+    state = state.removed("b");
+    conduit.first().notifyRemoval("b", Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(outputs.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+
+    outputs.clear();
+
+    state = state.removed("a");
+    conduit.first().notifyRemoval("a", Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(outputs.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(outputs.get(0), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void changeOutputPeriod(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(2)));
+
+      final RateLimitedMapConduit<String, Integer> conduit = new RateLimitedMapConduit<>(
+          schedule, periodPersister);
+
+      changeOutputPeriod(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(1));
+    } else {
+      final RateLimitedMapConduit<String, Integer> conduit = new RateLimitedMapConduit<>(
+          schedule, Duration.ofSeconds(2));
+
+      changeOutputPeriod(schedule, conduit);
+    }
+  }
+
+  private void changeOutputPeriod(final ConnectorTestUtil.FakeSchedule schedule,
+                                  final RateLimitedMapConduit<String, Integer> conduit) {
+    final ArrayList<MapAction<String, Integer>> outputs = new ArrayList<>();
+    final MapReceptacle<String, Integer> receptacle = new MapReceptacle<String, Integer>() {
+      @Override
+      public void notifyChange(final String key, final Deferred<Integer> value,
+                               final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new Remove<>(key, map.get()));
+      }
+    };
+
+    conduit.subscribe(receptacle);
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    HashTrieMap<String, Integer> state = HashTrieMap.<String, Integer>empty().updated("a", 1);
+    conduit.first().notifyChange("a", Deferred.value(1), Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(outputs.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    outputs.clear();
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(1)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(1000L));
+
+    Assert.assertEquals(0, outputs.size());
+
+    state = state.removed("a");
+    conduit.first().notifyRemoval("a", Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(1000L);
+
+    Assert.assertEquals(outputs.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(outputs.get(0), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ReduceFieldsConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/ReduceFieldsConduitSpec.java
@@ -1,0 +1,74 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.ActionAccumulator;
+
+public class ReduceFieldsConduitSpec {
+
+  @Test
+  public void addValuesToReduction() {
+    final ReduceFieldsConduit<Long, Integer, Integer> conduit = new ReduceFieldsConduit<>(
+        0, Integer::sum, Integer::sum);
+
+    final ActionAccumulator<Long, Integer> acc = new ActionAccumulator<>();
+
+    final ArrayList<Integer> outputs = ConnectorTestUtil.pushData(conduit,
+        acc.update(1000L, 5),
+        acc.update(2000L, 7));
+
+    Assert.assertEquals(outputs.size(), 2);
+    Assert.assertEquals(outputs.get(0).intValue(), 5);
+    Assert.assertEquals(outputs.get(1).intValue(), 12);
+  }
+
+  @Test
+  public void replaceValueInReduction() {
+    final ReduceFieldsConduit<Long, Integer, Integer> conduit = new ReduceFieldsConduit<>(
+        0, Integer::sum, Integer::sum);
+
+    final ActionAccumulator<Long, Integer> acc = new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(conduit,
+        acc.update(1000L, 5),
+        acc.update(2000L, 7));
+
+    final ArrayList<Integer> outputs = ConnectorTestUtil.pushData(conduit, acc.update(1000L, -3));
+
+    Assert.assertEquals(outputs.size(), 1);
+    Assert.assertEquals(outputs.get(0).intValue(), 4);
+  }
+
+  @Test
+  public void removeValueFromReduction() {
+    final ReduceFieldsConduit<Long, Integer, Integer> conduit = new ReduceFieldsConduit<>(
+        0, Integer::sum, Integer::sum);
+
+    final ActionAccumulator<Long, Integer> acc = new ActionAccumulator<>();
+
+    ConnectorTestUtil.pushData(conduit,
+        acc.update(1000L, 5),
+        acc.update(2000L, 7));
+
+    final ArrayList<Integer> outputs = ConnectorTestUtil.pushData(conduit, acc.remove(1000L));
+
+    Assert.assertEquals(outputs.size(), 1);
+    Assert.assertEquals(outputs.get(0).intValue(), 7);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/SamplingMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/SamplingMapConduitSpec.java
@@ -1,0 +1,235 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.form.DurationForm;
+
+public class SamplingMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void sampleFromOutput(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(2)));
+
+      final SamplingMapConduit<String, Integer> conduit = new SamplingMapConduit<>(
+          schedule, periodPersister);
+
+      sampleFromOutput(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(2));
+    } else {
+      final SamplingMapConduit<String, Integer> conduit = new SamplingMapConduit<>(
+          schedule, Duration.ofSeconds(2));
+
+      sampleFromOutput(schedule, conduit);
+    }
+  }
+
+  private void sampleFromOutput(final ConnectorTestUtil.FakeSchedule schedule, final SamplingMapConduit<String, Integer> conduit) {
+    final ArrayList<MapAction<String, Integer>> outputs = new ArrayList<>();
+    final MapReceptacle<String, Integer> receptacle = new MapReceptacle<String, Integer>() {
+      @Override
+      public void notifyChange(final String key, final Deferred<Integer> value, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new ConnectorTestUtil.Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new ConnectorTestUtil.Remove<>(key, map.get()));
+      }
+    };
+
+    conduit.subscribe(receptacle);
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    HashTrieMap<String, Integer> state = HashTrieMap.<String, Integer>empty().updated("a", 1);
+    conduit.first().notifyChange("a", Deferred.value(1), Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    state = state.updated("b", 2);
+    conduit.first().notifyChange("b", Deferred.value(2), Deferred.value(MapView.wrap(state)));
+
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(outputs.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), 2);
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 2);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), 2);
+    });
+
+    outputs.clear();
+
+    state = state.removed("a");
+    conduit.first().notifyRemoval("a", Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(outputs.size(), 2);
+
+    for (final MapAction<String, Integer> action : outputs) {
+      action.push(new MapReceptacle<String, Integer>() {
+        @Override
+        public void notifyChange(final String key, final Deferred<Integer> value, final Deferred<MapView<String, Integer>> map) {
+          Assert.assertEquals(key, "b");
+          Assert.assertEquals(value.get().intValue(), 2);
+          final MapView<String, Integer> view = map.get();
+          Assert.assertEquals(view.size(), 1);
+          Assert.assertEquals(view.get("b").get().intValue(), 2);
+        }
+
+        @Override
+        public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+          Assert.assertEquals(key, "a");
+          final MapView<String, Integer> view = map.get();
+          Assert.assertEquals(view.size(), 1);
+          Assert.assertEquals(view.get("b").get().intValue(), 2);
+        }
+      });
+    }
+  }
+
+  @Test(dataProvider = "withState")
+  public void changeOutputPeriod(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(2)));
+
+      final SamplingMapConduit<String, Integer> conduit = new SamplingMapConduit<>(
+          schedule, periodPersister);
+
+      changeOutputPeriod(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(10));
+    } else {
+      final SamplingMapConduit<String, Integer> conduit = new SamplingMapConduit<>(
+          schedule, Duration.ofSeconds(2));
+
+      changeOutputPeriod(schedule, conduit);
+    }
+
+  }
+
+  private void changeOutputPeriod(final ConnectorTestUtil.FakeSchedule schedule,
+                                  final SamplingMapConduit<String, Integer> conduit) {
+    final ArrayList<MapAction<String, Integer>> outputs = new ArrayList<>();
+    final MapReceptacle<String, Integer> receptacle = new MapReceptacle<String, Integer>() {
+      @Override
+      public void notifyChange(final String key, final Deferred<Integer> value, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new ConnectorTestUtil.Update<>(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(new ConnectorTestUtil.Remove<>(key, map.get()));
+      }
+    };
+
+    conduit.subscribe(receptacle);
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    HashTrieMap<String, Integer> state = HashTrieMap.<String, Integer>empty().updated("a", 1);
+    conduit.first().notifyChange("a", Deferred.value(1), Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(0, outputs.size());
+
+    schedule.runScheduled(2000L);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(2000L));
+
+    Assert.assertEquals(outputs.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    outputs.clear();
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(10)));
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(10000L));
+
+    state = state.updated("b", 2);
+    conduit.first().notifyChange("b", Deferred.value(2), Deferred.value(MapView.wrap(state)));
+
+    Assert.assertEquals(outputs.size(), 0);
+
+    schedule.runScheduled(10000);
+
+    Assert.assertEquals(outputs.size(), 2);
+
+    final HashSet<String> expectedKeys = new HashSet<>();
+    expectedKeys.add("a");
+    expectedKeys.add("b");
+
+    for (final MapAction<String, Integer> action : outputs) {
+      ConnectorTestUtil.expectUpdate(action, (k, v, m) -> {
+        Assert.assertTrue(expectedKeys.contains(k));
+        expectedKeys.remove(k);
+        Assert.assertEquals(m.size(), 2);
+        Assert.assertEquals(m.get("a").get().intValue(), 1);
+        Assert.assertEquals(m.get("b").get().intValue(), 2);
+      });
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/SamplingMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/SamplingMapConduitSpec.java
@@ -25,6 +25,7 @@ import swim.dataflow.connector.ConnectorTestUtil.MapAction;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.form.DurationForm;
+import swim.util.Deferred;
 
 public class SamplingMapConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/StatefulConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/StatefulConduitSpec.java
@@ -1,0 +1,171 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.ConnectorTestUtil.Multiple;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.FingerTrieSeqForm;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class StatefulConduitSpec {
+
+  @Test
+  public void foldInputs() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<FingerTrieSeq<Integer>> persister =
+        provider.forValue("state", new FingerTrieSeqForm<>(Form.forInteger()), FingerTrieSeq.of(0));
+
+    final Conduit<Integer, FingerTrieSeq<Integer>> conduit = StatefulConduits.foldPersistent(
+        persister, FingerTrieSeq::appended);
+
+    final ArrayList<FingerTrieSeq<Integer>> results = ConnectorTestUtil.pushData(conduit, 1, 2, 3, 4);
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0), FingerTrieSeq.of(0, 1));
+    Assert.assertEquals(results.get(1), FingerTrieSeq.of(0, 1, 2));
+    Assert.assertEquals(results.get(2), FingerTrieSeq.of(0, 1, 2, 3));
+    Assert.assertEquals(results.get(3), FingerTrieSeq.of(0, 1, 2, 3, 4));
+
+    Assert.assertEquals(persister.get(), FingerTrieSeq.of(0, 1, 2, 3, 4));
+  }
+
+  @Test
+  public void reduceInputsFromNothing() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Integer> persister =
+        provider.forValue("state", Form.forInteger(), null);
+
+    final Conduit<Integer, Integer> conduit = StatefulConduits.reduce(persister, Math::min);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 35, 76, 12, 7);
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 35);
+    Assert.assertEquals(results.get(1).intValue(), 35);
+    Assert.assertEquals(results.get(2).intValue(), 12);
+    Assert.assertEquals(results.get(3).intValue(), 7);
+
+    Assert.assertEquals(persister.get().intValue(), 7);
+  }
+
+  @Test
+  public void reduceInputsFromSeed() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Integer> persister =
+        provider.forValue("state", Form.forInteger(), 30);
+
+    final Conduit<Integer, Integer> conduit = StatefulConduits.reduce(persister, Math::min);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 35, 76, 12, 7);
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 30);
+    Assert.assertEquals(results.get(1).intValue(), 30);
+    Assert.assertEquals(results.get(2).intValue(), 12);
+    Assert.assertEquals(results.get(3).intValue(), 7);
+
+    Assert.assertEquals(persister.get().intValue(), 7);
+  }
+
+  @Test
+  public void foldInputsModally() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Parity> modePersister = provider.forValue("mode", Form.forEnum(Parity.class), Parity.ODD);
+
+    final ValuePersister<FingerTrieSeq<Integer>> valPersister =
+        provider.forValue("state", new FingerTrieSeqForm<>(Form.forInteger()), FingerTrieSeq.of(0));
+
+    final Junction2<Integer, Parity, FingerTrieSeq<Integer>> conduit = StatefulConduits.modalFold(
+        modePersister, valPersister, (Parity p) -> (FingerTrieSeq<Integer> seq, Integer n) ->
+        (n % 2) == p.ordinal() ? seq.appended(n) : seq);
+
+    final ArrayList<FingerTrieSeq<Integer>> results = ConnectorTestUtil.pushData(
+        conduit, left(1), left(2), right(Parity.EVEN), left(3), left(4));
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0), FingerTrieSeq.of(0, 1));
+    Assert.assertEquals(results.get(1), FingerTrieSeq.of(0, 1));
+    Assert.assertEquals(results.get(2), FingerTrieSeq.of(0, 1));
+    Assert.assertEquals(results.get(3), FingerTrieSeq.of(0, 1, 4));
+
+    Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    Assert.assertEquals(valPersister.get(), FingerTrieSeq.of(0, 1, 4));
+  }
+
+  @Test
+  public void reduceInputsModallyFromNothing() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Multiple> modePersister = provider.forValue(
+        "mode", Form.forEnum(Multiple.class), Multiple.DOUBLE);
+    final ValuePersister<Integer> valPersister =
+        provider.forValue("state", Form.forInteger(), null);
+
+    final Junction2<Integer, Multiple, Integer> conduit =
+        StatefulConduits.modalReduce(modePersister, valPersister, m -> (sum, n) -> sum * m.getFactor() + n);
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(
+        conduit, left(1), left(2), right(Multiple.TRIPLE), left(3), left(4));
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 1);
+    Assert.assertEquals(results.get(1).intValue(), 4);
+    Assert.assertEquals(results.get(2).intValue(), 15);
+    Assert.assertEquals(results.get(3).intValue(), 49);
+
+    Assert.assertEquals(modePersister.get(), Multiple.TRIPLE);
+    Assert.assertEquals(valPersister.get().intValue(), 49);
+  }
+
+  @Test
+  public void reduceInputsModallyFromSeed() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Multiple> modePersister = provider.forValue(
+        "mode", Form.forEnum(Multiple.class), Multiple.DOUBLE);
+    final ValuePersister<Integer> valPersister =
+        provider.forValue("state", Form.forInteger(), 2);
+
+    final Junction2<Integer, Multiple, Integer> conduit =
+        StatefulConduits.modalReduce(modePersister, valPersister, m -> (sum, n) -> sum * m.getFactor() + n);
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(
+        conduit, left(1), left(2), right(Multiple.TRIPLE), left(3), left(4));
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 5);
+    Assert.assertEquals(results.get(1).intValue(), 12);
+    Assert.assertEquals(results.get(2).intValue(), 39);
+    Assert.assertEquals(results.get(3).intValue(), 121);
+
+    Assert.assertEquals(modePersister.get(), Multiple.TRIPLE);
+    Assert.assertEquals(valPersister.get().intValue(), 121);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/StatefulMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/StatefulMapConduitSpec.java
@@ -1,0 +1,306 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.Multiple;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import swim.dataflow.graph.persistence.FingerTrieSeqForm;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class StatefulMapConduitSpec {
+
+  @Test
+  public void foldInputs() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final MapPersister<String, FingerTrieSeq<Integer>> persister =
+        provider.forMap("state", Form.forString(), new FingerTrieSeqForm<>(Form.forInteger()), FingerTrieSeq.empty());
+
+    final MapConduit<String, String, Integer, FingerTrieSeq<Integer>> conduit = StatefulConduits.foldMapPersistent(
+        persister, FingerTrieSeq::appended);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, FingerTrieSeq<Integer>>> results = ConnectorTestUtil.pushData(
+        conduit,
+        acc.update("a", 1),
+        acc.update("a", 2),
+        acc.update("a", 3),
+        acc.update("b", 4),
+        acc.remove("a"));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 2);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 2, 3);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(4);
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1, 2, 3));
+      Assert.assertEquals(m.get("b").get(), FingerTrieSeq.of(4));
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(4), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get(), FingerTrieSeq.of(4));
+    });
+
+    Assert.assertEquals(persister.keys(), HashTrieSet.of("b"));
+    Assert.assertEquals(persister.get("b"), FingerTrieSeq.of(4));
+  }
+
+  @Test
+  public void reduceInputs() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final MapPersister<String, Integer> persister =
+        provider.forMap("state", Form.forString(), Form.forInteger(), null);
+
+    final StatefulMapConduit<String, Integer, Integer> conduit = StatefulConduits.reduceMap(persister, Math::min);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit,
+        acc.update("a", 35),
+        acc.update("b", 76),
+        acc.update("a", 12),
+        acc.update("b", 7),
+        acc.update("b", 99));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 35);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 35);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 76);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 35);
+      Assert.assertEquals(m.get("b").get().intValue(), 76);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 12);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 76);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+    Assert.assertEquals(persister.keys(), HashTrieSet.of("a", "b"));
+    Assert.assertEquals(persister.get("a").intValue(), 12);
+    Assert.assertEquals(persister.get("b").intValue(), 7);
+  }
+
+  @Test
+  public void foldInputsModally() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Parity> modePersister = provider.forValue("mode",
+        Form.forEnum(Parity.class), Parity.ODD);
+
+    final MapPersister<String, FingerTrieSeq<Integer>> persister =
+        provider.forMap("state", Form.forString(), new FingerTrieSeqForm<>(Form.forInteger()), FingerTrieSeq.empty());
+
+    final ModalStatefulMapConduit<String, Integer, Parity, FingerTrieSeq<Integer>> conduit =
+        StatefulConduits.modalFoldMap(modePersister, persister,
+            (Parity p) -> (FingerTrieSeq<Integer> seq, Integer n) -> (n % 2) == p.ordinal() ? seq.appended(n) : seq);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, FingerTrieSeq<Integer>>> results = ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update("a", 1)),
+        left(acc.update("b", 2)),
+        right(Parity.EVEN),
+        left(acc.remove("b")),
+        left(acc.update("a", 3)),
+        left(acc.update("a", 4)));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.empty();
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1));
+      Assert.assertEquals(m.get("b").get(), expected);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(2), (k, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1));
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 4);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    Assert.assertEquals(modePersister.get(), Parity.EVEN);
+    Assert.assertEquals(persister.keys(), HashTrieSet.of("a"));
+    Assert.assertEquals(persister.get("a"), FingerTrieSeq.of(1, 4));
+  }
+
+  @Test
+  public void reduceInputsModally() {
+
+    final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+
+    final ValuePersister<Multiple> modePersister = provider.forValue("mode",
+        Form.forEnum(Multiple.class), Multiple.DOUBLE);
+
+    final MapPersister<String, Integer> persister =
+        provider.forMap("state", Form.forString(), Form.forInteger(), null);
+
+    final ModalStatefulMapConduit<String, Integer, Multiple, Integer> conduit =
+        StatefulConduits.modalReduceMap(modePersister, persister, m -> (sum, n) -> sum * m.getFactor() + n);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update("a", 1)),
+        left(acc.update("a", 2)),
+        right(Multiple.TRIPLE),
+        left(acc.update("a", 3)),
+        left(acc.remove("a")),
+        left(acc.update("a", 4)));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 4);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 15);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 15);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(3), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 4);
+    });
+
+    Assert.assertEquals(modePersister.get(), Multiple.TRIPLE);
+    Assert.assertEquals(persister.keys(), HashTrieSet.of("a"));
+    Assert.assertEquals(persister.get("a").intValue(), 4);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransformConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransformConduitSpec.java
@@ -1,0 +1,33 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+public class TransformConduitSpec {
+
+  @Test
+  public void transformInput() {
+    final TransformConduit<Integer, Integer> conduit = new TransformConduit<>(n -> 2 * n);
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 2);
+
+    assertEquals(results.size(), 1);
+    assertEquals(results.get(0).intValue(), 4);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransformMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransformMapConduitSpec.java
@@ -1,0 +1,53 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TransformMapConduitSpec {
+
+  @Test
+  public void transformInput() {
+
+    final TransformMapConduit<Integer, Integer, Integer> conduit =
+        new TransformMapConduit<>((k, v) -> k * v);
+
+    final ConnectorTestUtil.ActionAccumulator<Integer, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, Integer>> results = ConnectorTestUtil.pushData(
+        conduit, acc.update(2, 3), acc.update(4, 7));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v.intValue(), 6);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(2).get().intValue(), 6);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v.intValue(), 28);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(2).get().intValue(), 6);
+      Assert.assertEquals(m.get(4).get().intValue(), 28);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientMapCollectorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientMapCollectorSpec.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.Pair;
+import static swim.dataflow.graph.Pair.pair;
+
+public class TransientMapCollectorSpec {
+
+  @Test
+  public void accumulateEntries() {
+
+    final TransientMapCollector<Pair<Integer, Integer>, Integer, Integer> collector =
+        new TransientMapCollector<>(Pair::getFirst, Pair::getSecond);
+
+    final ArrayList<ConnectorTestUtil.MapAction<Integer, Integer>> results = ConnectorTestUtil.pushData(
+        collector, pair(1, 2), pair(3, 3), pair(4, 5));
+
+    Assert.assertEquals(results.size(), 3);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 1);
+      Assert.assertEquals(v.intValue(), 2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 3);
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+      Assert.assertEquals(m.get(3).get().intValue(), 3);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 4);
+      Assert.assertEquals(v.intValue(), 5);
+      Assert.assertEquals(m.size(), 3);
+      Assert.assertEquals(m.get(1).get().intValue(), 2);
+      Assert.assertEquals(m.get(3).get().intValue(), 3);
+      Assert.assertEquals(m.get(4).get().intValue(), 5);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientStatefulConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientStatefulConduitSpec.java
@@ -1,0 +1,85 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.connector.ConnectorTestUtil.Multiple;
+import swim.dataflow.connector.ConnectorTestUtil.Parity;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class TransientStatefulConduitSpec {
+
+  @Test
+  public void foldInputs() {
+
+    final TransientStatefulConduit<Integer, FingerTrieSeq<Integer>> conduit = StatefulConduits.fold(
+        FingerTrieSeq.empty(), FingerTrieSeq::appended);
+
+    final ArrayList<FingerTrieSeq<Integer>> results = ConnectorTestUtil.pushData(conduit, 1, 2, 3, 4);
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0), FingerTrieSeq.of(1));
+    Assert.assertEquals(results.get(1), FingerTrieSeq.of(1, 2));
+    Assert.assertEquals(results.get(2), FingerTrieSeq.of(1, 2, 3));
+    Assert.assertEquals(results.get(3), FingerTrieSeq.of(1, 2, 3, 4));
+  }
+
+  @Test
+  public void reduceInputs() {
+    final TransientStatefulConduit<Integer, Integer> conduit = StatefulConduits.reduce(Math::min);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, 35, 76, 12, 7);
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 35);
+    Assert.assertEquals(results.get(1).intValue(), 35);
+    Assert.assertEquals(results.get(2).intValue(), 12);
+    Assert.assertEquals(results.get(3).intValue(), 7);
+  }
+
+  @Test
+  public void foldInputsModally() {
+    final TransientModalStatefulConduit<Integer, Parity, FingerTrieSeq<Integer>> conduit = StatefulConduits.modalFold(Parity.ODD,
+        FingerTrieSeq.empty(), p -> (seq, n) ->
+            (n % 2) == p.ordinal() ? seq.appended(n) : seq);
+
+    final ArrayList<FingerTrieSeq<Integer>> results = ConnectorTestUtil.pushData(
+        conduit, left(1), left(2), right(Parity.EVEN), left(3), left(4));
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0), FingerTrieSeq.of(1));
+    Assert.assertEquals(results.get(1), FingerTrieSeq.of(1));
+    Assert.assertEquals(results.get(2), FingerTrieSeq.of(1));
+    Assert.assertEquals(results.get(3), FingerTrieSeq.of(1, 4));
+  }
+
+  @Test
+  public void reduceInputsModally() {
+    final TransientModalStatefulConduit<Integer, Multiple, Integer> conduit =
+        StatefulConduits.modalReduce(Multiple.DOUBLE, m -> (sum, n) -> sum * m.getFactor() + n);
+
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(
+        conduit, left(1), left(2), right(Multiple.TRIPLE), left(3), left(4));
+
+    Assert.assertEquals(results.size(), 4);
+    Assert.assertEquals(results.get(0).intValue(), 1);
+    Assert.assertEquals(results.get(1).intValue(), 4);
+    Assert.assertEquals(results.get(2).intValue(), 15);
+    Assert.assertEquals(results.get(3).intValue(), 49);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientStatefulMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/TransientStatefulMapConduitSpec.java
@@ -1,0 +1,255 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class TransientStatefulMapConduitSpec {
+
+  @Test
+  public void foldInputs() {
+
+    final TransientStatefulMapConduit<String, Integer, FingerTrieSeq<Integer>> conduit = StatefulConduits.foldMap(
+        FingerTrieSeq.empty(), FingerTrieSeq::appended);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, FingerTrieSeq<Integer>>> results = ConnectorTestUtil.pushData(
+        conduit,
+        acc.update("a", 1),
+        acc.update("a", 2),
+        acc.update("a", 3),
+        acc.update("b", 4),
+        acc.remove("a"));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 2);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 2, 3);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(4);
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1, 2, 3));
+      Assert.assertEquals(m.get("b").get(), FingerTrieSeq.of(4));
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(4), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get(), FingerTrieSeq.of(4));
+    });
+  }
+
+  @Test
+  public void reduceInputs() {
+    final TransientStatefulMapConduit<String, Integer, Integer> conduit = StatefulConduits.reduceMap(Math::min);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, Integer>> results = ConnectorTestUtil.pushData(conduit,
+        acc.update("a", 35),
+        acc.update("b", 76),
+        acc.update("a", 12),
+        acc.update("b", 7),
+        acc.update("b", 99));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 35);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 35);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 76);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 35);
+      Assert.assertEquals(m.get("b").get().intValue(), 76);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 12);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 76);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 12);
+      Assert.assertEquals(m.get("b").get().intValue(), 7);
+    });
+  }
+
+  @Test
+  public void foldInputsModally() {
+    final TransientModalStatefulMapConduit<String, Integer, ConnectorTestUtil.Parity, FingerTrieSeq<Integer>> conduit =
+        StatefulConduits.modalFoldMap(ConnectorTestUtil.Parity.ODD, FingerTrieSeq.empty(),
+            p -> (seq, n) -> (n % 2) == p.ordinal() ? seq.appended(n) : seq);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, FingerTrieSeq<Integer>>> results = ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update("a", 1)),
+        left(acc.update("b", 2)),
+        right(ConnectorTestUtil.Parity.EVEN),
+        left(acc.remove("b")),
+        left(acc.update("a", 3)),
+        left(acc.update("a", 4)));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.empty();
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1));
+      Assert.assertEquals(m.get("b").get(), expected);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(2), (k, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), FingerTrieSeq.of(1));
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(3), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      final FingerTrieSeq<Integer> expected = FingerTrieSeq.of(1, 4);
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v, expected);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get(), expected);
+    });
+
+  }
+
+  @Test
+  public void reduceInputsModally() {
+    final TransientModalStatefulMapConduit<String, Integer, ConnectorTestUtil.Multiple, Integer> conduit =
+        StatefulConduits.modalReduceMap(ConnectorTestUtil.Multiple.DOUBLE, m -> (sum, n) -> sum * m.getFactor() + n);
+
+    final ConnectorTestUtil.ActionAccumulator<String, Integer> acc =
+        new ConnectorTestUtil.ActionAccumulator<>();
+
+    final ArrayList<ConnectorTestUtil.MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        conduit,
+        left(acc.update("a", 1)),
+        left(acc.update("a", 2)),
+        right(ConnectorTestUtil.Multiple.TRIPLE),
+        left(acc.update("a", 3)),
+        left(acc.remove("a")),
+        left(acc.update("a", 4)));
+
+    Assert.assertEquals(results.size(), 5);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 4);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(2), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 15);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 15);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(3), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(4), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 4);
+    });
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/UnionJunctionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/UnionJunctionSpec.java
@@ -17,6 +17,7 @@ package swim.dataflow.connector;
 import java.util.ArrayList;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import swim.util.Deferred;
 
 public class UnionJunctionSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/UnionJunctionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/UnionJunctionSpec.java
@@ -1,0 +1,46 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class UnionJunctionSpec {
+
+  @Test
+  public void propagateAllInputs() {
+    final int numInputs = 5;
+
+    final UnionJunction<Integer> junction = new UnionJunction<>(numInputs);
+
+    final ArrayList<Integer> results = new ArrayList<>(numInputs);
+
+    final Receptacle<Integer> receptacle = n -> results.add(n.get());
+
+    junction.subscribe(receptacle);
+
+    for (int i = 0; i < numInputs; ++i) {
+      junction.getInput(i).notifyChange(Deferred.value(i));
+    }
+
+    Assert.assertEquals(results.size(), numInputs);
+    for (int i = 0; i < numInputs; ++i) {
+      Assert.assertEquals(results.get(i).intValue(), i);
+    }
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableDelayJunctionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableDelayJunctionSpec.java
@@ -1,0 +1,177 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.Either;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialListPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+
+public class VariableDelayJunctionSpec {
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForZeroDelay() {
+    new VariableDelayJunction<>(0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForZeroDelayFromState() {
+    new VariableDelayJunction<Integer>(new TrivialListPersister<>(), new TrivialValuePersister<>(0));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForNegativeDelay() {
+    new VariableDelayJunction<>(-1);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForNegativeDelayFromState() {
+    new VariableDelayJunction<Integer>(new TrivialListPersister<>(), new TrivialValuePersister<>(-1));
+  }
+
+  @Test
+  public void emitsNothingOnIntialInput() {
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(1);
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, Either.left(7));
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void emitsPreviousValues() {
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(1);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(conduit, Either.left(7));
+    Assert.assertTrue(results1.isEmpty());
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, Either.left(5));
+    Assert.assertEquals(results2.size(), 1);
+    Assert.assertEquals(results2.get(0).intValue(), 7);
+    final ArrayList<Integer> results3 = ConnectorTestUtil.pushData(conduit, Either.left(2));
+    Assert.assertEquals(results3.size(), 1);
+    Assert.assertEquals(results3.get(0).intValue(), 5);
+  }
+
+  @Test
+  public void emitsWithLongerDelay() {
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(3);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(
+        conduit, Either.left(6), Either.left(5), Either.left(98));
+    Assert.assertTrue(results1.isEmpty());
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, Either.left(76));
+    Assert.assertEquals(results2.size(), 1);
+    Assert.assertEquals(results2.get(0).intValue(), 6);
+  }
+
+  @Test
+  public void storesBufferInState() {
+    final ListPersister<Integer> state = new TrivialListPersister<>();
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(state,
+        new TrivialValuePersister<>(2));
+    ConnectorTestUtil.pushData(conduit, Either.left(1), Either.left(2), Either.left(3), Either.left(4));
+    Assert.assertEquals(state.size(), 3);
+    Assert.assertEquals(state.get(0).intValue(), 2);
+    Assert.assertEquals(state.get(1).intValue(), 3);
+    Assert.assertEquals(state.get(2).intValue(), 4);
+  }
+
+  @Test
+  public void restoreBufferFromState() {
+    final ListPersister<Integer> state = new TrivialListPersister<>();
+    state.append(1);
+    state.append(2);
+    state.append(3);
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(state,
+        new TrivialValuePersister<>(2));
+    final ArrayList<Integer> results = ConnectorTestUtil.pushData(conduit, Either.left(4));
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), 2);
+  }
+
+  @Test
+  public void handleReductionInBufferSize() {
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(3);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(
+        conduit, Either.left(1), Either.left(2), Either.left(3), Either.left(4));
+
+    Assert.assertEquals(results1.size(), 1);
+    Assert.assertEquals(results1.get(0).intValue(), 1);
+
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, Either.right(1));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<Integer> results3 = ConnectorTestUtil.pushData(conduit, Either.left(5));
+
+    Assert.assertEquals(results3.size(), 1);
+    Assert.assertEquals(results3.get(0).intValue(), 4);
+  }
+
+  @Test
+  public void handleIncreaseInBufferSize() {
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(2);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(
+        conduit, Either.left(1), Either.left(2));
+
+    Assert.assertTrue(results1.isEmpty());
+
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, Either.right(3));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<Integer> results3 = ConnectorTestUtil.pushData(conduit, Either.left(3));
+
+    Assert.assertTrue(results3.isEmpty());
+
+    final ArrayList<Integer> results4 = ConnectorTestUtil.pushData(conduit, Either.left(4));
+
+    Assert.assertEquals(results4.size(), 1);
+    Assert.assertEquals(results4.get(0).intValue(), 1);
+  }
+
+  @Test
+  public void storesDelayInState() {
+    final ListPersister<Integer> bufferState = new TrivialListPersister<>();
+    final TrivialValuePersister<Integer> delayState = new TrivialValuePersister<>(2);
+    final VariableDelayJunction<Integer> junction = new VariableDelayJunction<>(bufferState, delayState);
+
+    ConnectorTestUtil.pushData(junction, Either.right(3));
+
+    Assert.assertEquals(delayState.get().intValue(), 3);
+  }
+
+  @Test
+  public void ignoresInvalidDelays() {
+    final TrivialValuePersister<Integer> delayState = new TrivialValuePersister<>(2);
+    final VariableDelayJunction<Integer> conduit = new VariableDelayJunction<>(
+        new TrivialListPersister<>(), delayState);
+    final ArrayList<Integer> results1 = ConnectorTestUtil.pushData(
+        conduit, Either.left(1), Either.left(2));
+
+    Assert.assertTrue(results1.isEmpty());
+
+    final ArrayList<Integer> results2 = ConnectorTestUtil.pushData(conduit, Either.right(-1));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<Integer> results3 = ConnectorTestUtil.pushData(conduit, Either.left(3));
+
+    Assert.assertEquals(results3.size(), 1);
+    Assert.assertEquals(results3.get(0).intValue(), 1);
+
+    Assert.assertEquals(delayState.get().intValue(), 2);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableDelayMapJunctionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableDelayMapJunctionSpec.java
@@ -1,0 +1,326 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.Either;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider.TrivialValuePersister;
+import static swim.dataflow.connector.ConnectorTestUtil.remove;
+import static swim.dataflow.connector.ConnectorTestUtil.update;
+import static swim.dataflow.graph.Either.left;
+import static swim.dataflow.graph.Either.right;
+
+public class VariableDelayMapJunctionSpec {
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForZeroDelay() {
+    new VariableDelayMapJunction<>(0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void failsForNegativeDelay() {
+    new VariableDelayMapJunction<>(-1);
+  }
+
+  @Test
+  public void emitsNothingOnIntialInput() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        junction, left(update("a", 3)));
+    Assert.assertTrue(results.isEmpty());
+  }
+
+  @Test
+  public void emitsPreviousValuesForAKey() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        junction, left(update("a", 3)), left(update("a", 5)));
+
+    Assert.assertEquals(results.size(), 1);
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+  }
+
+  @Test
+  public void emitsWithLongerDelay() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(3);
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        junction, left(update("a", 3)), left(update("a", 5)), left(update("a", -4)));
+    Assert.assertTrue(results.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(
+        junction, left(update("a", 10)));
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+  }
+
+  @Test
+  public void ignoresOtherKeysWithUnderfullBuffers() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(junction,
+        left(update("a", 3)), left(update("b", -2)), left(update("b", 4)));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), -2);
+    });
+  }
+
+  @Test
+  public void remembersPreviousKeys() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(1);
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(junction,
+        left(update("a", 3)), left(update("b", -2)), left(update("a", 12)), left(update("b", 4)));
+
+    Assert.assertEquals(results.size(), 2);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 3);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -2);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 3);
+      Assert.assertEquals(m.get("b").get().intValue(), -2);
+    });
+  }
+
+  @Test
+  public void restoreFromState() {
+    final SetPersister<String> keys = new TrivialPersistenceProvider.TrivialSetPersisiter<>();
+    keys.add("a");
+    keys.add("b");
+
+    final HashTrieMap<String, ListPersister<Integer>> buffers = HashTrieMap.<String, ListPersister<Integer>>empty()
+        .updated("a", new TrivialPersistenceProvider.TrivialListPersister<>())
+        .updated("b", new TrivialPersistenceProvider.TrivialListPersister<>());
+
+    final ListPersister<Integer> forA = buffers.get("a");
+    final ListPersister<Integer> forB = buffers.get("b");
+    Assert.assertNotNull(forA);
+    Assert.assertNotNull(forB);
+    forA.append(1);
+    forA.append(2);
+    forB.append(-1);
+
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(
+        buffers::get, keys, new TrivialValuePersister<>(1));
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        junction, left(update("b", 7)));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), -1);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), -1);
+    });
+  }
+
+  private static final class BufferFactory implements Function<String, ListPersister<Integer>> {
+    HashTrieMap<String, ListPersister<Integer>> persisters = HashTrieMap.empty();
+
+    @Override
+    public ListPersister<Integer> apply(final String s) {
+      final ListPersister<Integer> existing = persisters.get(s);
+      if (existing != null) {
+        return existing;
+      } else {
+        final TrivialPersistenceProvider.TrivialListPersister<Integer> fresh = new TrivialPersistenceProvider.TrivialListPersister<>();
+        persisters = persisters.updated(s, fresh);
+        return fresh;
+      }
+    }
+  }
+
+  @Test
+  public void storeKeysAndBuffersInState() {
+    final SetPersister<String> keys = new TrivialPersistenceProvider.TrivialSetPersisiter<>();
+    final VariableDelayMapJunctionSpec.BufferFactory fac = new VariableDelayMapJunctionSpec.BufferFactory();
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(
+        fac, keys, new TrivialValuePersister<>(1));
+
+    ConnectorTestUtil.pushData(junction,
+        left(update("a", 1)), left(update("b", 2)), left(update("b", 3)), left(update("b", 4)));
+
+    Assert.assertEquals(keys.get(), HashTrieSet.of("a", "b"));
+
+    final HashTrieMap<String, ListPersister<Integer>> buffers = fac.persisters;
+
+    Assert.assertEquals(buffers.keySet(), keys.get());
+
+    final ListPersister<Integer> forA = buffers.get("a");
+    Assert.assertNotNull(forA);
+    Assert.assertEquals(forA.size(), 1);
+    Assert.assertEquals(forA.get(0).intValue(), 1);
+
+    final ListPersister<Integer> forB = buffers.get("b");
+    Assert.assertNotNull(forB);
+    Assert.assertEquals(forB.size(), 2);
+    Assert.assertEquals(forB.get(0).intValue(), 3);
+    Assert.assertEquals(forB.get(1).intValue(), 4);
+  }
+
+  @Test
+  public void removalResetsBuffers() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(1);
+    ConnectorTestUtil.pushData(
+        junction, left(update("a", 3)), left(update("a", 5)));
+
+    final ArrayList<MapAction<String, Integer>> results = ConnectorTestUtil.pushData(
+        junction, left(remove("a")), left(update("a", 7)));
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectRemoval(results.get(0), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  @Test
+  public void handleReductionInBufferSize() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(3);
+    final ArrayList<MapAction<String, Integer>> results1 = ConnectorTestUtil.pushData(
+        junction, left(update("a", 1)), left(update("a", 2)), left(update("a", 3)), left(update("a", 4)));
+
+    Assert.assertEquals(results1.size(), 1);
+    ConnectorTestUtil.expectUpdate(results1.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(junction, right(1));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results3 = ConnectorTestUtil.pushData(junction, left(update("a", 5)));
+
+    Assert.assertEquals(results3.size(), 1);
+    ConnectorTestUtil.expectUpdate(results3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 4);
+    });
+  }
+
+  @Test
+  public void handleIncreaseInBufferSize() {
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(2);
+    final ArrayList<MapAction<String, Integer>> results1 = ConnectorTestUtil.pushData(
+        junction, left(update("a", 1)), left(update("a", 2)));
+
+    Assert.assertTrue(results1.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(junction, right(3));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results3 = ConnectorTestUtil.pushData(junction, left(update("a", 3)));
+
+    Assert.assertTrue(results3.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results4 = ConnectorTestUtil.pushData(junction, left(update("a", 4)));
+
+    Assert.assertEquals(results4.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+  }
+
+  @Test
+  public void storesDelayInState() {
+    final SetPersister<String> keys = new TrivialPersistenceProvider.TrivialSetPersisiter<>();
+    final VariableDelayMapJunctionSpec.BufferFactory fac = new VariableDelayMapJunctionSpec.BufferFactory();
+    final TrivialValuePersister<Integer> delayState = new TrivialValuePersister<>(2);
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(
+        fac, keys, delayState);
+
+    ConnectorTestUtil.pushData(junction, Either.right(3));
+
+    Assert.assertEquals(delayState.get().intValue(), 3);
+  }
+
+  @Test
+  public void ignoresInvalidDelays() {
+    final SetPersister<String> keys = new TrivialPersistenceProvider.TrivialSetPersisiter<>();
+    final VariableDelayMapJunctionSpec.BufferFactory fac = new VariableDelayMapJunctionSpec.BufferFactory();
+    final TrivialValuePersister<Integer> delayState = new TrivialValuePersister<>(2);
+    final VariableDelayMapJunction<String, Integer> junction = new VariableDelayMapJunction<>(
+        fac, keys, delayState);
+
+
+    final ArrayList<MapAction<String, Integer>> results1 = ConnectorTestUtil.pushData(
+        junction, left(update("a", 1)), left(update("a", 2)));
+
+    Assert.assertTrue(results1.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results2 = ConnectorTestUtil.pushData(junction, right(-1));
+
+    Assert.assertTrue(results2.isEmpty());
+
+    final ArrayList<MapAction<String, Integer>> results3 = ConnectorTestUtil.pushData(junction, left(update("a", 3)));
+
+    Assert.assertEquals(results3.size(), 1);
+    ConnectorTestUtil.expectUpdate(results3.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 1);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 1);
+    });
+
+    Assert.assertEquals(delayState.get().intValue(), 2);
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableFlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableFlatMapConduitSpec.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.form.DurationForm;
+import swim.util.Deferred;
 
 public class VariableFlatMapConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableFlatMapConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariableFlatMapConduitSpec.java
@@ -1,0 +1,90 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.form.DurationForm;
+
+public class VariableFlatMapConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void emitOutputsOnVariableSchedule(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("state",
+          new DurationForm(Duration.ofSeconds(2)));
+      final VariableFlatMapConduit<Integer, Integer> conduit = new VariableFlatMapConduit<>(n -> Arrays.asList(n, n + 1),
+          schedule, periodPersister);
+      emitOutputsOnVariableSchedule(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(5));
+    } else {
+      final VariableFlatMapConduit<Integer, Integer> conduit = new VariableFlatMapConduit<>(n -> Arrays.asList(n, n + 1),
+          schedule, Duration.ofSeconds(2));
+
+      emitOutputsOnVariableSchedule(schedule, conduit);
+    }
+  }
+
+  private void emitOutputsOnVariableSchedule(final ConnectorTestUtil.FakeSchedule schedule, final VariableFlatMapConduit<Integer, Integer> conduit) {
+    final ArrayList<Integer> results = new ArrayList<>(2);
+
+    final Receptacle<Integer> receptacle = n -> results.add(n.get());
+
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    conduit.first().notifyChange(Deferred.value(1));
+
+    check(schedule, results, 2000, 1);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 0);
+
+    results.clear();
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(5)));
+    conduit.first().notifyChange(Deferred.value(3));
+
+    check(schedule, results, 5000, 3);
+  }
+
+  private void check(final ConnectorTestUtil.FakeSchedule schedule, final ArrayList<Integer> results,
+                     final long delay,
+                     final int start) {
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0).intValue(), start);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(delay));
+    schedule.runScheduled(delay);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1).intValue(), start + 1);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariablePeriodicConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariablePeriodicConduitSpec.java
@@ -23,6 +23,7 @@ import swim.dataflow.graph.StreamInterpretation;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.dataflow.graph.persistence.ValuePersister;
 import swim.structure.form.DurationForm;
+import swim.util.Deferred;
 
 public class VariablePeriodicConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariablePeriodicConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/connector/VariablePeriodicConduitSpec.java
@@ -1,0 +1,170 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.connector;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.StreamInterpretation;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.form.DurationForm;
+
+public class VariablePeriodicConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+
+  @Test(dataProvider = "withState")
+  public void limitRateOfOutput(final boolean withState) {
+
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(5)));
+
+      final VariablePeriodicConduit<String> conduit = new VariablePeriodicConduit<>(schedule,
+          periodPersister, StreamInterpretation.DISCRETE);
+
+      limitRateOfOutput(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(4));
+    } else {
+      final VariablePeriodicConduit<String> conduit = new VariablePeriodicConduit<>(schedule,
+          Duration.ofSeconds(5), StreamInterpretation.DISCRETE);
+
+      limitRateOfOutput(schedule, conduit);
+    }
+  }
+
+  private void limitRateOfOutput(final ConnectorTestUtil.FakeSchedule schedule,
+                                 final VariablePeriodicConduit<String> conduit) {
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = w -> results.add(w.get());
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    conduit.first().notifyChange(Deferred.value("The"));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+    conduit.first().notifyChange(Deferred.value("cat"));
+    conduit.first().notifyChange(Deferred.value("sat"));
+
+    Assert.assertTrue(results.isEmpty());
+
+    schedule.runScheduled(5000L);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "sat");
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(4)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(4000L));
+
+    schedule.runScheduled(4000L);
+    Assert.assertEquals(results.size(), 1);
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(4000L));
+
+    conduit.first().notifyChange(Deferred.value("on"));
+    conduit.first().notifyChange(Deferred.value("the"));
+    conduit.first().notifyChange(Deferred.value("mat."));
+
+    schedule.runScheduled(4000L);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1), "mat.");
+  }
+
+  @Test(dataProvider = "withState")
+  public void sampleFromInput(final boolean withState) {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    if (withState) {
+
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final ValuePersister<Duration> periodPersister = provider.forValue("period",
+          new DurationForm(Duration.ofSeconds(5)));
+
+      final VariablePeriodicConduit<String> conduit = new VariablePeriodicConduit<>(schedule,
+          periodPersister, StreamInterpretation.CONTINUOUS);
+
+      sampleFromInput(schedule, conduit);
+
+      Assert.assertEquals(periodPersister.get(), Duration.ofSeconds(4));
+    } else {
+      final VariablePeriodicConduit<String> conduit = new VariablePeriodicConduit<>(schedule,
+          Duration.ofSeconds(5), StreamInterpretation.CONTINUOUS);
+
+      sampleFromInput(schedule, conduit);
+    }
+
+  }
+
+  private void sampleFromInput(final ConnectorTestUtil.FakeSchedule schedule,
+                               final VariablePeriodicConduit<String> conduit) {
+    final ArrayList<String> results = new ArrayList<>();
+
+    final Receptacle<String> receptacle = w -> results.add(w.get());
+    conduit.subscribe(receptacle);
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+
+    conduit.first().notifyChange(Deferred.value("The"));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+    conduit.first().notifyChange(Deferred.value("cat"));
+    conduit.first().notifyChange(Deferred.value("sat"));
+
+    Assert.assertTrue(results.isEmpty());
+
+    schedule.runScheduled(5000L);
+
+    Assert.assertEquals(results.size(), 1);
+    Assert.assertEquals(results.get(0), "sat");
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(5000L));
+
+    schedule.runScheduled(5000L);
+    Assert.assertEquals(results.size(), 2);
+    Assert.assertEquals(results.get(1), "sat");
+
+    conduit.second().notifyChange(Deferred.value(Duration.ofSeconds(4)));
+
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(4000L));
+
+    conduit.first().notifyChange(Deferred.value("on"));
+    conduit.first().notifyChange(Deferred.value("the"));
+    conduit.first().notifyChange(Deferred.value("mat."));
+
+    schedule.runScheduled(4000L);
+    Assert.assertEquals(results.size(), 3);
+    Assert.assertEquals(results.get(2), "mat.");
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/GraphConstructionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/GraphConstructionSpec.java
@@ -18,12 +18,12 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import swim.dataflow.connector.AbstractJunction;
 import swim.dataflow.connector.ConnectorTestUtil;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.Receptacle;
 import swim.dataflow.graph.Sink;
 import swim.dataflow.graph.SwimStreamContext;
 import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 public class GraphConstructionSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/GraphConstructionSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/GraphConstructionSpec.java
@@ -1,0 +1,76 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.AbstractJunction;
+import swim.dataflow.connector.ConnectorTestUtil;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.Receptacle;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.structure.Form;
+
+public class GraphConstructionSpec {
+
+  private static final class TestInput<T> extends AbstractJunction<T> {
+
+    void push(final T val) {
+      emit(Deferred.value(val));
+    }
+
+  }
+
+  private static final class TestSink<T> implements Sink<T> {
+
+    private T value = null;
+
+    public T getValue() {
+      return value;
+    }
+
+    @Override
+    public Receptacle<T> instantiate(final SwimStreamContext.InitContext context) {
+      return val -> value = val.get();
+    }
+  }
+
+  @Test
+  public void executeSimpleGraph() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final ContextImpl context = new ContextImpl(schedule, new TrivialPersistenceProvider());
+    final TestInput<Integer> input = new TestInput<>();
+    final TestSink<Integer> output = new TestSink<>();
+
+    context.fromJunction(input, Form.forInteger())
+        .map(n -> n * 2)
+        .reduce(Math::max)
+        .bind(output);
+
+    context.constructGraph();
+    input.push(6);
+    Assert.assertEquals(output.getValue().intValue(), 12);
+
+    input.push(10);
+    Assert.assertEquals(output.getValue().intValue(), 20);
+
+    input.push(7);
+    Assert.assertEquals(output.getValue().intValue(), 20);
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/partitions/PartitionConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/partitions/PartitionConduitSpec.java
@@ -1,0 +1,315 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.partitions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.TrivialPersistenceProvider;
+import swim.dataflow.graph.windows.PartitionAssigner;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Value;
+
+public class PartitionConduitSpec {
+
+  @DataProvider(name = "withState")
+  public Object[][] withOrWithoutState() {
+    return new Object[][] {{true}, {false}};
+  }
+
+  @Test(dataProvider = "withState")
+  public void emitsSinglePartitionCorrectly(final boolean withState) {
+    final SimplePartitionAssigner<Integer, Integer, PartitionSet<Integer>> assigner =
+        SimplePartitionAssigner.ofMulti(n -> HashTrieSet.of(n % 5));
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, Integer> persister = provider.forMap("state", Form.forInteger(), Form.forInteger());
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, persister);
+      emitsSinglePartitionCorrectly(conduit);
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(2));
+      Assert.assertEquals(persister.get(2).intValue(), 7);
+    } else {
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, Form.forInteger());
+
+      emitsSinglePartitionCorrectly(conduit);
+    }
+  }
+
+  private void emitsSinglePartitionCorrectly(final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit) {
+    final ArrayList<MapAction<Integer, Integer>> results =
+        ConnectorTestUtil.pushData(conduit, 7);
+
+    Assert.assertEquals(results.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v.intValue(), 7);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get(2).get().intValue(), 7);
+    });
+  }
+
+  @Test(dataProvider = "withState")
+  public void emitsTwoPartitionsCorrectly(final boolean withState) {
+    final SimplePartitionAssigner<Integer, Integer, PartitionSet<Integer>> assigner =
+        SimplePartitionAssigner.ofMulti(n -> HashTrieSet.of(n % 3, n % 5, n % 7));
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, Integer> persister = provider.forMap("state", Form.forInteger(), Form.forInteger());
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, persister);
+
+      emitsTwoPartitionsCorrectly(conduit);
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(0, 1, 2));
+      Assert.assertEquals(persister.get(0).intValue(), 7);
+      Assert.assertEquals(persister.get(1).intValue(), 7);
+      Assert.assertEquals(persister.get(2).intValue(), 7);
+    } else {
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, Form.forInteger());
+
+      emitsTwoPartitionsCorrectly(conduit);
+    }
+  }
+
+  private void emitsTwoPartitionsCorrectly(final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit) {
+    final ArrayList<MapAction<Integer, Integer>> results =
+        ConnectorTestUtil.pushData(conduit, 7);
+
+    Assert.assertEquals(results.size(), 3);
+
+    final HashSet<Integer> expectedParts = new HashSet<>();
+    expectedParts.add(0);
+    expectedParts.add(1);
+    expectedParts.add(2);
+
+    for (final MapAction<Integer, Integer> action : results) {
+      ConnectorTestUtil.expectUpdate(action, (k, v, m) -> {
+        Assert.assertTrue(expectedParts.contains(k));
+        expectedParts.remove(k);
+        Assert.assertEquals(v.intValue(), 7);
+        Assert.assertEquals(m.size(), 3);
+        Assert.assertEquals(m.get(0).get().intValue(), 7);
+        Assert.assertEquals(m.get(1).get().intValue(), 7);
+        Assert.assertEquals(m.get(2).get().intValue(), 7);
+      });
+    }
+  }
+
+  @Test(dataProvider = "withState")
+  public void updateExistingPartition(final boolean withState) {
+    final SimplePartitionAssigner<Integer, Integer, PartitionSet<Integer>> assigner =
+        SimplePartitionAssigner.ofMulti(PartitionConduitSpec::nonTrivialFactors);
+
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<Integer, Integer> persister = provider.forMap("state", Form.forInteger(), Form.forInteger());
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, persister);
+
+      updateExistingPartition(conduit);
+
+
+      Assert.assertEquals(persister.keys(), HashTrieSet.of(2, 4));
+      Assert.assertEquals(persister.get(2).intValue(), 4);
+      Assert.assertEquals(persister.get(4).intValue(), 8);
+    } else {
+      final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit =
+          new PartitionConduit<>(assigner, Form.forInteger());
+
+      updateExistingPartition(conduit);
+    }
+
+  }
+
+  private void updateExistingPartition(final PartitionConduit<Integer, Integer, PartitionSet<Integer>> conduit) {
+    final ArrayList<MapAction<Integer, Integer>> results1 = ConnectorTestUtil.pushData(conduit, 8);
+
+    Assert.assertEquals(results1.size(), 2);
+
+    final ArrayList<MapAction<Integer, Integer>> results2 = ConnectorTestUtil.pushData(conduit, 4);
+
+    Assert.assertEquals(results2.size(), 1);
+
+    ConnectorTestUtil.expectUpdate(results2.get(0), (k, v, m) -> {
+      Assert.assertEquals(k.intValue(), 2);
+      Assert.assertEquals(v.intValue(), 4);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get(2).get().intValue(), 4);
+      Assert.assertEquals(m.get(4).get().intValue(), 8);
+    });
+  }
+
+  private static Set<Integer> nonTrivialFactors(final int n) {
+    HashTrieSet<Integer> facs = HashTrieSet.empty();
+    for (int i = 2; i < n; ++i) {
+      if (n % i == 0) {
+        facs = facs.added(i);
+      }
+    }
+    return facs;
+  }
+
+  @Test(dataProvider = "withState")
+  public void removeExpiredPartition(final boolean withState) {
+    final TestPartitionAssigner assigner = new TestPartitionAssigner();
+    if (withState) {
+      final TrivialPersistenceProvider provider = new TrivialPersistenceProvider();
+      final MapPersister<String, Record> persister = provider.forMap("state", Form.forString(), RECORD_FORM);
+      final PartitionConduit<Record, String, PartitionSet<String>> conduit =
+          new PartitionConduit<>(assigner, persister);
+
+      removeExpiredPartitions(conduit);
+
+      Assert.assertTrue(persister.keys().isEmpty());
+    } else {
+      final PartitionConduit<Record, String, PartitionSet<String>> conduit =
+          new PartitionConduit<>(assigner, RECORD_FORM);
+
+      removeExpiredPartitions(conduit);
+    }
+  }
+
+  private void removeExpiredPartitions(final PartitionConduit<Record, String, PartitionSet<String>> conduit) {
+    final ArrayList<MapAction<String, Record>> results = ConnectorTestUtil.pushData(conduit,
+        new Record("name", false, 2),
+        new Record("name", false, 8),
+        new Record("name", true, -1));
+
+    Assert.assertEquals(results.size(), 3);
+
+    ConnectorTestUtil.expectUpdate(results.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "name");
+      Assert.assertEquals(v.data, 2);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("name").get().data, 2);
+    });
+
+    ConnectorTestUtil.expectUpdate(results.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "name");
+      Assert.assertEquals(v.data, 8);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("name").get().data, 8);
+    });
+
+    ConnectorTestUtil.expectRemoval(results.get(2), (k, m) -> {
+      Assert.assertEquals(k, "name");
+      Assert.assertEquals(m.size(), 0);
+    });
+  }
+
+  private static final class Record {
+    private final String kind;
+    private final boolean finished;
+    private final int data;
+
+    private Record(final String kind, final boolean finished, final int data) {
+      this.kind = kind;
+      this.finished = finished;
+      this.data = data;
+    }
+  }
+
+  private static final Form<Record> RECORD_FORM = new Form<Record>() {
+    @Override
+    public Class<?> type() {
+      return Form.class;
+    }
+
+    @Override
+    public Item mold(final Record object) {
+      if (object != null) {
+        return swim.structure.Record.create(1).attr("rec",
+            swim.structure.Record.create(3).item(object.kind).item(object.finished).item(object.data));
+      } else {
+        return Value.absent();
+      }
+    }
+
+    @Override
+    public Record cast(final Item item) {
+      if (item.isDefined()) {
+        final Value asValue = item.toValue();
+        final String kind = asValue.getItem(0).stringValue();
+        final boolean finished = asValue.getItem(1).booleanValue();
+        final int data = asValue.getItem(2).intValue();
+        return new Record(kind, finished, data);
+      } else {
+        return null;
+      }
+    }
+  };
+
+  private static final class TestPartitionAssigner implements
+      PartitionAssigner<Record, String, PartitionSet<String>> {
+
+    @Override
+    public Supplier<PartitionSet<String>> stateFactory() {
+      return PartitionSet::new;
+    }
+
+    @Override
+    public Assignment<String, PartitionSet<String>> partitionsFor(final Record data,
+                                                                  final PartitionSet<String> partState) {
+      final String part = data.kind;
+      if (!data.finished) {
+
+        final PartitionSet<String> newState =
+            partState.activePartitions().contains(part) ? partState : partState.addPartition(part);
+        return new Assignment<String, PartitionSet<String>>() {
+          @Override
+          public Set<String> partitions() {
+            return Collections.singleton(part);
+          }
+
+          @Override
+          public PartitionSet<String> updatedState() {
+            return newState;
+          }
+        };
+      } else {
+        final PartitionSet<String> newState =
+            partState.activePartitions().contains(part) ? partState.removePartition(part) : partState;
+        return new Assignment<String, PartitionSet<String>>() {
+          @Override
+          public Set<String> partitions() {
+            return Collections.emptySet();
+          }
+
+          @Override
+          public PartitionSet<String> updatedState() {
+            return newState;
+          }
+        };
+      }
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/partitions/SimplePartitionAssignerSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/partitions/SimplePartitionAssignerSpec.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.partitions;
+
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.graph.windows.PartitionAssigner;
+
+public class SimplePartitionAssignerSpec {
+
+  @Test
+  public void initialStateEmpty() {
+    final SimplePartitionAssigner<Integer, Integer, PartitionSet<Integer>> assigner =
+        SimplePartitionAssigner.of(n -> n % 5);
+
+    final PartitionSet<Integer> state = assigner.stateFactory().get();
+    Assert.assertTrue(state.activePartitions().isEmpty());
+  }
+
+  @Test
+  public void assignsPartitionsCorrectly() {
+    final SimplePartitionAssigner<Integer, Integer, PartitionSet<Integer>> assigner =
+        SimplePartitionAssigner.of(n -> n % 5);
+
+    final PartitionSet<Integer> state = assigner.stateFactory().get();
+    final PartitionAssigner.Assignment<Integer, PartitionSet<Integer>> assignment =
+        assigner.partitionsFor(6, state);
+
+    Assert.assertEquals(assignment.partitions(), Collections.singleton(1));
+    final PartitionSet<Integer> newState = assignment.updatedState();
+
+    Assert.assertEquals(newState.activePartitions(), Collections.singleton(1));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/DefaultPaneManagerSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/DefaultPaneManagerSpec.java
@@ -1,0 +1,633 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.Unit;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.ActionWithCallback;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.OnInit;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.OutputCollector;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.SelfReplacingCallback;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.SingleAction;
+import swim.dataflow.graph.impl.windows.WindowTestingMocks.UnitAssigner;
+import swim.dataflow.graph.windows.SingletonWindowStore;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.dataflow.graph.windows.triggers.TriggerAction;
+
+public class DefaultPaneManagerSpec {
+
+  @Test
+  public void handleNoActionOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createSimple(acc, outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(43));
+  }
+
+  @Test
+  public void handlePurgeOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new OnInit(TriggerAction.PURGE), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  @Test
+  public void handleTriggerOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new OnInit(TriggerAction.TRIGGER), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 42);
+
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(43));
+  }
+
+  @Test
+  public void handleTriggerAndPurgeOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new OnInit(TriggerAction.TRIGGER_AND_PURGE), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 42);
+
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  @Test
+  public void handleDoubleTriggerOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new OnInit(TriggerAction.TRIGGER, TriggerAction.TRIGGER), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 2);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 42);
+    Assert.assertEquals(outputs.getOutputs().get(1).getSecond().intValue(), 43);
+
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(43));
+  }
+
+  @Test
+  public void handleTriggerPurgeTriggerOnInit() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new OnInit(TriggerAction.TRIGGER_AND_PURGE, TriggerAction.TRIGGER), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 2);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 42);
+    Assert.assertEquals(outputs.getOutputs().get(1).getSecond().intValue(), 1);
+
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+
+  @Test
+  public void requestCallbackOnInit() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new WindowTestingMocks.CallbackOnInit(1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+    Assert.assertEquals(outputs.getCallbacks().get(0).getFirst().longValue(), 1000L);
+
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(43));
+  }
+
+  @Test
+  public void ignoreCallbackOnPurgeInit() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new WindowTestingMocks.CallbackOnInit(TriggerAction.PURGE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  @Test
+  public void ignoreCallbackOnPurgeAndTriggerInit() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final MapWindowAccumulators<Unit, Integer> acc = new MapWindowAccumulators<>(HashTrieMap.of(Unit.INSTANCE, 42));
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(acc, new WindowTestingMocks.CallbackOnInit(TriggerAction.TRIGGER_AND_PURGE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 42);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  @Test
+  public void handleNoTrigger() {
+
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createSimple(TriggerAction.NONE, outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+  }
+
+  @Test
+  public void handlePurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createSimple(TriggerAction.PURGE, outputs);
+
+    final HashTrieMap<Unit, Integer> state = HashTrieMap.<Unit, Integer>empty().updated(Unit.INSTANCE, 3);
+    manager.setInternalState(new SingletonWindowStore<>(Unit.INSTANCE), new MapWindowAccumulators<>(state));
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertTrue(internalState.windows().isEmpty());
+
+  }
+
+  @Test
+  public void handleTrigger() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createSimple(TriggerAction.TRIGGER, outputs);
+
+    final HashTrieMap<Unit, Integer> state = HashTrieMap.<Unit, Integer>empty().updated(Unit.INSTANCE, 3);
+    manager.setInternalState(new SingletonWindowStore<>(Unit.INSTANCE), new MapWindowAccumulators<>(state));
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 4);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertFalse(internalState.windows().isEmpty());
+    Assert.assertEquals(internalState.getForWindow(Unit.INSTANCE), Optional.of(4));
+  }
+
+  @Test
+  public void handleTriggerAndPurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createSimple(TriggerAction.TRIGGER_AND_PURGE, outputs);
+
+    final HashTrieMap<Unit, Integer> state = HashTrieMap.<Unit, Integer>empty().updated(Unit.INSTANCE, 3);
+    manager.setInternalState(new SingletonWindowStore<>(Unit.INSTANCE), new MapWindowAccumulators<>(state));
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 4);
+    Assert.assertEquals(outputs.getCallbacks().size(), 0);
+
+    final WindowAccumulators<Unit, Integer> internalState = manager.getAccumulators();
+    Assert.assertTrue(internalState.windows().isEmpty());
+  }
+
+  @Test
+  public void ignoreTimersOnPurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.PURGE, TriggerAction.PURGE, TriggerAction.NONE, 1000L), outputs);
+
+    final HashTrieMap<Unit, Integer> state = HashTrieMap.<Unit, Integer>empty().updated(Unit.INSTANCE, 3);
+    manager.setInternalState(new SingletonWindowStore<>(Unit.INSTANCE), new MapWindowAccumulators<>(state));
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+  }
+
+  @Test
+  public void ignoreTimersOnTriggerAndPurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.TRIGGER_AND_PURGE, TriggerAction.PURGE, TriggerAction.NONE, 1000L), outputs);
+
+    final HashTrieMap<Unit, Integer> state = HashTrieMap.<Unit, Integer>empty().updated(Unit.INSTANCE, 3);
+    manager.setInternalState(new SingletonWindowStore<>(Unit.INSTANCE), new MapWindowAccumulators<>(state));
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+  }
+
+  @Test
+  public void handleNoActionOnTimer() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.NONE, TriggerAction.NONE, TriggerAction.NONE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertTrue(outputs.getOutputs().isEmpty());
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertFalse(stateAfterTimer.windows().isEmpty());
+    Assert.assertEquals(stateAfterTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+  }
+
+  @Test
+  public void handlePurgeOnTimer() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.NONE, TriggerAction.PURGE, TriggerAction.NONE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertTrue(outputs.getOutputs().isEmpty());
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertTrue(stateAfterTimer.windows().isEmpty());
+
+  }
+
+  @Test
+  public void handleTriggerOnTimer() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.NONE, TriggerAction.TRIGGER, TriggerAction.NONE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 1);
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertFalse(stateAfterTimer.windows().isEmpty());
+    Assert.assertEquals(stateAfterTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+  }
+
+  @Test
+  public void handleTriggerAndPurgeOnTimer() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new ActionWithCallback(TriggerAction.NONE, TriggerAction.TRIGGER_AND_PURGE,
+            TriggerAction.NONE, 1000L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 1);
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertTrue(stateAfterTimer.windows().isEmpty());
+
+  }
+
+  @Test
+  public void ignoreNewTimersOnTimerOnPurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new SelfReplacingCallback(
+            TriggerAction.NONE, TriggerAction.PURGE, TriggerAction.NONE, 1000L, 100L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertTrue(outputs.getOutputs().isEmpty());
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertTrue(stateAfterTimer.windows().isEmpty());
+  }
+
+  @Test
+  public void ignoreNewTimersOnTimerOnTriggerAndPurge() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new SelfReplacingCallback(
+            TriggerAction.NONE, TriggerAction.TRIGGER_AND_PURGE, TriggerAction.NONE, 1000L, 100L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 1);
+    Assert.assertTrue(outputs.getCallbacks().isEmpty());
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertTrue(stateAfterTimer.windows().isEmpty());
+  }
+
+  @Test
+  public void registerCallbackOnTimerOnNoAction() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new SelfReplacingCallback(
+            TriggerAction.NONE, TriggerAction.NONE, TriggerAction.NONE, 1000L, 100L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertTrue(outputs.getOutputs().isEmpty());
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final Pair<Long, PaneManager.WindowCallback> newCbPair = outputs.getCallbacks().get(0);
+
+    Assert.assertEquals(newCbPair.getFirst().longValue(), 1100L);
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertFalse(stateAfterTimer.windows().isEmpty());
+    Assert.assertEquals(stateAfterTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  @Test
+  public void registerCallbackOnTimerOnTrigger() {
+    final OutputCollector<Unit> outputs = new OutputCollector<>();
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        createWithTrigger(new SelfReplacingCallback(
+            TriggerAction.NONE, TriggerAction.TRIGGER, TriggerAction.NONE, 1000L, 100L), outputs);
+
+    manager.update("name", 0L, outputs);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 0);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final WindowAccumulators<Unit, Integer> stateBeforeTimer = manager.getAccumulators();
+    Assert.assertFalse(stateBeforeTimer.windows().isEmpty());
+    Assert.assertEquals(stateBeforeTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+
+    final Pair<Long, PaneManager.WindowCallback> cbPair = outputs.getCallbacks().get(0);
+
+    outputs.clear();
+
+    Assert.assertEquals(cbPair.getFirst().longValue(), 1000L);
+    cbPair.getSecond().runEvent(1000L, 1000L);
+
+    Assert.assertEquals(outputs.getOutputs().size(), 1);
+    Assert.assertEquals(outputs.getOutputs().get(0).getSecond().intValue(), 1);
+    Assert.assertEquals(outputs.getCallbacks().size(), 1);
+
+    final Pair<Long, PaneManager.WindowCallback> newCbPair = outputs.getCallbacks().get(0);
+
+    Assert.assertEquals(newCbPair.getFirst().longValue(), 1100L);
+
+    final WindowAccumulators<Unit, Integer> stateAfterTimer = manager.getAccumulators();
+    Assert.assertFalse(stateAfterTimer.windows().isEmpty());
+    Assert.assertEquals(stateAfterTimer.getForWindow(Unit.INSTANCE), Optional.of(1));
+  }
+
+  private static DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> createSimple(
+      final WindowAccumulators<Unit, Integer> accumulators,
+      final OutputCollector<Unit> outputs) {
+    return createWithTrigger(accumulators, new SingleAction(TriggerAction.NONE), outputs);
+  }
+
+  private static DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> createSimple(
+      final TriggerAction action, final OutputCollector<Unit> outputs) {
+    return createWithTrigger(new MapWindowAccumulators<>(), new SingleAction(action), outputs);
+  }
+
+  private static DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> createWithTrigger(
+      final Trigger<String, Unit> trigger, final OutputCollector<Unit> outputs) {
+    return createWithTrigger(new MapWindowAccumulators<>(), trigger, outputs);
+  }
+
+  private static DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> createWithTrigger(
+      final WindowAccumulators<Unit, Integer> accumulators,
+      final Trigger<String, Unit> trigger, final OutputCollector<Unit> outputs) {
+    final TemporalWindowAssigner<String, Unit, SingletonWindowStore<Unit>> assigner = new UnitAssigner();
+
+
+    final PaneUpdater<String, Unit, Integer> updater = new PaneUpdater<String, Unit, Integer>() {
+      @Override
+      public Integer createPane(final Unit window) {
+        return 0;
+      }
+
+      @Override
+      public Integer addContribution(final Integer state, final Unit window, final String data, final long timestamp) {
+        return state + 1;
+      }
+    };
+
+    final PaneEvictor<String, Unit, Integer> evictor = NoOpEvictor.instance();
+    final PaneEvaluator<Integer, Unit, Integer> evaluator = PaneEvaluator.identity();
+
+
+
+    final DefaultPaneManager<String, Unit, SingletonWindowStore<Unit>, Integer, Integer> manager =
+        new DefaultPaneManager<>(accumulators, assigner, trigger, updater, evictor, evaluator);
+
+    manager.setListener(outputs);
+    return manager;
+  }
+
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/Expectation.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/Expectation.java
@@ -1,0 +1,67 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.graph.Pair;
+
+/**
+ * Specification for a call to {@link WindowConduit#notifyChange(Deferred)}.
+ */
+final class Expectation {
+
+  private final Pair<Long, Integer> data;
+  private final long timestamp;
+  private final Pair<Long, PaneManager.WindowCallback> willRequest;
+  private final Pair<Integer, Integer> willOutput;
+
+
+  /**
+   * @param data Expected input data.
+   * @param timestamp Expected timestamp for the input.
+   * @param willRequest Callbacks that should be requested (may be null).
+   * @param willOutput Immediate output to produce (may be null).
+   */
+  Expectation(final Pair<Long, Integer> data,
+              final long timestamp,
+              final Pair<Long, PaneManager.WindowCallback> willRequest,
+              final Pair<Integer, Integer> willOutput) {
+    this.data = data;
+    this.timestamp = timestamp;
+    this.willRequest = willRequest;
+    this.willOutput = willOutput;
+  }
+
+  Expectation(final Pair<Long, Integer> data,
+                      final long timestamp) {
+    this(data, timestamp, null, null);
+  }
+
+  public Pair<Long, Integer> getData() {
+    return data;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public Pair<Long, PaneManager.WindowCallback> getWillRequest() {
+    return willRequest;
+  }
+
+  public Pair<Integer, Integer> getWillOutput() {
+    return willOutput;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/Expectation.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/Expectation.java
@@ -14,8 +14,8 @@
 
 package swim.dataflow.graph.impl.windows;
 
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.graph.Pair;
+import swim.util.Deferred;
 
 /**
  * Specification for a call to {@link WindowConduit#notifyChange(Deferred)}.

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FakeClock.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FakeClock.java
@@ -1,0 +1,54 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+
+/**
+ * A fake clock that can be incremented at will.
+ */
+final class FakeClock implements TimestampAssigner<Pair<Long, Integer>>, LongSupplier {
+
+  @Override
+  public <U> U match(final Function<ToLongFunction<Pair<Long, Integer>>, U> fromData, final Function<LongSupplier, U> fromClock) {
+    return fromClock.apply(this);
+  }
+
+  @Override
+  public long applyAsLong(final Pair<Long, Integer> value) {
+    return getAsLong();
+  }
+
+  /**
+   * The current time according to the clock.
+   */
+  private long ts = 1000L;
+
+  void advance(final long time) {
+    if (time < ts) {
+      throw new IllegalArgumentException("Time must increase monotonically.");
+    }
+    ts = time;
+  }
+
+  @Override
+  public long getAsLong() {
+    return ts;
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FakePaneManager.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FakePaneManager.java
@@ -1,0 +1,77 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.function.Consumer;
+import org.testng.Assert;
+import swim.dataflow.graph.Pair;
+
+/**
+ * Implementation of {@link PaneManager} that executes an {@link Expectation} when updated.
+ */
+final class FakePaneManager implements PaneManager<Pair<Long, Integer>, Integer, Integer> {
+
+  private Listener<Integer, Integer> listener = null;
+  private Expectation expected = null;
+  private boolean isClosed = false;
+  private final Consumer<FakePaneManager> onClose;
+
+  FakePaneManager(final Consumer<FakePaneManager> onClose) {
+    this.onClose = onClose;
+  }
+
+  /**
+   * Register a new expectation for the next time this receives data.
+   * @param exp The expectation.
+   */
+  public void expect(final Expectation exp) {
+    expected = exp;
+  }
+
+  @Override
+  public void setListener(final Listener<Integer, Integer> listener) {
+    Assert.assertFalse(isClosed);
+    this.listener = listener;
+  }
+
+  @Override
+  public void update(final Pair<Long, Integer> data, final long timestamp, final TimeContext context) {
+    Assert.assertFalse(isClosed);
+    if (expected != null) {
+      Assert.assertEquals(data, expected.getData());
+      Assert.assertEquals(timestamp, expected.getTimestamp());
+      if (expected.getWillRequest() != null) {
+        final Pair<Long, WindowCallback> wr = expected.getWillRequest();
+        context.scheduleAt(wr.getFirst(), wr.getSecond());
+      }
+      if (expected.getWillOutput() != null) {
+        final Pair<Integer, Integer> wo = expected.getWillOutput();
+        Assert.assertNotNull(listener);
+        listener.accept(wo.getFirst(), wo.getSecond());
+      }
+      expected = null;
+    } else {
+      Assert.fail();
+    }
+  }
+
+  @Override
+  public void close() {
+    Assert.assertFalse(isClosed);
+    isClosed = true;
+    onClose.accept(this);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FoldingEvaluatorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/FoldingEvaluatorSpec.java
@@ -1,0 +1,61 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+
+public class FoldingEvaluatorSpec {
+
+  @Test
+  public void appliesFoldFunctionOverWindow() {
+    final FoldingEvaluator<Integer, TestWindow, Integer> eval =
+        new FoldingEvaluator<>(TestWindow::getSeed, (w, n, i) -> n + w.multiple * i);
+
+    final long t0 = System.currentTimeMillis();
+
+    FingerTrieSeq<WithTimestamp<Integer>> data = FingerTrieSeq.empty();
+
+    for (int i = 0; i < 5; ++i) {
+      data = data.appended(new WithTimestamp<>(i, t0 + i * 1000));
+    }
+
+    final Integer resultA = eval.evaluate(TestWindow.A, data);
+    final Integer resultB = eval.evaluate(TestWindow.B, data);
+
+    Assert.assertEquals(resultA.intValue(), 11);
+    Assert.assertEquals(resultB.intValue(), 32);
+  }
+
+  private enum TestWindow {
+    A(1, 1),
+    B(2, 3);
+
+    final int seed;
+    final int multiple;
+
+    public int getSeed() {
+      return seed;
+    }
+
+    TestWindow(final int seed, final int multiple) {
+      this.seed = seed;
+      this.multiple = multiple;
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/KeyedWindowConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/KeyedWindowConduitSpec.java
@@ -1,0 +1,337 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieMap;
+import swim.collections.HashTrieSet;
+import swim.dataflow.connector.ConnectorTestUtil;
+import swim.dataflow.connector.ConnectorTestUtil.MapAction;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+
+public class KeyedWindowConduitSpec {
+
+  @Test
+  public void handleUpdatesAndRemovals() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final FakePaneManagers managers = new FakePaneManagers();
+
+    final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit = new KeyedWindowConduit<>(
+        schedule, managers, TimestampAssigner.fromData(Pair::getFirst));
+
+    final ArrayList<MapAction<String, Integer>> outputs = createOutputCollector(conduit);
+
+    final Pair<Long, Integer> in1 = Pair.pair(1000L, 15);
+    final Pair<Long, Integer> in2 = Pair.pair(2000L, 15);
+
+    managers.expect("a", new Expectation(in1,
+        1000L, null, Pair.pair(6, 16)));
+    managers.expect("b", new Expectation(in2,
+        2000L, null, Pair.pair(8, 18)));
+
+    final HashTrieMap<String, Pair<Long, Integer>> inMap = HashTrieMap.of("a", in1);
+
+    //Push values for two different keys and then remove the first.
+    conduit.notifyChange("a", Deferred.value(in1), Deferred.value(MapView.wrap(inMap)));
+    conduit.notifyChange("b", Deferred.value(in2), Deferred.value(MapView.wrap(inMap.updated("b", in2))));
+    conduit.notifyRemoval("a", Deferred.value(MapView.wrap(HashTrieMap.of("b", in2))));
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertEquals(outputs.size(), 3);
+
+    //Check we get the expected updates and removals.
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 16);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 16);
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs.get(1), (k, v, m) -> {
+      Assert.assertEquals(k, "b");
+      Assert.assertEquals(v.intValue(), 18);
+      Assert.assertEquals(m.size(), 2);
+      Assert.assertEquals(m.get("a").get().intValue(), 16);
+      Assert.assertEquals(m.get("b").get().intValue(), 18);
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs.get(2), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("b").get().intValue(), 18);
+    });
+
+    final HashTrieMap<String, FingerTrieSeq<FakePaneManager>> closed = managers.closed;
+    Assert.assertEquals(closed.keySet(), HashTrieSet.of("a"));
+    final FingerTrieSeq<FakePaneManager> forA = closed.get("a");
+    Assert.assertNotNull(forA);
+    Assert.assertEquals(forA.size(), 1);
+  }
+
+  @Test
+  public void replacePaneManagerOnRemoval() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final FakePaneManagers managers = new FakePaneManagers();
+
+    final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit = new KeyedWindowConduit<>(
+        schedule, managers, TimestampAssigner.fromData(Pair::getFirst));
+
+    final ArrayList<MapAction<String, Integer>> outputs = createOutputCollector(conduit);
+
+    final Pair<Long, Integer> in1 = Pair.pair(1000L, 15);
+    final Pair<Long, Integer> in2 = Pair.pair(2000L, 15);
+
+    managers.expect("a", new Expectation(in1,
+        1000L, null, Pair.pair(6, 16)));
+
+    //Push values for two different keys and then remove the first.
+    conduit.notifyChange("a", Deferred.value(in1), Deferred.value(MapView.wrap(HashTrieMap.of("a", in1))));
+    conduit.notifyRemoval("a", Deferred.value(MapView.wrapSimple(HashTrieMap.empty())));
+
+    final HashTrieMap<String, FingerTrieSeq<FakePaneManager>> closed1 = managers.closed;
+    Assert.assertEquals(closed1.keySet(), HashTrieSet.of("a"));
+    final FingerTrieSeq<FakePaneManager> forA1 = closed1.get("a");
+    Assert.assertNotNull(forA1);
+    Assert.assertEquals(forA1.size(), 1);
+
+    managers.expect("a", new Expectation(in2,
+        2000L, null, Pair.pair(8, 18)));
+
+    conduit.notifyChange("a", Deferred.value(in2), Deferred.value(MapView.wrap(HashTrieMap.of("a", in2))));
+    conduit.notifyRemoval("a", Deferred.value(MapView.wrapSimple(HashTrieMap.empty())));
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertEquals(outputs.size(), 4);
+
+    //Check we get the expected updates and removals.
+    ConnectorTestUtil.expectUpdate(outputs.get(0), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 16);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 16);
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs.get(1), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+
+    ConnectorTestUtil.expectUpdate(outputs.get(2), (k, v, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(v.intValue(), 18);
+      Assert.assertEquals(m.size(), 1);
+      Assert.assertEquals(m.get("a").get().intValue(), 18);
+    });
+
+    ConnectorTestUtil.expectRemoval(outputs.get(3), (k, m) -> {
+      Assert.assertEquals(k, "a");
+      Assert.assertEquals(m.size(), 0);
+    });
+
+    final HashTrieMap<String, FingerTrieSeq<FakePaneManager>> closed2 = managers.closed;
+    Assert.assertEquals(closed2.keySet(), HashTrieSet.of("a"));
+    final FingerTrieSeq<FakePaneManager> forA2 = closed2.get("a");
+    Assert.assertNotNull(forA2);
+    Assert.assertEquals(forA2.size(), 2);
+  }
+
+  @Test
+  public void triggerByDataTimestampsForOneKey() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final FakePaneManagers managers = new FakePaneManagers();
+
+    final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit = new KeyedWindowConduit<>(
+        schedule, managers, TimestampAssigner.fromData(Pair::getFirst));
+
+    final ArrayList<MapAction<String, Integer>> outputs = createOutputCollector(conduit);
+    final ArrayList<Pair<Long, Long>> executedCallbacks = new ArrayList<>();
+
+    final Pair<Long, Integer> in1 = Pair.pair(1000L, 15);
+    final Pair<Long, Integer> in2 = Pair.pair(2000L, 15);
+
+    final PaneManager.WindowCallback cb = (requested, actual) -> executedCallbacks.add(Pair.pair(requested, actual));
+
+    //Request a callback in the future.
+    managers.expect("a", new Expectation(in1,
+        1000L, Pair.pair(1500L, cb), null));
+
+    final HashTrieMap<String, Pair<Long, Integer>> inMap = HashTrieMap.of("a", in1);
+
+    conduit.notifyChange("a", Deferred.value(in1), Deferred.value(MapView.wrap(inMap)));
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    managers.expect("a", new Expectation(in2,
+        2000L, null, null));
+
+    //Push another value for the same key at a time after the callback time.
+    conduit.notifyChange("a", Deferred.value(in2), Deferred.value(MapView.wrap(inMap.updated("a", in2))));
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+
+    //Check that the callback was received.
+    Assert.assertEquals(executedCallbacks.size(), 1);
+    Assert.assertEquals(executedCallbacks.get(0), Pair.pair(1500L, 2000L));
+
+    Assert.assertTrue(managers.closed.isEmpty());
+  }
+
+  @Test
+  public void triggerByDataTimestampsBetweenKeys() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final FakePaneManagers managers = new FakePaneManagers();
+
+    final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit = new KeyedWindowConduit<>(
+        schedule, managers, TimestampAssigner.fromData(Pair::getFirst));
+
+    final ArrayList<MapAction<String, Integer>> outputs = createOutputCollector(conduit);
+    final ArrayList<Pair<Long, Long>> executedCallbacks = new ArrayList<>();
+
+    final Pair<Long, Integer> in1 = Pair.pair(1000L, 15);
+    final Pair<Long, Integer> in2 = Pair.pair(2000L, 15);
+
+
+    final PaneManager.WindowCallback cb = (requested, actual) -> executedCallbacks.add(Pair.pair(requested, actual));
+
+    //Request a callback in the future.
+    managers.expect("a", new Expectation(in1,
+        1000L, Pair.pair(1500L, cb), null));
+
+    final HashTrieMap<String, Pair<Long, Integer>> inMap = HashTrieMap.of("a", in1);
+
+    conduit.notifyChange("a", Deferred.value(in1), Deferred.value(MapView.wrap(inMap)));
+
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    managers.expect("b", new Expectation(in2,
+        2000L, null, null));
+
+    //Push a value, for another key, a time after the scheduled callback.
+    conduit.notifyChange("b", Deferred.value(in2), Deferred.value(MapView.wrap(inMap.updated("b", in2))));
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+
+    //Verify that the callback occurred on the original key.
+    Assert.assertEquals(executedCallbacks.size(), 1);
+    Assert.assertEquals(executedCallbacks.get(0), Pair.pair(1500L, 2000L));
+
+    Assert.assertTrue(managers.closed.isEmpty());
+  }
+
+  @Test
+  public void scheduleCallbacksUsingClockTimestamps() {
+    final ConnectorTestUtil.FakeSchedule schedule = new ConnectorTestUtil.FakeSchedule();
+    final FakePaneManagers managers = new FakePaneManagers();
+    final FakeClock clock = new FakeClock();
+
+    final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit = new KeyedWindowConduit<>(
+        schedule, managers, clock);
+
+    final ArrayList<MapAction<String, Integer>> outputs = createOutputCollector(conduit);
+    final ArrayList<Pair<Long, Long>> executedCallbacks = new ArrayList<>();
+
+    final Pair<Long, Integer> in1 = Pair.pair(1000L, 15);
+
+    final PaneManager.WindowCallback cb = (requested, actual) -> executedCallbacks.add(Pair.pair(requested, actual));
+
+    //Schedule a callback in the future.
+    managers.expect("a", new Expectation(in1,
+        1000L, Pair.pair(1500L, cb), null));
+
+    final HashTrieMap<String, Pair<Long, Integer>> inMap = HashTrieMap.of("a", in1);
+
+    conduit.notifyChange("a", Deferred.value(in1), Deferred.value(MapView.wrap(inMap)));
+
+    //Check that the callback has been registered with the scheduler.
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(500L));
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    //Trigger the callback.
+    clock.advance(1600L);
+    schedule.runScheduled(500L);
+
+    //Verify that the callback was received.
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertEquals(executedCallbacks.size(), 1);
+    Assert.assertEquals(executedCallbacks.get(0), Pair.pair(1500L, 1600L));
+
+    Assert.assertTrue(managers.closed.isEmpty());
+
+  }
+
+  private static ArrayList<MapAction<String, Integer>> createOutputCollector(
+      final KeyedWindowConduit<String, Pair<Long, Integer>, Integer, Integer> conduit) {
+    final ArrayList<MapAction<String, Integer>> outputs = new ArrayList<>();
+
+    conduit.subscribe(new MapReceptacle<String, Integer>() {
+      @Override
+      public void notifyChange(final String key, final Deferred<Integer> value, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(ConnectorTestUtil.update(key, value.get(), map.get()));
+      }
+
+      @Override
+      public void notifyRemoval(final String key, final Deferred<MapView<String, Integer>> map) {
+        outputs.add(ConnectorTestUtil.remove(key, map.get()));
+      }
+    });
+    return outputs;
+  }
+
+  /**
+   * Factory for fake pane managers that allows expectations to be injected per key.
+   */
+  private static final class FakePaneManagers implements Function<String, PaneManager<Pair<Long, Integer>, Integer, Integer>> {
+
+    private HashTrieMap<String, FakePaneManager> managers = HashTrieMap.empty();
+    private HashTrieMap<String, FingerTrieSeq<FakePaneManager>> closed = HashTrieMap.empty();
+
+    @Override
+    public PaneManager<Pair<Long, Integer>, Integer, Integer> apply(final String s) {
+      return get(s);
+    }
+
+    private FakePaneManager get(final String s) {
+      if (!managers.containsKey(s)) {
+        final Consumer<FakePaneManager> onClose = manager -> {
+          managers = managers.removed(s);
+          final FingerTrieSeq<FakePaneManager> seq = closed.getOrDefault(s, FingerTrieSeq.empty());
+          closed = closed.updated(s, seq.appended(manager));
+        };
+        managers = managers.updated(s, new FakePaneManager(onClose));
+      }
+      return managers.get(s);
+    }
+
+    void expect(final String key, final Expectation exp) {
+      get(key).expect(exp);
+    }
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/KeyedWindowConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/KeyedWindowConduitSpec.java
@@ -24,11 +24,11 @@ import swim.collections.HashTrieMap;
 import swim.collections.HashTrieSet;
 import swim.dataflow.connector.ConnectorTestUtil;
 import swim.dataflow.connector.ConnectorTestUtil.MapAction;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.MapReceptacle;
 import swim.dataflow.connector.MapView;
 import swim.dataflow.graph.Pair;
 import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.util.Deferred;
 
 public class KeyedWindowConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/ReducingEvaluatorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/ReducingEvaluatorSpec.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.BTreeMap;
+import swim.dataflow.graph.Unit;
+
+public class ReducingEvaluatorSpec {
+
+  @Test
+  public void reducesValuesCorrectly() {
+
+    final ReducingEvaluator<Long, Integer, Unit, Integer> eval = new ReducingEvaluator<>(
+        u -> Integer.MIN_VALUE, (w, s, n) -> Math.max(s, n),
+        (w, s1, s2) -> Math.max(s1, s2));
+
+    final BTreeMap<Long, Integer, Integer> map = BTreeMap.<Long, Integer, Integer>empty()
+        .updated(100L, 5)
+        .updated(200L, 65)
+        .updated(300L, -1)
+        .updated(400L, 47);
+
+    final int result = eval.evaluate(Unit.INSTANCE, map);
+
+    Assert.assertEquals(result, 65);
+
+    final BTreeMap<Long, Integer, Integer> map2 = map.removed(200L);
+
+    final int result2 = eval.evaluate(Unit.INSTANCE, map2);
+
+    Assert.assertEquals(result2, 47);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/SequenceThresholdEvictorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/SequenceThresholdEvictorSpec.java
@@ -1,0 +1,167 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.FingerTrieSeq;
+import swim.dataflow.graph.timestamps.WithTimestamp;
+import swim.dataflow.graph.windows.SlidingInterval;
+import swim.dataflow.graph.windows.eviction.EvictionCriterionFunction;
+import swim.dataflow.graph.windows.eviction.EvictionThresholdFunction;
+
+public class SequenceThresholdEvictorSpec {
+
+  public static final class Record {
+    final int data;
+
+    public Record(final int data) {
+      this.data = data;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) {
+        return true;
+      } else if (!(obj instanceof Record)) {
+        return false;
+      } else {
+        final Record other = (Record) obj;
+        return data == other.data;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Integer.hashCode(data);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Record[%d]", data);
+    }
+  }
+
+
+  @Test
+  public void retainsUnexpiredRecords() {
+
+    final Random rand = new Random();
+    retainsUnexpiredRecords(true, rand);
+    retainsUnexpiredRecords(false, rand);
+  }
+
+  public void retainsUnexpiredRecords(final boolean assumeOrdered, final Random rand) {
+    final EvictionCriterionFunction<Record, Long> criterion = (rec, ts) -> ts;
+    final EvictionThresholdFunction<Record, SlidingInterval, Long> threshold = (rec, window, ts) -> ts - window.length();
+    final SequenceThresholdEvictor<Record, Long, SlidingInterval> evictor = new SequenceThresholdEvictor<>(
+        criterion,
+        threshold,
+        assumeOrdered);
+
+    final Record rec1 = new Record(rand.nextInt());
+    final Record rec2 = new Record(rand.nextInt());
+    final Record rec3 = new Record(rand.nextInt());
+
+    final FingerTrieSeq<WithTimestamp<Record>> data = FingerTrieSeq.<WithTimestamp<Record>>empty()
+        .appended(new WithTimestamp<>(rec1, 1000L))
+        .appended(new WithTimestamp<>(rec2, 2000L))
+        .appended(new WithTimestamp<>(rec3, 3000L));
+
+    final SlidingInterval window = new SlidingInterval(10000L);
+
+    final FingerTrieSeq<WithTimestamp<Record>> evicted = evictor.evict(
+        data, window, rec3, 3000L);
+
+    Assert.assertEquals(evicted, data);
+  }
+
+  @Test
+  public void evictsExpiredRecords() {
+    final Random rand = new Random();
+    evictsExpiredRecords(true, rand);
+    evictsExpiredRecords(false, rand);
+  }
+
+  public void evictsExpiredRecords(final boolean assumeOrdered, final Random rand) {
+    final EvictionCriterionFunction<Record, Long> criterion = (rec, ts) -> ts;
+    final EvictionThresholdFunction<Record, SlidingInterval, Long> threshold = (rec, window, ts) -> ts - window.length();
+    final SequenceThresholdEvictor<Record, Long, SlidingInterval> evictor = new SequenceThresholdEvictor<>(
+        criterion,
+        threshold,
+        assumeOrdered);
+
+    final Record rec1 = new Record(rand.nextInt());
+    final Record rec2 = new Record(rand.nextInt());
+    final Record rec3 = new Record(rand.nextInt());
+    final Record rec4 = new Record(rand.nextInt());
+
+    final FingerTrieSeq<WithTimestamp<Record>> data = FingerTrieSeq.<WithTimestamp<Record>>empty()
+        .appended(new WithTimestamp<>(rec1, 1000L))
+        .appended(new WithTimestamp<>(rec2, 2000L))
+        .appended(new WithTimestamp<>(rec3, 10000L))
+        .appended(new WithTimestamp<>(rec4, 15000L));
+
+    final SlidingInterval window = new SlidingInterval(10000L);
+
+    final FingerTrieSeq<WithTimestamp<Record>> evicted = evictor.evict(
+        data, window, rec4, 15000L);
+
+    final FingerTrieSeq<WithTimestamp<Record>> expected = FingerTrieSeq.<WithTimestamp<Record>>empty()
+        .appended(new WithTimestamp<>(rec3, 10000L))
+        .appended(new WithTimestamp<>(rec4, 15000L));
+
+    Assert.assertEquals(evicted, expected);
+
+  }
+
+  @Test
+  public void preservesOrder() {
+    final Random rand = new Random();
+    final EvictionCriterionFunction<Record, Long> criterion = (rec, ts) -> ts;
+    final EvictionThresholdFunction<Record, SlidingInterval, Long> threshold = (rec, window, ts) -> ts - window.length();
+    final SequenceThresholdEvictor<Record, Long, SlidingInterval> evictor = new SequenceThresholdEvictor<>(
+        criterion,
+        threshold,
+        false);
+
+    final Record rec1 = new Record(rand.nextInt());
+    final Record rec2 = new Record(rand.nextInt());
+    final Record rec3 = new Record(rand.nextInt());
+    final Record rec4 = new Record(rand.nextInt());
+    final Record rec5 = new Record(rand.nextInt());
+
+    final FingerTrieSeq<WithTimestamp<Record>> data = FingerTrieSeq.<WithTimestamp<Record>>empty()
+        .appended(new WithTimestamp<>(rec1, 10000L))
+        .appended(new WithTimestamp<>(rec2, 2000L))
+        .appended(new WithTimestamp<>(rec3, 7000L))
+        .appended(new WithTimestamp<>(rec4, 1000L))
+        .appended(new WithTimestamp<>(rec5, 15000L));
+
+    final SlidingInterval window = new SlidingInterval(10000L);
+
+    final FingerTrieSeq<WithTimestamp<Record>> evicted = evictor.evict(
+        data, window, rec5, 15000L);
+
+    final FingerTrieSeq<WithTimestamp<Record>> expected = FingerTrieSeq.<WithTimestamp<Record>>empty()
+        .appended(new WithTimestamp<>(rec1, 10000L))
+        .appended(new WithTimestamp<>(rec3, 7000L))
+        .appended(new WithTimestamp<>(rec5, 15000L));
+
+    Assert.assertEquals(evicted, expected);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/ThresholdEvictorSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/ThresholdEvictorSpec.java
@@ -1,0 +1,107 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.BTreeMap;
+import swim.dataflow.graph.windows.SlidingInterval;
+import swim.dataflow.graph.windows.eviction.EvictionThresholdFunction;
+
+public class ThresholdEvictorSpec {
+
+  public static final class Record {
+    final int data;
+
+    private Record(final int data) {
+      this.data = data;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (this == obj) {
+        return true;
+      } else if (!(obj instanceof Record)) {
+        return false;
+      } else {
+        final Record other = (Record) obj;
+        return data == other.data;
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Integer.hashCode(data);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Record[%d]", data);
+    }
+  }
+
+  @Test
+  public void retainsUnexpiredRecords() {
+
+    final Random rand = new Random();
+
+    final EvictionThresholdFunction<Record, SlidingInterval, Long> threshold =
+        (rec, window, ts) -> ts - window.length();
+
+    final ThresholdEvictor<Record, Long, SlidingInterval, Integer> evictor = new ThresholdEvictor<>(threshold);
+
+    final SlidingInterval window = new SlidingInterval(10000L);
+
+    final Record rec1 = new Record(rand.nextInt());
+    final Record rec2 = new Record(rand.nextInt());
+    final Record rec3 = new Record(rand.nextInt());
+
+    final BTreeMap<Long, Record, Integer> data = BTreeMap.<Long, Record, Integer>empty()
+        .updated(1000L, rec1).updated(2000L, rec2).updated(3000L, rec3);
+
+    final BTreeMap<Long, Record, Integer> evicted = evictor.evict(data, window, rec3, 3000L);
+
+    Assert.assertEquals(evicted, data);
+  }
+
+  @Test
+  public void evictsExpiredRecords() {
+    final Random rand = new Random();
+
+    final EvictionThresholdFunction<Record, SlidingInterval, Long> threshold =
+        (rec, window, ts) -> ts - window.length();
+
+    final ThresholdEvictor<Record, Long, SlidingInterval, Integer> evictor = new ThresholdEvictor<>(threshold);
+
+    final SlidingInterval window = new SlidingInterval(10000L);
+
+    final Record rec1 = new Record(rand.nextInt());
+    final Record rec2 = new Record(rand.nextInt());
+    final Record rec3 = new Record(rand.nextInt());
+    final Record rec4 = new Record(rand.nextInt());
+
+    final BTreeMap<Long, Record, Integer> data = BTreeMap.<Long, Record, Integer>empty()
+        .updated(1000L, rec1).updated(2000L, rec2).updated(10000L, rec3).updated(15000L, rec3);
+
+    final BTreeMap<Long, Record, Integer> evicted = evictor.evict(data, window, rec4, 15000L);
+
+    final BTreeMap<Long, Record, Integer> expected = BTreeMap.<Long, Record, Integer>empty()
+        .updated(10000L, rec3).updated(15000L, rec3);
+
+    Assert.assertEquals(evicted, expected);
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowConduitSpec.java
@@ -18,9 +18,9 @@ import java.util.ArrayList;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import swim.dataflow.connector.ConnectorTestUtil.FakeSchedule;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.graph.Pair;
 import swim.dataflow.graph.timestamps.TimestampAssigner;
+import swim.util.Deferred;
 
 public class WindowConduitSpec {
 

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowConduitSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowConduitSpec.java
@@ -1,0 +1,130 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.ArrayList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.dataflow.connector.ConnectorTestUtil.FakeSchedule;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.timestamps.TimestampAssigner;
+
+public class WindowConduitSpec {
+
+  @Test
+  public void timestampsFromData() {
+
+    final FakePaneManager manager = new FakePaneManager(man -> { });
+    final FakeSchedule schedule = new FakeSchedule();
+    final WindowConduit<Pair<Long, Integer>, Integer, Integer> conduit = new WindowConduit<>(
+        schedule, manager, TimestampAssigner.fromData(Pair::getFirst));
+
+    final ArrayList<Integer> outputs = new ArrayList<>();
+    final ArrayList<Pair<Long, Long>> executedCallbacks = new ArrayList<>();
+
+    conduit.subscribe(n -> outputs.add(n.get()));
+
+    final Pair<Long, Integer> input1 = Pair.pair(1000L, 5);
+
+    final PaneManager.WindowCallback cb1 = (requested, actual) -> executedCallbacks.add(Pair.pair(requested, actual));
+
+    //Expect the appropriate input and register a timer event in response.
+
+    final Expectation exp1 = new Expectation(input1, 1000L, Pair.pair(2500L, cb1), null);
+    manager.expect(exp1);
+
+    conduit.notifyChange(Deferred.value(input1));
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    final Pair<Long, Integer> input2 = Pair.pair(2000L, 7);
+
+    //Expect the next input and produce an output.
+
+    final Expectation exp2 = new Expectation(input2, 2000L, null, Pair.pair(9, 10));
+    manager.expect(exp2);
+
+    conduit.notifyChange(Deferred.value(input2));
+
+    //Verify the expected output.
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertEquals(outputs.size(), 1);
+    Assert.assertEquals(outputs.get(0).intValue(), 10);
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    outputs.clear();
+
+    //Feed a new input that is past the timer we registered earlier.
+    final Pair<Long, Integer> input3 = Pair.pair(3000L, 17);
+
+    final Expectation exp3 = new Expectation(input3, 3000L);
+    manager.expect(exp3);
+
+    conduit.notifyChange(Deferred.value(input3));
+
+    //Verify that the timer event was received.
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertEquals(executedCallbacks.size(), 1);
+    Assert.assertEquals(executedCallbacks.get(0), Pair.pair(2500L, 3000L));
+
+  }
+
+  @Test
+  public void timestampsFromClock() {
+
+    final FakePaneManager manager = new FakePaneManager(man -> { });
+    final FakeSchedule schedule = new FakeSchedule();
+    final FakeClock clock = new FakeClock();
+    final WindowConduit<Pair<Long, Integer>, Integer, Integer> conduit = new WindowConduit<>(
+        schedule, manager, clock);
+
+    final ArrayList<Integer> outputs = new ArrayList<>();
+    final ArrayList<Pair<Long, Long>> executedCallbacks = new ArrayList<>();
+
+    conduit.subscribe(n -> outputs.add(n.get()));
+
+    final Pair<Long, Integer> input1 = Pair.pair(1000L, 5);
+
+
+    final PaneManager.WindowCallback cb1 = (requested, actual) -> executedCallbacks.add(Pair.pair(requested, actual));
+
+
+    //Expect the appropriate input and request a callback.
+    final Expectation exp1 = new Expectation(input1, 1000L, Pair.pair(2500L, cb1), null);
+    manager.expect(exp1);
+
+    //Verify that the callback was sent to the scheduler.
+    conduit.notifyChange(Deferred.value(input1));
+    Assert.assertEquals(schedule.getScheduled().size(), 1);
+    Assert.assertTrue(schedule.getScheduled().containsKey(1500L));
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertTrue(executedCallbacks.isEmpty());
+
+    //Trigger the callback.
+    clock.advance(2500L);
+
+    schedule.runScheduled(1500L);
+
+    //Verify that the callback was received.
+    Assert.assertTrue(schedule.getScheduled().isEmpty());
+    Assert.assertTrue(outputs.isEmpty());
+    Assert.assertEquals(executedCallbacks.size(), 1);
+    Assert.assertEquals(executedCallbacks.get(0), Pair.pair(2500L, 2500L));
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowTestingMocks.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/impl/windows/WindowTestingMocks.java
@@ -1,0 +1,247 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.impl.windows;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import swim.dataflow.graph.Pair;
+import swim.dataflow.graph.Unit;
+import swim.dataflow.graph.timestamps.TimestampContext;
+import swim.dataflow.graph.windows.SingletonWindowStore;
+import swim.dataflow.graph.windows.TemporalWindowAssigner;
+import swim.dataflow.graph.windows.triggers.Trigger;
+import swim.dataflow.graph.windows.triggers.TriggerAction;
+
+final class WindowTestingMocks {
+
+  private WindowTestingMocks() {
+
+  }
+
+  static final class OutputCollector<W> implements PaneManager.Listener<W, Integer>, PaneManager.TimeContext {
+
+    private final ArrayList<Pair<W, Integer>> outputs = new ArrayList<>();
+    private final ArrayList<Pair<Long, PaneManager.WindowCallback>> callbacks = new ArrayList<>();
+
+    public List<Pair<W, Integer>> getOutputs() {
+      return outputs;
+    }
+
+    public List<Pair<Long, PaneManager.WindowCallback>> getCallbacks() {
+      return callbacks;
+    }
+
+    public void clear() {
+      outputs.clear();
+      callbacks.clear();
+    }
+
+    @Override
+    public void accept(final W window, final Integer value) {
+      outputs.add(Pair.pair(window, value));
+    }
+
+    @Override
+    public void scheduleAt(final long timestamp, final PaneManager.WindowCallback callback) {
+      callbacks.add(Pair.pair(timestamp, callback));
+    }
+  }
+
+  static final class CallbackOnInit implements Trigger<String, Unit> {
+
+    private final TriggerAction action;
+    private final long ts;
+
+    CallbackOnInit(final TriggerAction action, final long ts) {
+      this.action = action;
+      this.ts = ts;
+    }
+
+    CallbackOnInit(final long ts) {
+      this(TriggerAction.NONE, ts);
+    }
+
+    @Override
+    public TriggerAction onNewValue(final String data, final Unit window, final TimestampContext time) {
+      return TriggerAction.NONE;
+    }
+
+    @Override
+    public TriggerAction onTimer(final Unit window, final TimestampContext time) {
+      return TriggerAction.NONE;
+    }
+
+    @Override
+    public TriggerAction onRestore(final Unit window, final TimestampContext time) {
+      time.scheduleAt(ts);
+      return action;
+    }
+  }
+
+  static final class OnInit implements Trigger<String, Unit> {
+
+    private final TriggerAction action;
+    private final TriggerAction actionOnData;
+
+    OnInit(final TriggerAction action, final TriggerAction onData) {
+      this.action = action;
+      actionOnData = onData;
+    }
+
+    OnInit(final TriggerAction action) {
+      this(action, TriggerAction.NONE);
+    }
+
+    @Override
+    public TriggerAction onNewValue(final String data, final Unit window, final TimestampContext time) {
+      return actionOnData;
+    }
+
+    @Override
+    public TriggerAction onTimer(final Unit window, final TimestampContext time) {
+      return TriggerAction.NONE;
+    }
+
+    @Override
+    public TriggerAction onRestore(final Unit window, final TimestampContext time) {
+      return action;
+    }
+  }
+
+  static final class SingleAction implements Trigger<String, Unit> {
+
+    private final TriggerAction action;
+
+    SingleAction(final TriggerAction action) {
+      this.action = action;
+    }
+
+    @Override
+    public TriggerAction onNewValue(final String data, final Unit window, final TimestampContext time) {
+      return action;
+    }
+
+    @Override
+    public TriggerAction onTimer(final Unit window, final TimestampContext time) {
+      return action;
+    }
+
+    @Override
+    public TriggerAction onRestore(final Unit window, final TimestampContext time) {
+      return action;
+    }
+  }
+
+  static final class ActionWithCallback implements Trigger<String, Unit> {
+
+    private final TriggerAction action;
+    private final TriggerAction onCallback;
+    private final TriggerAction onRestore;
+    private final long timestamp;
+
+    ActionWithCallback(final TriggerAction action, final TriggerAction onCallback,
+                       final TriggerAction onRestore, final long timestamp) {
+      this.action = action;
+      this.onRestore = onRestore;
+      this.timestamp = timestamp;
+      this.onCallback = onCallback;
+    }
+
+    @Override
+    public TriggerAction onNewValue(final String data, final Unit window, final TimestampContext time) {
+      time.scheduleAt(timestamp);
+      return action;
+    }
+
+    @Override
+    public TriggerAction onTimer(final Unit window, final TimestampContext time) {
+      return onCallback;
+    }
+
+    @Override
+    public TriggerAction onRestore(final Unit window, final TimestampContext time) {
+      return onRestore;
+    }
+  }
+
+  static final class SelfReplacingCallback implements Trigger<String, Unit> {
+
+    private final TriggerAction action;
+    private final TriggerAction onCallback;
+    private final TriggerAction onRestore;
+    private long timestamp;
+    private final long increment;
+
+    SelfReplacingCallback(final TriggerAction action,
+                          final TriggerAction onCallback,
+                          final TriggerAction onRestore, final long timestamp,
+                          final long increment) {
+      this.action = action;
+      this.onRestore = onRestore;
+      this.timestamp = timestamp;
+      this.onCallback = onCallback;
+      this.increment = increment;
+    }
+
+
+    @Override
+    public TriggerAction onNewValue(final String data, final Unit window, final TimestampContext time) {
+      time.scheduleAt(timestamp);
+      timestamp += increment;
+      return action;
+    }
+
+    @Override
+    public TriggerAction onTimer(final Unit window, final TimestampContext time) {
+      time.scheduleAt(timestamp);
+      timestamp += increment;
+      return onCallback;
+    }
+
+    @Override
+    public TriggerAction onRestore(final Unit window, final TimestampContext time) {
+      time.scheduleAt(timestamp);
+      timestamp += increment;
+      return onRestore;
+    }
+  }
+
+  static final class UnitAssigner implements TemporalWindowAssigner<String, Unit, SingletonWindowStore<Unit>> {
+
+    @Override
+    public Function<Set<Unit>, SingletonWindowStore<Unit>> stateInitializer() {
+      return windows -> new SingletonWindowStore<>(Unit.INSTANCE);
+    }
+
+    @Override
+    public Assignment<Unit, SingletonWindowStore<Unit>> windowsFor(final String value, final long timestamp,
+                                                                   final SingletonWindowStore<Unit> openWindows) {
+      return new Assignment<Unit, SingletonWindowStore<Unit>>() {
+        @Override
+        public Set<Unit> windows() {
+          return Collections.singleton(Unit.INSTANCE);
+        }
+
+        @Override
+        public SingletonWindowStore<Unit> updatedState() {
+          return openWindows;
+        }
+      };
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/windows/SmoothSlidingWindowsSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/windows/SmoothSlidingWindowsSpec.java
@@ -1,0 +1,93 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+
+public class SmoothSlidingWindowsSpec {
+
+  @Test
+  public void createsCorrectSingletonState() {
+
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    final SingletonWindowStore<SlidingInterval> state = assigner.stateInitializer().apply(HashTrieSet.empty());
+    Assert.assertEquals(state.openWindows(), Collections.singleton(window));
+  }
+
+  @Test
+  public void assignsSingletonWindow() {
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    final SingletonWindowStore<SlidingInterval> state = assigner.stateInitializer().apply(HashTrieSet.empty());
+    final TemporalWindowAssigner.Assignment<SlidingInterval, SingletonWindowStore<SlidingInterval>> assignment =
+        assigner.windowsFor("name", 10000, state);
+
+    Assert.assertEquals(assignment.updatedState().openWindows(), Collections.singleton(window));
+    Assert.assertEquals(assignment.windows(), Collections.singleton(window));
+  }
+
+  @Test
+  public void initializeEmptyState() {
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    final SingletonWindowStore<SlidingInterval> state = assigner.stateInitializer().apply(HashTrieSet.empty());
+
+    Assert.assertEquals(state.openWindows(), HashTrieSet.of(window));
+  }
+
+  @Test
+  public void initializeFromCorrectState() {
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    final SingletonWindowStore<SlidingInterval> state = assigner.stateInitializer().apply(HashTrieSet.of(window));
+
+    Assert.assertEquals(state.openWindows(), HashTrieSet.of(window));
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void failsToRestoreInvalidState() {
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    assigner.stateInitializer().apply(
+        HashTrieSet.of(window, new SlidingInterval(76L)));
+
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void failsToRestoreNonMatchingWindow() {
+    final SlidingInterval window = new SlidingInterval(3124L);
+    final SmoothSlidingWindows<String> assigner = new SmoothSlidingWindows<>(
+        window);
+
+    assigner.stateInitializer().apply(
+        HashTrieSet.of(new SlidingInterval(77L)));
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/windows/TumblingWindowsSpec.java
+++ b/swim-system-java/swim-core-java/swim.dataflow/src/test/java/swim/dataflow/graph/windows/TumblingWindowsSpec.java
@@ -1,0 +1,251 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.dataflow.graph.windows;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import swim.collections.HashTrieSet;
+import swim.dataflow.graph.windows.TemporalWindowAssigner.Assignment;
+
+public class TumblingWindowsSpec {
+
+  private final Instant origin = Instant.parse("2019-01-01T00:00:00Z");
+  private final Instant dayBefore = origin.minus(1, ChronoUnit.DAYS);
+
+  @Test
+  public void alignWindowBoundariesAfterOrigin() {
+
+    final Instant time = origin.plus(5, ChronoUnit.HOURS)
+        .plus(13, ChronoUnit.MINUTES)
+        .plus(27, ChronoUnit.SECONDS)
+        .plus(344, ChronoUnit.MILLIS);
+
+    final TimeInterval hourWindow = TumblingWindows.alignWindow(origin, Duration.ofHours(1), time.toEpochMilli());
+    checkWindow(hourWindow, origin.plus(
+        5, ChronoUnit.HOURS), origin.plus(6, ChronoUnit.HOURS));
+
+    final TimeInterval quarterHourWindow = TumblingWindows.alignWindow(
+        origin, Duration.ofMinutes(15), time.toEpochMilli());
+
+    checkWindow(quarterHourWindow, Instant.parse("2019-01-01T05:00:00Z"), Instant.parse("2019-01-01T05:15:00Z"));
+
+    final TimeInterval minuteWindow = TumblingWindows.alignWindow(origin, Duration.ofMinutes(1), time.toEpochMilli());
+
+    checkWindow(minuteWindow, Instant.parse("2019-01-01T05:13:00Z"), Instant.parse("2019-01-01T05:14:00Z"));
+
+    final TimeInterval sevenMinuteWindow = TumblingWindows.alignWindow(
+        origin, Duration.ofMinutes(7), time.toEpochMilli());
+
+    checkWindow(sevenMinuteWindow, Instant.parse("2019-01-01T05:08:00Z"), Instant.parse("2019-01-01T05:15:00Z"));
+  }
+
+  @Test
+  public void alignWindowBoundariesBeforeOrigin() {
+
+    final Instant time = dayBefore.plus(5, ChronoUnit.HOURS)
+        .plus(13, ChronoUnit.MINUTES)
+        .plus(27, ChronoUnit.SECONDS)
+        .plus(344, ChronoUnit.MILLIS);
+
+    final TimeInterval hourWindow = TumblingWindows.alignWindow(origin, Duration.ofHours(1), time.toEpochMilli());
+    checkWindow(hourWindow, Instant.parse("2018-12-31T05:00:00Z"), Instant.parse("2018-12-31T06:00:00Z"));
+
+    final TimeInterval quarterHourWindow = TumblingWindows.alignWindow(
+        origin, Duration.ofMinutes(15), time.toEpochMilli());
+
+    checkWindow(quarterHourWindow, Instant.parse("2018-12-31T05:00:00Z"), Instant.parse("2018-12-31T05:15:00Z"));
+
+    final TimeInterval minuteWindow = TumblingWindows.alignWindow(origin, Duration.ofMinutes(1), time.toEpochMilli());
+
+    checkWindow(minuteWindow, Instant.parse("2018-12-31T05:13:00Z"), Instant.parse("2018-12-31T05:14:00Z"));
+
+    final TimeInterval sevenMinuteWindow = TumblingWindows.alignWindow(
+        origin, Duration.ofMinutes(7), time.toEpochMilli());
+
+    checkWindow(sevenMinuteWindow, Instant.parse("2018-12-31T05:13:00Z"), Instant.parse("2018-12-31T05:20:00Z"));
+  }
+
+  @Test
+  public void alignWindowBoundariesOnEdgesAfterOrigin() {
+
+    final TimeInterval hourWindow = TumblingWindows.alignWindow(origin, Duration.ofHours(1),
+        origin.plus(7, ChronoUnit.HOURS).toEpochMilli());
+
+    checkWindow(hourWindow, Instant.parse("2019-01-01T07:00:00Z"), Instant.parse("2019-01-01T08:00:00Z"));
+
+    final TimeInterval quarterHourWindow = TumblingWindows.alignWindow(origin, Duration.ofMinutes(15),
+        origin.plus(7, ChronoUnit.HOURS).plus(45, ChronoUnit.MINUTES).toEpochMilli());
+
+    checkWindow(quarterHourWindow, Instant.parse("2019-01-01T07:45:00Z"), Instant.parse("2019-01-01T08:00:00Z"));
+  }
+
+  @Test
+  public void alignWindowBoundariesOnEdgesBeforeOrigin() {
+
+    final TimeInterval hourWindow = TumblingWindows.alignWindow(origin, Duration.ofHours(1),
+        dayBefore.plus(7, ChronoUnit.HOURS).toEpochMilli());
+
+    checkWindow(hourWindow, Instant.parse("2018-12-31T07:00:00Z"), Instant.parse("2018-12-31T08:00:00Z"));
+
+    final TimeInterval quarterHourWindow = TumblingWindows.alignWindow(origin, Duration.ofMinutes(15),
+        dayBefore.plus(7, ChronoUnit.HOURS).plus(45, ChronoUnit.MINUTES).toEpochMilli());
+
+    checkWindow(quarterHourWindow, Instant.parse("2018-12-31T07:45:00Z"), Instant.parse("2018-12-31T08:00:00Z"));
+  }
+
+  @Test
+  public void createsInitiallyEmptyState() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+    final SeqWindowStore<TimeInterval> store = assigner.stateInitializer().apply(HashTrieSet.empty());
+    Assert.assertTrue(store.getWindows().isEmpty());
+    Assert.assertTrue(store.openWindows().isEmpty());
+  }
+
+  @Test
+  public void assignsCorrectWindows() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+    final Instant time = origin.plus(5, ChronoUnit.HOURS)
+        .plus(13, ChronoUnit.MINUTES)
+        .plus(27, ChronoUnit.SECONDS)
+        .plus(344, ChronoUnit.MILLIS);
+
+    final SeqWindowStore<TimeInterval> store = assigner.stateInitializer().apply(HashTrieSet.empty());
+
+    final Assignment<TimeInterval, SeqWindowStore<TimeInterval>> assignment =
+        assigner.windowsFor("value", time.toEpochMilli(), store);
+
+    Assert.assertEquals(assignment.windows().size(), 1);
+    for (final TimeInterval window : assignment.windows()) {
+      checkWindow(window, origin.plus(
+          5, ChronoUnit.HOURS), origin.plus(6, ChronoUnit.HOURS));
+    }
+
+    Assert.assertEquals(assignment.updatedState().getWindows().size(), 1);
+    checkWindow(assignment.updatedState().getWindows().get(0), origin.plus(
+        5, ChronoUnit.HOURS), origin.plus(6, ChronoUnit.HOURS));
+  }
+
+  @Test
+  public void reusesWindowObjects() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+    final Instant time = origin.plus(5, ChronoUnit.HOURS)
+        .plus(13, ChronoUnit.MINUTES)
+        .plus(27, ChronoUnit.SECONDS)
+        .plus(344, ChronoUnit.MILLIS);
+
+    final SeqWindowStore<TimeInterval> store = assigner.stateInitializer().apply(HashTrieSet.empty());
+
+    final Assignment<TimeInterval, SeqWindowStore<TimeInterval>> assignment1 =
+        assigner.windowsFor("value", time.toEpochMilli(), store);
+
+    final Assignment<TimeInterval, SeqWindowStore<TimeInterval>> assignment2 =
+        assigner.windowsFor("value",
+            time.plus(10, ChronoUnit.SECONDS).toEpochMilli(),
+            assignment1.updatedState());
+
+    Assert.assertSame(assignment2.updatedState(), assignment1.updatedState());
+
+    Assert.assertEquals(assignment1.windows().size(), 1);
+    Assert.assertEquals(assignment2.windows().size(), 1);
+    Assert.assertSame(assignment2.windows().iterator().next(), assignment1.windows().iterator().next());
+  }
+
+  private static void checkWindow(final TimeInterval window, final Instant expectedStart, final Instant expectedEnd) {
+    Assert.assertEquals(Instant.ofEpochMilli(window.getStart()), expectedStart);
+    Assert.assertEquals(Instant.ofEpochMilli(window.getEnd()), expectedEnd);
+  }
+
+  @Test
+  public void initializeEmptyState() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+
+    final SeqWindowStore<TimeInterval> state = assigner.stateInitializer().apply(HashTrieSet.empty());
+
+    Assert.assertEquals(state.openWindows(), HashTrieSet.empty());
+  }
+
+  @Test
+  public void initializeFromCorrectlyAlignedWindows() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+
+    final Instant t1 = origin.plus(4, ChronoUnit.HOURS);
+    final Instant t2 = origin.plus(8, ChronoUnit.HOURS);
+
+    final TimeInterval window1 = new TimeInterval(t1.toEpochMilli(),
+        t1.plus(1, ChronoUnit.HOURS).toEpochMilli());
+    final TimeInterval window2 = new TimeInterval(t2.toEpochMilli(),
+        t2.plus(1, ChronoUnit.HOURS).toEpochMilli());
+
+    final SeqWindowStore<TimeInterval> state = assigner.stateInitializer().apply(
+        HashTrieSet.of(window1, window2));
+
+    Assert.assertEquals(state.openWindows(), HashTrieSet.of(window1, window2));
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void failsToInitializeForUnalignedWindows() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+
+    final Instant t1 = origin.plus(4, ChronoUnit.HOURS).plus(3, ChronoUnit.MINUTES);
+    final Instant t2 = origin.plus(8, ChronoUnit.HOURS);
+
+    final TimeInterval window1 = new TimeInterval(t1.toEpochMilli(),
+        t1.plus(1, ChronoUnit.HOURS).toEpochMilli());
+    final TimeInterval window2 = new TimeInterval(t2.toEpochMilli(),
+        t2.plus(1, ChronoUnit.HOURS).toEpochMilli());
+
+    assigner.stateInitializer().apply(
+        HashTrieSet.of(window1, window2));
+
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void failsToInitializeForTooShortWindows() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+
+    final Instant t1 = origin.plus(4, ChronoUnit.HOURS);
+    final Instant t2 = origin.plus(8, ChronoUnit.HOURS);
+
+    final TimeInterval window1 = new TimeInterval(t1.toEpochMilli(),
+        t1.plus(30, ChronoUnit.MINUTES).toEpochMilli());
+    final TimeInterval window2 = new TimeInterval(t2.toEpochMilli(),
+        t2.plus(1, ChronoUnit.HOURS).toEpochMilli());
+
+    assigner.stateInitializer().apply(
+        HashTrieSet.of(window1, window2));
+
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void failsToInitializeForTooLongWindows() {
+    final TumblingWindows<String> assigner = new TumblingWindows<>(origin, Duration.ofHours(1));
+
+    final Instant t1 = origin.plus(4, ChronoUnit.HOURS);
+    final Instant t2 = origin.plus(8, ChronoUnit.HOURS);
+
+    final TimeInterval window1 = new TimeInterval(t1.toEpochMilli(),
+        t1.plus(90, ChronoUnit.MINUTES).toEpochMilli());
+    final TimeInterval window2 = new TimeInterval(t2.toEpochMilli(),
+        t2.plus(1, ChronoUnit.HOURS).toEpochMilli());
+
+    assigner.stateInitializer().apply(
+        HashTrieSet.of(window1, window2));
+
+  }
+
+}

--- a/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/Form.java
+++ b/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/Form.java
@@ -38,6 +38,7 @@ import swim.structure.form.ByteForm;
 import swim.structure.form.CharacterForm;
 import swim.structure.form.CollectionForm;
 import swim.structure.form.DoubleForm;
+import swim.structure.form.EnumForm;
 import swim.structure.form.FloatForm;
 import swim.structure.form.IntegerForm;
 import swim.structure.form.ItemForm;
@@ -414,6 +415,8 @@ public abstract class Form<T> {
     if (type.isArray()) {
       final Class<?> componentType = type.getComponentType();
       return forArray(componentType, forClass(componentType));
+    } else if (type.isEnum()) {
+      return forEnumInternal(type.asSubclass(Enum.class));
     } else {
       Form<T> form = forBuiltin(type);
       if (form != null) {
@@ -436,5 +439,20 @@ public abstract class Form<T> {
    */
   public static <T> Form<T> forClass(Class<?> type) {
     return forClass(type, null);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static <T> Form<T> forEnumInternal(final Class<? extends Enum> type) {
+    return (Form<T>) forEnum(type);
+  }
+
+  /**
+   * Returns a {@link Form} for an enumerated type.
+   * @param type Class for the enumerated type.
+   * @param <E> The type of the enumeration.
+   * @return The form for the enumeration.
+   */
+  public static <E extends Enum<E>> Form<E> forEnum(final Class<E> type) {
+    return new EnumForm<>(type);
   }
 }

--- a/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/form/DurationForm.java
+++ b/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/form/DurationForm.java
@@ -1,0 +1,71 @@
+package swim.structure.form;
+
+import java.time.Duration;
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Record;
+import swim.structure.Value;
+
+/**
+ * Form for standard library {@link Duration}s.
+ */
+public final class DurationForm extends Form<Duration> {
+
+  private final Duration unit;
+
+  public DurationForm(final Duration unit) {
+    this.unit = unit;
+  }
+
+  @Override
+  public String tag() {
+    return "duration";
+  }
+
+  @Override
+  public Duration unit() {
+    return unit;
+  }
+
+  @Override
+  public Form<Duration> unit(final Duration unit) {
+    return new DurationForm(unit);
+  }
+
+  @Override
+  public Class<?> type() {
+    return Duration.class;
+  }
+
+  @Override
+  public Item mold(final Duration duration) {
+    if (duration != null) {
+      final Record inner;
+      if (duration.getNano() == 0) {
+        inner = Record.create(1).slot("seconds", duration.getSeconds());
+      } else {
+        inner = Record.create(2)
+            .slot("seconds", duration.getSeconds()).slot("nanos", duration.getNano());
+      }
+      return Record.create(1).attr(tag(), inner);
+    } else {
+      return Item.absent();
+    }
+  }
+
+  @Override
+  public Duration cast(final Item item) {
+    final Value header = item.toValue().header(tag());
+    if (header.isDefined()) {
+      final long seconds = header.get("seconds").longValue();
+      final Value nanoVal = header.get("nanos");
+      if (nanoVal.isDefined()) {
+        return Duration.ofSeconds(seconds, nanoVal.longValue());
+      } else {
+        return Duration.ofSeconds(seconds);
+      }
+    } else {
+      return null;
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/form/EnumForm.java
+++ b/swim-system-java/swim-core-java/swim.structure/src/main/java/swim/structure/form/EnumForm.java
@@ -1,0 +1,41 @@
+package swim.structure.form;
+
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Text;
+
+/**
+ * {@link Form} for an enumerated type that uses the string name of the constants.
+ * @param <E> The type of the enumeration.
+ */
+public class EnumForm<E extends Enum<E>> extends Form<E> {
+
+  private final Class<E> enumCls;
+
+  public EnumForm(final Class<E> enumCls) {
+    this.enumCls = enumCls;
+  }
+
+  @Override
+  public Class<E> type() {
+    return enumCls;
+  }
+
+  @Override
+  public Item mold(final E object) {
+    if (object == null) {
+      return Item.absent();
+    } else {
+      return Text.from(object.name());
+    }
+  }
+
+  @Override
+  public E cast(final Item item) {
+    if (item.isDefined()) {
+      return Enum.valueOf(enumCls, item.stringValue());
+    } else {
+      return null;
+    }
+  }
+}

--- a/swim-system-java/swim-core-java/swim.util/src/main/java/swim/util/Deferred.java
+++ b/swim-system-java/swim-core-java/swim.util/src/main/java/swim/util/Deferred.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swim.dataflow.connector;
+package swim.util;
 
 import java.util.function.Function;
 
@@ -132,3 +132,5 @@ class Memoized<U> implements Deferred<U> {
   }
 
 }
+
+

--- a/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/agent/DataflowAgent.java
+++ b/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/agent/DataflowAgent.java
@@ -1,0 +1,651 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.api.agent;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import swim.api.declarative.AgentPersistence;
+import swim.api.downlink.EventDownlink;
+import swim.api.downlink.MapDownlink;
+import swim.api.downlink.ValueDownlink;
+import swim.api.lane.JoinMapLane;
+import swim.api.lane.JoinValueLane;
+import swim.api.lane.MapLane;
+import swim.api.lane.ValueLane;
+import swim.api.warp.function.OnEvent;
+import swim.dataflow.connector.AbstractJunction;
+import swim.dataflow.connector.AbstractMapJunction;
+import swim.dataflow.connector.Deferred;
+import swim.dataflow.connector.Junction;
+import swim.dataflow.connector.MapJunction;
+import swim.dataflow.connector.MapReceptacle;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.graph.MapSink;
+import swim.dataflow.graph.MapSwimStream;
+import swim.dataflow.graph.Sink;
+import swim.dataflow.graph.SwimStream;
+import swim.dataflow.graph.SwimStreamContext;
+import swim.dataflow.graph.impl.Graphs;
+import swim.observable.function.DidRemoveKey;
+import swim.observable.function.DidSet;
+import swim.observable.function.DidUpdateKey;
+import swim.structure.Form;
+
+/**
+ * Extension to {@link AbstractAgent} that provides a declarative method for describing the relationship
+ * between lanes in the agent.
+ */
+public abstract class DataflowAgent extends AbstractAgent {
+
+  public DataflowAgent(final AgentContext context) {
+    super(context);
+  }
+
+  public DataflowAgent() {
+    super();
+  }
+
+  /**
+   * Create a {@link Sink} that will write to a {@link ValueLane}.
+   *
+   * @param lane The target lane.
+   * @param <T>  The type of the lane.
+   * @return The sink.
+   */
+  public static <T> Sink<T> sink(final ValueLane<T> lane) {
+    return context -> val -> lane.set(val.get());
+  }
+
+  /**
+   * Create a {@link MapSink} that will write to a {@link MapLane}.
+   *
+   * @param lane The target lane.
+   * @param <K>  The type of the keys.
+   * @param <V>  The type of the values.
+   * @return The sink.
+   */
+  public static <K, V> MapSink<K, V> sink(final MapLane<K, V> lane) {
+    return context -> new MapReceptacle<K, V>() {
+      @Override
+      public void notifyChange(final K key, final Deferred<V> value, final Deferred<MapView<K, V>> map) {
+        lane.put(key, value.get());
+      }
+
+      @Override
+      public void notifyRemoval(final K key, final Deferred<MapView<K, V>> map) {
+        lane.remove(key);
+      }
+    };
+  }
+
+  @Override
+  public final void didStart() {
+    willInitializeGraph();
+    final SwimStreamContext graphContext = Graphs.createContext(schedule(), new AgentPersistence(agentContext()));
+    final BuilderContextImpl builderCon = new BuilderContextImpl(graphContext);
+    onInitializeGraph(builderCon);
+    final SwimStreamContext.InitContext initCon = graphContext.constructGraph();
+    didInitializeGraph(initCon);
+  }
+
+  /**
+   * Called before the flow graphs are instantiated.
+   */
+  public void willInitializeGraph() {
+
+  }
+
+  /**
+   * Specify the flow graphs to create between lanes.
+   *
+   * @param context Context for tracking the flow graphs that have been created.
+   */
+  public abstract void onInitializeGraph(StreamBuilderContext context);
+
+  /**
+   * Called after the flow graphs are instantiated.
+   *
+   * @param initContext Context containing the created flow graphs.
+   */
+  public void didInitializeGraph(final SwimStreamContext.InitContext initContext) {
+
+  }
+
+  public interface StreamBuilderContext {
+
+    /**
+     * Create a stream from a value lane.
+     *
+     * @param lane       The lane.
+     * @param form       The form of the type.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    <T> SwimStream<T> fromValueLane(Supplier<ValueLane<T>> lane,
+                                    Form<T> form,
+                                    ToLongFunction<T> timestamps);
+
+    /**
+     * Create a stream from an external inlet (which could be a value lane or downlink).
+     *
+     * @param lane       The external lane.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <T> SwimStream<T> fromValueLane(final ValueLane<T> lane,
+                                            final ToLongFunction<T> timestamps) {
+      return fromValueLane(() -> lane, lane.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a value lane.
+     *
+     * @param lane The lane.
+     * @param form The form of the type.
+     * @param <T>  The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <T> SwimStream<T> fromValueLane(final Supplier<ValueLane<T>> lane, final Form<T> form) {
+      return fromValueLane(lane, form, null);
+    }
+
+    /**
+     * Create a stream from a value lane.
+     *
+     * @param lane The lane.
+     * @param <T>  The type of the values.
+     * @return The stream based on the outlet.
+     */
+    default <T> SwimStream<T> fromValueLane(final ValueLane<T> lane) {
+      return fromValueLane(() -> lane, lane.valueForm(), null);
+    }
+
+    /**
+     * Create a stream from an value downlink.
+     *
+     * @param downlink   The downlink.
+     * @param form       The form of the type.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    <T> SwimStream<T> fromValueDownlink(Supplier<ValueDownlink<T>> downlink,
+                                        Form<T> form,
+                                        ToLongFunction<T> timestamps);
+
+    /**
+     * Create a stream from a value downlink.
+     *
+     * @param downlink   The downlink.
+     * @param form       The form of the type.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromValueDownlink(final ValueDownlink<T> downlink,
+                                                final Form<T> form,
+                                                final ToLongFunction<T> timestamps) {
+      return fromValueDownlink(() -> downlink, downlink.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a value downlink.
+     *
+     * @param downlink The value downlink.
+     * @param form     The form of the type.
+     * @param <T>      The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromValueDownlink(final Supplier<ValueDownlink<T>> downlink, final Form<T> form) {
+      return fromValueDownlink(downlink, form, null);
+    }
+
+    /**
+     * Create a stream from a value downlink.
+     *
+     * @param downlink The downlink.
+     * @param <T>      The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromValueDownlink(final ValueDownlink<T> downlink) {
+      return fromValueDownlink(() -> downlink, downlink.valueForm(), null);
+    }
+
+    /**
+     * Create a stream from an event downlink.
+     *
+     * @param downlink   The downlink.
+     * @param form       The form of the type.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    <T> SwimStream<T> fromEventDownlink(Supplier<EventDownlink<T>> downlink,
+                                        Form<T> form,
+                                        ToLongFunction<T> timestamps);
+
+    /**
+     * Create a stream from an event downlink.
+     *
+     * @param downlink   The downlink.
+     * @param form       The form of the type.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <T>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromValueDownlink(final EventDownlink<T> downlink,
+                                                final Form<T> form,
+                                                final ToLongFunction<T> timestamps) {
+      return fromEventDownlink(() -> downlink, downlink.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from an event downlink.
+     *
+     * @param downlink The event downlink.
+     * @param form     The form of the type.
+     * @param <T>      The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromEventDownlink(final Supplier<EventDownlink<T>> downlink, final Form<T> form) {
+      return fromEventDownlink(downlink, form, null);
+    }
+
+    /**
+     * Create a stream from a value downlink.
+     *
+     * @param downlink The downlink.
+     * @param <T>      The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <T> SwimStream<T> fromEventDownlink(final EventDownlink<T> downlink) {
+      return fromEventDownlink(() -> downlink, downlink.valueForm(), null);
+    }
+    /**
+     * Create a stream from a map lane.
+     *
+     * @param lane       The lane.
+     * @param keyForm    The form of the keys.
+     * @param valueForm  The form of the values.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    <K, V> MapSwimStream<K, V> fromMapLane(Supplier<MapLane<K, V>> lane,
+                                           Form<K> keyForm, Form<V> valueForm,
+                                           ToLongFunction<V> timestamps);
+
+    /**
+     * Create a stream from a map lane.
+     *
+     * @param lane       The lane.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapLane(final MapLane<K, V> lane,
+                                                   final ToLongFunction<V> timestamps) {
+      return fromMapLane(() -> lane, lane.keyForm(), lane.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a map lane.
+     *
+     * @param lane      The lane.
+     * @param keyForm   The form of the keys.
+     * @param valueForm The form of the values.
+     * @param <K>       The type of the keys.
+     * @param <V>       The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapLane(final Supplier<MapLane<K, V>> lane,
+                                                   final Form<K> keyForm, final Form<V> valueForm) {
+      return fromMapLane(lane, keyForm, valueForm, null);
+    }
+
+    /**
+     * Create a stream from an map lane.
+     *
+     * @param lane The lane.
+     * @param <K>  The type of the keys.
+     * @param <V>  The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapLane(final MapLane<K, V> lane,
+                                                   final Form<K> keyForm, final Form<V> valueForm) {
+      return fromMapLane(() -> lane, lane.keyForm(), lane.valueForm(), null);
+    }
+
+    /**
+     * Create a stream from a map downlink.
+     *
+     * @param downlink   The downlink.
+     * @param keyForm    The form of the keys.
+     * @param valueForm  The form of the values.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    <K, V> MapSwimStream<K, V> fromMapDownlink(Supplier<MapDownlink<K, V>> downlink,
+                                               Form<K> keyForm, Form<V> valueForm,
+                                               ToLongFunction<V> timestamps);
+
+    /**
+     * Create a stream from a map downlink.
+     *
+     * @param downlink   The downlink.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapDownlink(final MapDownlink<K, V> downlink,
+                                                       final ToLongFunction<V> timestamps) {
+      return fromMapDownlink(() -> downlink, downlink.keyForm(), downlink.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a map downlink.
+     *
+     * @param downlink  The downlink.
+     * @param keyForm   The form of the keys.
+     * @param valueForm The form of the values.
+     * @param <K>       The type of the keys.
+     * @param <V>       The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapDownlink(final Supplier<MapDownlink<K, V>> downlink,
+                                                       final Form<K> keyForm, final Form<V> valueForm) {
+      return fromMapDownlink(downlink, keyForm, valueForm, null);
+    }
+
+    /**
+     * Create a stream from an map downlink.
+     *
+     * @param downlink The downlink.
+     * @param <K>      The type of the keys.
+     * @param <V>      The type of the values.
+     * @return The stream based on the downlink.
+     */
+    default <K, V> MapSwimStream<K, V> fromMapDownlink(final MapDownlink<K, V> downlink,
+                                                       final Form<K> keyForm, final Form<V> valueForm) {
+      return fromMapDownlink(() -> downlink, downlink.keyForm(), downlink.valueForm(), null);
+    }
+
+    /**
+     * Create a stream from a join value lane.
+     *
+     * @param lane       The lane.
+     * @param keyForm    The form of the keys.
+     * @param valueForm  The form of the values.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    <K, V> MapSwimStream<K, V> fromJoinValueLane(Supplier<JoinValueLane<K, V>> lane,
+                                                 Form<K> keyForm, Form<V> valueForm,
+                                                 ToLongFunction<V> timestamps);
+
+    /**
+     * Create a stream from a join value lane.
+     *
+     * @param lane       The lane.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinValueLane(final JoinValueLane<K, V> lane,
+                                                         final ToLongFunction<V> timestamps) {
+      return fromJoinValueLane(() -> lane, lane.keyForm(), lane.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a join value lane.
+     *
+     * @param lane      The lane.
+     * @param keyForm   The form of the keys.
+     * @param valueForm The form of the values.
+     * @param <K>       The type of the keys.
+     * @param <V>       The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinValueLane(final Supplier<JoinValueLane<K, V>> lane,
+                                                         final Form<K> keyForm, final Form<V> valueForm) {
+      return fromJoinValueLane(lane, keyForm, valueForm, null);
+    }
+
+    /**
+     * Create a stream from a join value lane.
+     *
+     * @param lane The lane.
+     * @param <K>  The type of the keys.
+     * @param <V>  The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinValueLane(final JoinValueLane<K, V> lane,
+                                                         final Form<K> keyForm, final Form<V> valueForm) {
+      return fromJoinValueLane(() -> lane, lane.keyForm(), lane.valueForm(), null);
+    }
+
+    /**
+     * Create a stream from a join map lane.
+     *
+     * @param lane       The lane.
+     * @param keyForm    The form of the keys.
+     * @param valueForm  The form of the values.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    <K, V> MapSwimStream<K, V> fromJoinMapLane(Supplier<JoinMapLane<?, K, V>> lane,
+                                               Form<K> keyForm, Form<V> valueForm,
+                                               ToLongFunction<V> timestamps);
+
+    /**
+     * Create a stream from a join map lane.
+     *
+     * @param lane       The lane.
+     * @param timestamps Assigns timestamps to the values.
+     * @param <K>        The type of the keys.
+     * @param <V>        The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinMapLane(final JoinMapLane<?, K, V> lane,
+                                                       final ToLongFunction<V> timestamps) {
+      return fromJoinMapLane(() -> lane, lane.keyForm(), lane.valueForm(), timestamps);
+    }
+
+    /**
+     * Create a stream from a join map lane.
+     *
+     * @param lane      The lane.
+     * @param keyForm   The form of the keys.
+     * @param valueForm The form of the values.
+     * @param <K>       The type of the keys.
+     * @param <V>       The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinMapLane(final Supplier<JoinMapLane<?, K, V>> lane,
+                                                       final Form<K> keyForm, final Form<V> valueForm) {
+      return fromJoinMapLane(lane, keyForm, valueForm, null);
+    }
+
+    /**
+     * Create a stream from an join map lane.
+     *
+     * @param lane The lane.
+     * @param <K>  The type of the keys.
+     * @param <V>  The type of the values.
+     * @return The stream based on the lane.
+     */
+    default <K, V> MapSwimStream<K, V> fromJoinMapLane(final JoinMapLane<?, K, V> lane,
+                                                       final Form<K> keyForm, final Form<V> valueForm) {
+      return fromJoinMapLane(() -> lane, lane.keyForm(), lane.valueForm(), null);
+    }
+
+
+  }
+
+  private static final class EventJunction<T> extends AbstractJunction<T> implements OnEvent<T> {
+
+    @Override
+    public void onEvent(final T value) {
+      emit(Deferred.value(value));
+    }
+  }
+
+  private static final class ValueLaneOrDlJunction<T> extends AbstractJunction<T> implements DidSet<T> {
+
+    @Override
+    public void didSet(final T newValue, final T oldValue) {
+      emit(Deferred.value(newValue));
+    }
+  }
+
+
+  private static final class MapLaneOrDlJunction<K, V> extends AbstractMapJunction<K, V> implements DidUpdateKey<K, V>, DidRemoveKey<K, V> {
+
+    private final Map<K, V> view;
+
+    private MapLaneOrDlJunction(final Map<K, V> view) {
+      this.view = view;
+    }
+
+    @Override
+    public void didRemove(final K key, final V oldValue) {
+      emitRemoval(key, MapView.wrap(view));
+    }
+
+    @Override
+    public void didUpdate(final K key, final V newValue, final V oldValue) {
+      emit(key, Deferred.value(newValue), Deferred.value(MapView.wrap(view)));
+    }
+  }
+
+  private static final class BuilderContextImpl implements StreamBuilderContext {
+
+    private final SwimStreamContext context;
+
+    private BuilderContextImpl(final SwimStreamContext context) {
+      this.context = context;
+    }
+
+    @Override
+    public <T> SwimStream<T> fromValueLane(final Supplier<ValueLane<T>> lane,
+                                           final Form<T> form,
+                                           final ToLongFunction<T> timestamps) {
+      final Supplier<Junction<T>> fac = () -> {
+        final ValueLane<T> laneRef = lane.get();
+        final ValueLaneOrDlJunction<T> junction = new ValueLaneOrDlJunction<>();
+        laneRef.observe(junction);
+        return junction;
+      };
+      return context.fromJunction(fac, form, timestamps);
+    }
+
+    @Override
+    public <T> SwimStream<T> fromValueDownlink(final Supplier<ValueDownlink<T>> downlink,
+                                               final Form<T> form,
+                                               final ToLongFunction<T> timestamps) {
+      final Supplier<Junction<T>> fac = () -> {
+        final ValueDownlink<T> dl = downlink.get();
+        final ValueLaneOrDlJunction<T> junction = new ValueLaneOrDlJunction<>();
+        dl.observe(junction);
+        return junction;
+      };
+      return context.fromJunction(fac, form, timestamps);
+    }
+
+    @Override
+    public <T> SwimStream<T> fromEventDownlink(final Supplier<EventDownlink<T>> downlink,
+                                               final Form<T> form,
+                                               final ToLongFunction<T> timestamps) {
+      final Supplier<Junction<T>> fac = () -> {
+        final EventDownlink<T> dl = downlink.get();
+        final EventJunction<T> junction = new EventJunction<>();
+        dl.observe(junction);
+        return junction;
+      };
+      return context.fromJunction(fac, form, timestamps);
+    }
+
+
+    @Override
+    public <K, V> MapSwimStream<K, V> fromMapLane(final Supplier<MapLane<K, V>> lane,
+                                                  final Form<K> keyForm,
+                                                  final Form<V> valueForm,
+                                                  final ToLongFunction<V> timestamps) {
+
+      final Supplier<MapJunction<K, V>> fac = () -> {
+        final MapLane<K, V> laneRef = lane.get();
+        final MapLaneOrDlJunction<K, V> junction = new MapLaneOrDlJunction<>(laneRef);
+        laneRef.observe(junction);
+        return junction;
+      };
+      return context.fromMapJunction(fac, keyForm, valueForm, timestamps);
+    }
+
+    @Override
+    public <K, V> MapSwimStream<K, V> fromMapDownlink(final Supplier<MapDownlink<K, V>> downlink,
+                                                      final Form<K> keyForm,
+                                                      final Form<V> valueForm,
+                                                      final ToLongFunction<V> timestamps) {
+      final Supplier<MapJunction<K, V>> fac = () -> {
+        final MapDownlink<K, V> dl = downlink.get();
+        final MapLaneOrDlJunction<K, V> junction = new MapLaneOrDlJunction<>(dl);
+        dl.observe(junction);
+        return junction;
+      };
+      return context.fromMapJunction(fac, keyForm, valueForm, timestamps);
+    }
+
+    @Override
+    public <K, V> MapSwimStream<K, V> fromJoinValueLane(final Supplier<JoinValueLane<K, V>> lane,
+                                                        final Form<K> keyForm,
+                                                        final Form<V> valueForm,
+                                                        final ToLongFunction<V> timestamps) {
+      final Supplier<MapJunction<K, V>> fac = () -> {
+        final JoinValueLane<K, V> laneRef = lane.get();
+        final MapLaneOrDlJunction<K, V> junction = new MapLaneOrDlJunction<>(laneRef);
+        laneRef.observe(junction);
+        return junction;
+      };
+      return context.fromMapJunction(fac, keyForm, valueForm, timestamps);
+    }
+
+    @Override
+    public <K, V> MapSwimStream<K, V> fromJoinMapLane(final Supplier<JoinMapLane<?, K, V>> lane,
+                                                      final Form<K> keyForm,
+                                                      final Form<V> valueForm,
+                                                      final ToLongFunction<V> timestamps) {
+      final Supplier<MapJunction<K, V>> fac = () -> {
+        final JoinMapLane<?, K, V> laneRef = lane.get();
+        final MapLaneOrDlJunction<K, V> junction = new MapLaneOrDlJunction<>(laneRef);
+        laneRef.observe(junction);
+        return junction;
+      };
+      return context.fromMapJunction(fac, keyForm, valueForm, timestamps);
+    }
+  }
+}

--- a/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/agent/DataflowAgent.java
+++ b/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/agent/DataflowAgent.java
@@ -28,7 +28,6 @@ import swim.api.lane.ValueLane;
 import swim.api.warp.function.OnEvent;
 import swim.dataflow.connector.AbstractJunction;
 import swim.dataflow.connector.AbstractMapJunction;
-import swim.dataflow.connector.Deferred;
 import swim.dataflow.connector.Junction;
 import swim.dataflow.connector.MapJunction;
 import swim.dataflow.connector.MapReceptacle;
@@ -43,6 +42,7 @@ import swim.observable.function.DidRemoveKey;
 import swim.observable.function.DidSet;
 import swim.observable.function.DidUpdateKey;
 import swim.structure.Form;
+import swim.util.Deferred;
 
 /**
  * Extension to {@link AbstractAgent} that provides a declarative method for describing the relationship

--- a/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/declarative/AgentPersistence.java
+++ b/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/declarative/AgentPersistence.java
@@ -1,0 +1,264 @@
+// Copyright 2015-2019 SWIM.AI inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.api.declarative;
+
+import java.util.List;
+import java.util.Set;
+import swim.api.data.ListData;
+import swim.api.data.MapData;
+import swim.api.data.ValueData;
+import swim.api.store.Store;
+import swim.dataflow.connector.MapView;
+import swim.dataflow.graph.Unit;
+import swim.dataflow.graph.persistence.ListPersister;
+import swim.dataflow.graph.persistence.MapPersister;
+import swim.dataflow.graph.persistence.PersistenceProvider;
+import swim.dataflow.graph.persistence.SetPersister;
+import swim.dataflow.graph.persistence.ValuePersister;
+import swim.structure.Form;
+import swim.structure.Value;
+
+/**
+ * Persistence provider which stores state using a {@link Store}.
+ */
+public class AgentPersistence implements PersistenceProvider {
+
+  private final Store factory;
+
+  public AgentPersistence(final Store factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  public <T> ValuePersister<T> forValue(final Value key, final Form<T> form) {
+    return new ValueDataPersister<>(factory.valueData(key).valueForm(form));
+  }
+
+  @Override
+  public <T> SetPersister<T> forSet(final Value key, final Form<T> form) {
+    return new SetDataPersister<>(factory.mapData(key).keyForm(form).valueForm(Unit.FORM));
+  }
+
+  @Override
+  public <T> ListPersister<T> forList(final Value key, final Form<T> form) {
+    return new ListDataPersister<>(factory.listData(key).valueForm(form));
+  }
+
+  @Override
+  public <K, V> MapPersister<K, V> forMap(final Value key, final Form<K> keyForm, final Form<V> valForm) {
+    return new MapDataPersister<>(factory.mapData(key).keyForm(keyForm).valueForm(valForm));
+  }
+}
+
+final class ValueDataPersister<T> implements ValuePersister<T> {
+
+  private ValueData<T> data;
+
+  ValueDataPersister(final ValueData<T> data) {
+    this.data = data;
+  }
+
+  @Override
+  public T get() {
+    checkOpen();
+    return data.get();
+  }
+
+  private void checkOpen() {
+    if (data == null) {
+      throw new IllegalStateException("Value persister has already been closed.");
+    }
+  }
+
+  @Override
+  public void set(final T value) {
+    checkOpen();
+    data.set(value);
+  }
+
+  @Override
+  public void close() {
+    if (data != null) {
+      try {
+        data.close();
+      } finally {
+        data = null;
+      }
+    }
+
+  }
+}
+
+final class MapDataPersister<K, V> implements MapPersister<K, V> {
+
+  private MapData<K, V> data;
+
+  MapDataPersister(final MapData<K, V> data) {
+    this.data = data;
+  }
+
+  private void checkOpen() {
+    if (data == null) {
+      throw new IllegalStateException("Value persister has already been closed.");
+    }
+  }
+
+  @Override
+  public V get(final K key) {
+    checkOpen();
+    return data.get(key);
+  }
+
+  @Override
+  public V getOrDefault(final K key) {
+    checkOpen();
+    return data.getOrDefault(key, data.valueForm().unit());
+  }
+
+  @Override
+  public boolean containsKey(final K key) {
+    checkOpen();
+    return data.containsKey(key);
+  }
+
+  @Override
+  public MapView<K, V> get() {
+    return MapView.wrap(data.snapshot());
+  }
+
+  @Override
+  public Set<K> keys() {
+    checkOpen();
+    return data.keySet();
+  }
+
+  @Override
+  public void put(final K key, final V value) {
+    checkOpen();
+    data.put(key, value);
+  }
+
+  @Override
+  public void remove(final K key) {
+    checkOpen();
+    data.remove(key);
+  }
+
+  @Override
+  public void close() {
+    if (data != null) {
+      try {
+        data.close();
+      } finally {
+        data = null;
+      }
+    }
+  }
+}
+
+final class ListDataPersister<T> implements ListPersister<T> {
+
+  private ListData<T> data;
+
+  ListDataPersister(final ListData<T> data) {
+    this.data = data;
+  }
+
+  @Override
+  public T get(final int index) {
+    return data.get(index);
+  }
+
+  @Override
+  public void append(final T value) {
+    data.add(value);
+  }
+
+  @Override
+  public void prepend(final T value) {
+    data.add(0, value);
+  }
+
+  @Override
+  public int size() {
+    return data.size();
+  }
+
+  @Override
+  public void drop(final int n) {
+    data.drop(n);
+  }
+
+  @Override
+  public void take(final int n) {
+    data.take(n);
+  }
+
+  @Override
+  public List<T> get() {
+    return data.snapshot();
+  }
+
+  @Override
+  public void close() {
+    if (data != null) {
+      try {
+        data.close();
+      } finally {
+        data = null;
+      }
+    }
+  }
+}
+
+final class SetDataPersister<T> implements SetPersister<T> {
+
+  private MapData<T, Unit> data;
+
+  SetDataPersister(final MapData<T, Unit> data) {
+    this.data = data;
+  }
+
+  @Override
+  public boolean contains(final T val) {
+    return data.containsKey(val);
+  }
+
+  @Override
+  public Set<T> get() {
+    return data.snapshot().keySet();
+  }
+
+  @Override
+  public void add(final T value) {
+    data.put(value, Unit.INSTANCE);
+  }
+
+  @Override
+  public void remove(final T value) {
+    data.remove(value, Unit.INSTANCE);
+  }
+
+  @Override
+  public void close() {
+    if (data != null) {
+      try {
+        data.close();
+      } finally {
+        data = null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
A library of combinators to transform streams of data from Swim lanes. There are two main components:

1. A fluent API for constructing combinator graphs, [found here](https://github.com/swimos/swim/tree/feature/combinators/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/graph). The primary interfaces are SwimStream and MapSwimStream upon which transformations can be stacked.
2. Semantic interpretation of the combinator graphs, [found here](https://github.com/swimos/swim/tree/feature/combinators/swim-system-java/swim-core-java/swim.dataflow/src/main/java/swim/dataflow/connector). Based around the Junction/MapJunction Receptacle/MapReceptacle interfaces.

See [DataFlowAgent](https://github.com/swimos/swim/blob/feature/combinators/swim-system-java/swim-mesh-java/swim.api/src/main/java/swim/api/agent/DataflowAgent.java) for an example of how combinator graphs can be attached to agent lanes and downlinks.
