### PR TITLE
Validates permessage-deflate HTTP headers 

### DIFF
--- a/swim-system-java/swim-core-java/swim.ws/src/main/java/swim/ws/WsEngineSettings.java
+++ b/swim-system-java/swim-core-java/swim.ws/src/main/java/swim/ws/WsEngineSettings.java
@@ -261,6 +261,10 @@ public class WsEngineSettings implements Debug {
           } else if ("server_max_window_bits".equals(key)) {
             try {
               requestServerMaxWindowBits = Integer.parseInt(value);
+
+              if (requestServerMaxWindowBits < 8 || requestServerMaxWindowBits > 15) {
+                throw new WsException("invalid permessage-deflate parameter: server_max_window_bits; " + param.toHttp());
+              }
             } catch (NumberFormatException error) {
               throw new WsException("invalid permessage-deflate; " + param.toHttp());
             }
@@ -270,6 +274,10 @@ public class WsEngineSettings implements Debug {
             } else {
               try {
                 requestClientMaxWindowBits = Integer.parseInt(value);
+
+                if (requestClientMaxWindowBits < 8 || requestClientMaxWindowBits > 15) {
+                  throw new WsException("invalid permessage-deflate parameter: client_max_window_bits; " + param.toHttp());
+                }
               } catch (NumberFormatException error) {
                 throw new WsException("invalid permessage-deflate; " + param.toHttp());
               }
@@ -283,6 +291,7 @@ public class WsEngineSettings implements Debug {
         } else if (requestClientMaxWindowBits == 0) {
           requestClientMaxWindowBits = clientMaxWindowBits;
         }
+
         permessageDeflate = WebSocketExtension.permessageDeflate(
             requestServerNoContextTakeover || this.serverNoContextTakeover,
             requestClientNoContextTakeover || this.clientNoContextTakeover,

--- a/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsEngineSettingsSpec.java
+++ b/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsEngineSettingsSpec.java
@@ -82,4 +82,31 @@ public class WsEngineSettingsSpec {
     assertEquals(responseDeflateExtension, expected);
   }
 
+  @Test
+  public void invalidMaxWindowBits() {
+    final WsEngineSettings wsEngineSettings = WsEngineSettings.standard().maxFrameSize(2048)
+        .maxMessageSize(4096)
+        .serverCompressionLevel(7)
+        .clientCompressionLevel(9)
+        .serverNoContextTakeover(true)
+        .clientNoContextTakeover(true)
+        .serverMaxWindowBits(15)
+        .clientMaxWindowBits(15);
+
+    try {
+      final FingerTrieSeq<WebSocketExtension> requestExtensions = FingerTrieSeq.of(WebSocketExtension.permessageDeflate(false, false, 15, 1));
+      wsEngineSettings.acceptExtensions(requestExtensions);
+    } catch (WsException e) {
+      assertEquals(e.getLocalizedMessage(), "invalid permessage-deflate parameter: client_max_window_bits; client_max_window_bits=1");
+    }
+
+    try {
+      final FingerTrieSeq<WebSocketExtension> requestExtensions = FingerTrieSeq.of(WebSocketExtension.permessageDeflate(false, false, 1, 15));
+      wsEngineSettings.acceptExtensions(requestExtensions);
+    } catch (WsException e) {
+      assertEquals(e.getLocalizedMessage(), "invalid permessage-deflate parameter: server_max_window_bits; server_max_window_bits=1");
+    }
+
+  }
+
 }

--- a/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsEngineSettingsSpec.java
+++ b/swim-system-java/swim-core-java/swim.ws/src/test/java/swim/ws/WsEngineSettingsSpec.java
@@ -22,6 +22,7 @@ import swim.structure.Record;
 import swim.structure.Slot;
 import swim.structure.Value;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 public class WsEngineSettingsSpec {
 
@@ -96,6 +97,7 @@ public class WsEngineSettingsSpec {
     try {
       final FingerTrieSeq<WebSocketExtension> requestExtensions = FingerTrieSeq.of(WebSocketExtension.permessageDeflate(false, false, 15, 1));
       wsEngineSettings.acceptExtensions(requestExtensions);
+      fail();
     } catch (WsException e) {
       assertEquals(e.getLocalizedMessage(), "invalid permessage-deflate parameter: client_max_window_bits; client_max_window_bits=1");
     }
@@ -103,6 +105,7 @@ public class WsEngineSettingsSpec {
     try {
       final FingerTrieSeq<WebSocketExtension> requestExtensions = FingerTrieSeq.of(WebSocketExtension.permessageDeflate(false, false, 1, 15));
       wsEngineSettings.acceptExtensions(requestExtensions);
+      fail();
     } catch (WsException e) {
       assertEquals(e.getLocalizedMessage(), "invalid permessage-deflate parameter: server_max_window_bits; server_max_window_bits=1");
     }


### PR DESCRIPTION
Adds validation to HTTP request headers for `client_max_window_bits` and `server_max_window_bits` to assert that they are within 8..15 inclusive.