### PR TITLE
Receiving a close frame without a body raises an exception in the swim decoder.

### DIFF
--- a/swim-system-java/swim-core-java/swim.ws/src/main/java/swim/ws/WsStatusDecoder.java
+++ b/swim-system-java/swim-core-java/swim.ws/src/main/java/swim/ws/WsStatusDecoder.java
@@ -36,10 +36,14 @@ final class WsStatusDecoder extends Decoder<WsStatus> {
   }
 
   static Decoder<WsStatus> decode(InputBuffer input, int code, Decoder<String> reason, int step) {
-    if (step == 1 && input.isCont()) {
-      code = input.head() << 8;
-      input = input.step();
-      step = 2;
+    if (step == 1) {
+      if (input.isCont()) {
+        code = input.head() << 8;
+        input = input.step();
+        step = 2;
+      } else if (input.isDone()) {
+        return done(null);
+      }
     }
     if (step == 2 && input.isCont()) {
       code |= input.head();
@@ -74,5 +78,4 @@ final class WsStatusDecoder extends Decoder<WsStatus> {
   public Decoder<WsStatus> feed(InputBuffer input) {
     return decode(input, this.code, this.reason, this.step);
   }
-
 }

--- a/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsFrameDecoderSpec.java
+++ b/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsFrameDecoderSpec.java
@@ -114,6 +114,11 @@ public class WsFrameDecoderSpec {
   }
 
   @Test
+  public void decodeEmptyCloseFrame() {
+    assertDecodes(Data.fromBase16("8800"), WsClose.empty());
+  }
+
+  @Test
   public void decodeMaxTinyFrame() {
     final int payloadSize = 125;
     final Data payload = Data.wrap(new byte[payloadSize]);


### PR DESCRIPTION
* Changed the `decode()` method to return an empty status if the received closed frame had no body.
* Added a unit test.