### PR TITLE
Avoid adding a path segment that implicitly inserted a slash which ca…

### DIFF
--- a/swim-system-java/swim-core-java/swim.uri/src/main/java/swim/uri/UriPathBuilder.java
+++ b/swim-system-java/swim-core-java/swim.uri/src/main/java/swim/uri/UriPathBuilder.java
@@ -91,11 +91,18 @@ public final class UriPathBuilder implements Builder<String, UriPath> {
   public boolean addSegment(String segment) {
     segment = UriPath.cacheSegment(segment);
     final UriPath tail = UriPath.segment(segment, UriPath.empty());
-    final int size = this.size;
+    int size = this.size;
     if (size == 0) {
       this.first = tail;
     } else {
-      dealias(size - 1).setTail(tail);
+      final UriPath last = dealias(size - 1);
+      if (last.isAbsolute()) {
+        last.setTail(tail);
+      } else {
+        last.setTail(UriPath.slash(tail));
+        size += 1;
+        this.aliased += 1;
+      }
     }
     this.last = tail;
     this.size = size + 1;
@@ -109,7 +116,14 @@ public final class UriPathBuilder implements Builder<String, UriPath> {
       if (size == 0) {
         this.first = path;
       } else {
-        dealias(size - 1).setTail(path);
+        final UriPath last = dealias(size - 1);
+        if (last.isAbsolute() || path.isAbsolute()) {
+          last.setTail(path);
+        } else {
+          last.setTail(UriPath.slash(path));
+          size += 1;
+          this.aliased += 1;
+        }
       }
       size += 1;
       do {

--- a/swim-system-java/swim-core-java/swim.uri/src/main/java/swim/uri/UriPathSegment.java
+++ b/swim-system-java/swim-core-java/swim.uri/src/main/java/swim/uri/UriPathSegment.java
@@ -63,10 +63,10 @@ final class UriPathSegment extends UriPath {
 
   @Override
   void setTail(UriPath tail) {
-    if (tail.isAbsolute()) {
-      this.tail = tail;
+    if (tail instanceof UriPathSegment) {
+      throw new UnsupportedOperationException();
     } else {
-      this.tail = UriPath.slash(tail);
+      this.tail = tail;
     }
   }
 


### PR DESCRIPTION
…uses the UriPathBuilder's alias tracking to get out of sync