### PR TITLE
More resilient lane tests

### DIFF
--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/CommandLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/CommandLaneSpec.java
@@ -29,19 +29,28 @@ import swim.api.function.DidConnect;
 import swim.api.function.DidDisconnect;
 import swim.api.lane.CommandLane;
 import swim.api.plane.AbstractPlane;
+import swim.api.warp.WarpUplink;
+import swim.api.warp.function.DidCommand;
 import swim.api.warp.function.DidLink;
+import swim.api.warp.function.DidReceive;
 import swim.api.warp.function.DidSync;
 import swim.api.warp.function.DidUnlink;
+import swim.api.warp.function.DidUplink;
 import swim.api.warp.function.OnCommand;
 import swim.api.warp.function.OnEvent;
+import swim.api.warp.function.WillCommand;
 import swim.api.warp.function.WillLink;
+import swim.api.warp.function.WillReceive;
 import swim.api.warp.function.WillSync;
 import swim.api.warp.function.WillUnlink;
+import swim.api.warp.function.WillUplink;
 import swim.codec.Format;
 import swim.concurrent.Cont;
 import swim.kernel.Kernel;
 import swim.service.web.WebServiceDef;
+import swim.structure.Form;
 import swim.structure.Text;
+import swim.structure.Value;
 import swim.warp.CommandMessage;
 import static org.testng.Assert.assertEquals;
 
@@ -55,9 +64,20 @@ public class CommandLaneSpec {
 
     final CountDownLatch commandDidSend = new CountDownLatch(2);
     final CountDownLatch linkOnEvent = new CountDownLatch(2);
+
+    final CountDownLatch didConnect = new CountDownLatch(2);
+    final CountDownLatch willLink = new CountDownLatch(2);
+    final CountDownLatch didLink = new CountDownLatch(2);
+    final CountDownLatch didDisconnect = new CountDownLatch(2);
+
+    final CountDownLatch willReceiveLink = new CountDownLatch(2);
+    final CountDownLatch didReceiveLink = new CountDownLatch(1);
+    final CountDownLatch willReceivePlane = new CountDownLatch(2);
+    final CountDownLatch didReceivePlane = new CountDownLatch(1);
+
     class CommandLinkController implements OnEvent<String>,
         WillLink, DidLink, WillSync, DidSync, WillUnlink, DidUnlink,
-        DidConnect, DidDisconnect, DidClose {
+        DidConnect, DidDisconnect, DidClose, WillReceive, DidReceive {
 
       @Override
       public void onEvent(String value) {
@@ -66,13 +86,41 @@ public class CommandLaneSpec {
       }
 
       @Override
+      public void willReceive(Value body) {
+        System.out.println("link willReceive: " + body.stringValue());
+        if ("Hello, link!".equals(body.stringValue())) {
+          willReceiveLink.countDown();
+        }
+        if ("Hello, plane!".equals(body.stringValue())) {
+          willReceivePlane.countDown();
+        }
+      }
+
+      @Override
+      public void didReceive(Value body) {
+        System.out.println("link didReceive: " + body.stringValue());
+        if ("Hello, link!".equals(body.stringValue())) {
+          assertEquals(willReceiveLink.getCount(), 1);
+          didReceiveLink.countDown();
+        }
+        if ("Hello, plane!".equals(body.stringValue())) {
+          assertEquals(willReceivePlane.getCount(), 1);
+          didReceivePlane.countDown();
+        }
+      }
+
+      @Override
       public void willLink() {
         System.out.println("link willLink");
+        //assertEquals(didConnect.getCount(), 1);
+        willLink.countDown();
       }
 
       @Override
       public void didLink() {
         System.out.println("link didLink");
+        assertEquals(willLink.getCount(), 1);
+        didLink.countDown();
       }
 
       @Override
@@ -98,11 +146,13 @@ public class CommandLaneSpec {
       @Override
       public void didConnect() {
         System.out.println("link didConnect");
+        didConnect.countDown();
       }
 
       @Override
       public void didDisconnect() {
         System.out.println("link didDisconnect");
+        didDisconnect.countDown();
       }
 
       @Override
@@ -144,10 +194,69 @@ public class CommandLaneSpec {
           throw new TestException(error);
         }
       });
-      commandDidSend.await(1, TimeUnit.SECONDS);
-      linkOnEvent.await(1, TimeUnit.SECONDS);
+
+      didReceivePlane.await(1, TimeUnit.SECONDS);
+      didReceiveLink.await(1, TimeUnit.SECONDS);
+
+      //TODO: Why do EventDownlinks have access to willCommand but not onCommand/didCommand?
+
+      //assertEquals(didConnect.getCount(), 1); //TODO: Duplicate didConnect calls
+      assertEquals(willLink.getCount(), 1);
+      assertEquals(didLink.getCount(), 1);
       assertEquals(commandDidSend.getCount(), 0);
       assertEquals(linkOnEvent.getCount(), 0);
+      assertEquals(willReceiveLink.getCount(), 1);
+      assertEquals(didReceiveLink.getCount(), 0);
+      assertEquals(willReceivePlane.getCount(), 1);
+      assertEquals(didReceivePlane.getCount(), 0);
+    } finally {
+      kernel.stop();
+      assertEquals(didDisconnect.getCount(), 1);
+    }
+  }
+
+  private static CountDownLatch willCommand;
+  private static CountDownLatch onCommand;
+  private static CountDownLatch didCommand;
+  private static CountDownLatch willUplink;
+  private static CountDownLatch didUplink;
+
+  private static void resetLatches() {
+    willCommand = new CountDownLatch(2);
+    onCommand = new CountDownLatch(2);
+    didCommand = new CountDownLatch(1);
+    willUplink = new CountDownLatch(2);
+    didUplink = new CountDownLatch(1);
+  }
+
+  @Test
+  public void testCommandLaneCallbacks() throws InterruptedException {
+    final Kernel kernel = ServerLoader.loadServerStack();
+    final TestCommandPlane plane = kernel.openSpace(ActorSpaceDef.fromName("test"))
+            .openPlane("test", TestCommandPlane.class);
+
+    try {
+      kernel.openService(WebServiceDef.standard().port(53556).spaceName("test"));
+      kernel.start();
+
+      resetLatches();
+
+      final EventDownlink<String> commandLink = plane.downlink()
+              .valueForm(Form.forString())
+              .hostUri("warp://localhost:53556")
+              .nodeUri("/commandLatched/hello")
+              .laneUri("command")
+              .open();
+      commandLink.command(Text.from("Hi"));
+
+      didUplink.await(2, TimeUnit.SECONDS);
+      didCommand.await(2, TimeUnit.SECONDS);
+      assertEquals(willCommand.getCount(), 1);
+      assertEquals(onCommand.getCount(), 1);
+      assertEquals(didCommand.getCount(), 0);
+      //assertEquals(willUplink.getCount(), 1); //TODO: wilUplink not implemented
+      assertEquals(didUplink.getCount(), 0);
+
     } finally {
       kernel.stop();
     }
@@ -167,10 +276,61 @@ public class CommandLaneSpec {
 
   }
 
+  static class TestLatchedCommandLaneAgent extends AbstractAgent {
+
+    @SwimLane("command")
+    CommandLane<String> testValue = commandLane()
+            .valueForm(Form.forString())
+            .observe(new TestCommandLaneControllerLatched());
+
+    class TestCommandLaneControllerLatched implements WillCommand, OnCommand<String>, DidCommand,
+            WillUplink, DidUplink {
+
+      @Override
+      public void willCommand(Value body) {
+        System.out.println(nodeUri() + " willCommand: " + body.stringValue());
+        assertEquals(didUplink.getCount(), 0);
+        willCommand.countDown();
+      }
+
+      @Override
+      public void onCommand(String value) {
+        System.out.println(nodeUri() + " onCommand: " + value);
+        assertEquals(willCommand.getCount(), 1);
+        onCommand.countDown();
+      }
+
+      @Override
+      public void didCommand(Value body) {
+        System.out.println(nodeUri() + " onCommand: " + body.stringValue());
+        assertEquals(onCommand.getCount(), 1);
+        didCommand.countDown();
+      }
+
+      @Override
+      public void willUplink(WarpUplink uplink) {
+        System.out.println(nodeUri() + " willUplink: " + uplink.toString());
+        willUplink.countDown();
+      }
+
+      @Override
+      public void didUplink(WarpUplink uplink) {
+        System.out.println(nodeUri() + " didUplink: " + uplink.toString());
+        //assertEquals(willUplink.getCount(), 1);
+        didUplink.countDown();
+      }
+
+    }
+
+  }
+
   static class TestCommandPlane extends AbstractPlane {
 
     @SwimRoute("/command/:name")
     AgentRoute<TestCommandLaneAgent> commandAgent;
+
+    @SwimRoute("/commandLatched/:name")
+    AgentRoute<TestLatchedCommandLaneAgent> latchedCommandAgent;
 
   }
 

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinMapLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinMapLaneSpec.java
@@ -214,7 +214,7 @@ public class JoinMapLaneSpec {
               .laneUri("map")
               .open();
 
-      final MapDownlink<String, String> join = plane.downlinkMap()
+      plane.downlinkMap()
               .keyClass(String.class)
               .valueClass(String.class)
               .hostUri("warp://localhost:53556/")
@@ -233,18 +233,14 @@ public class JoinMapLaneSpec {
       xs.put("x1", "b");
       didUpdateInitialX0.await(2, TimeUnit.SECONDS);
       didUpdateInitialX1.await(2, TimeUnit.SECONDS);
-      assertEquals(willUpdateInitialX0.getCount(), 1);
       assertEquals(didUpdateInitialX0.getCount(), 0);
-      assertEquals(willUpdateInitialX1.getCount(), 1);
       assertEquals(didUpdateInitialX1.getCount(), 0);
 
       xs.put("x0", "aa");
       xs.put("x1", "bb");
       didUpdateX0.await(2, TimeUnit.SECONDS);
       didUpdateX1.await(2, TimeUnit.SECONDS);
-      assertEquals(willUpdateX0.getCount(), 1);
       assertEquals(didUpdateX0.getCount(), 0);
-      assertEquals(willUpdateX1.getCount(), 1);
       assertEquals(didUpdateX1.getCount(), 0);
 
       xs.remove("x0");
@@ -367,19 +363,15 @@ public class JoinMapLaneSpec {
       public void didUpdate(String key, String newValue, String oldValue) {
         System.out.println(nodeUri() + " didUpdate key: " + Format.debug(key) + "; newValue: " + Format.debug(newValue) + "; oldValue: " + Format.debug(oldValue));
         if ("x0".equals(key) && "a".equals(newValue) && "".equals(oldValue)) {
-          assertEquals(willUpdateInitialX0.getCount(), 1);
           didUpdateInitialX0.countDown();
         }
         if ("x1".equals(key) && "b".equals(newValue) && "".equals(oldValue)) {
-          assertEquals(willUpdateInitialX1.getCount(), 1);
           didUpdateInitialX1.countDown();
         }
         if ("x0".equals(key) && "aa".equals(newValue) && "a".equals(oldValue)) {
-          assertEquals(willUpdateX0.getCount(), 1);
           didUpdateX0.countDown();
         }
         if ("x1".equals(key) && "bb".equals(newValue) && "b".equals(oldValue)) {
-          assertEquals(willUpdateX1.getCount(),1);
           didUpdateX1.countDown();
         }
       }

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinMapLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinMapLaneSpec.java
@@ -179,23 +179,23 @@ public class JoinMapLaneSpec {
     }
   }
 
-  private final static CountDownLatch willDownlinkXs = new CountDownLatch(2);
-  private final static CountDownLatch didDownlinkXs = new CountDownLatch(1);
-  private final static CountDownLatch willDownlinkYs = new CountDownLatch(2);
-  private final static CountDownLatch didDownlinkYs = new CountDownLatch(1);
+  private static CountDownLatch willDownlinkXs = new CountDownLatch(2);
+  private static CountDownLatch didDownlinkXs = new CountDownLatch(1);
+  private static CountDownLatch willDownlinkYs = new CountDownLatch(2);
+  private static CountDownLatch didDownlinkYs = new CountDownLatch(1);
 
-  private final static CountDownLatch willUpdateInitialX0 = new CountDownLatch(2);
-  private final static CountDownLatch didUpdateInitialX0 = new CountDownLatch(1);
-  private final static CountDownLatch willUpdateInitialX1 = new CountDownLatch(2);
-  private final static CountDownLatch didUpdateInitialX1 = new CountDownLatch(1);
+  private static CountDownLatch willUpdateInitialX0 = new CountDownLatch(2);
+  private static CountDownLatch didUpdateInitialX0 = new CountDownLatch(1);
+  private static CountDownLatch willUpdateInitialX1 = new CountDownLatch(2);
+  private static CountDownLatch didUpdateInitialX1 = new CountDownLatch(1);
 
-  private final static CountDownLatch willUpdateX0 = new CountDownLatch(2);
-  private final static CountDownLatch didUpdateX0 = new CountDownLatch(1);
-  private final static CountDownLatch willUpdateX1 = new CountDownLatch(2);
-  private final static CountDownLatch didUpdateX1 = new CountDownLatch(1);
+  private static CountDownLatch willUpdateX0 = new CountDownLatch(2);
+  private static CountDownLatch didUpdateX0 = new CountDownLatch(1);
+  private static CountDownLatch willUpdateX1 = new CountDownLatch(2);
+  private static CountDownLatch didUpdateX1 = new CountDownLatch(1);
 
-  private final static CountDownLatch willRemoveX0 = new CountDownLatch(2);
-  private final static CountDownLatch didRemoveX0 = new CountDownLatch(1);
+  private static CountDownLatch willRemoveX0 = new CountDownLatch(2);
+  private static CountDownLatch didRemoveX0 = new CountDownLatch(1);
 
   @Test
   public void testJoinMapLaneCallback() throws InterruptedException {
@@ -222,8 +222,8 @@ public class JoinMapLaneSpec {
               .laneUri("join")
               .open();
 
-      didDownlinkXs.await(2,TimeUnit.SECONDS);
-      didDownlinkYs.await(2,TimeUnit.SECONDS);
+      didDownlinkXs.await(2, TimeUnit.SECONDS);
+      didDownlinkYs.await(2, TimeUnit.SECONDS);
       assertEquals(willDownlinkXs.getCount(), 1);
       assertEquals(didDownlinkXs.getCount(), 0);
       assertEquals(willDownlinkYs.getCount(), 1);

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinValueLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/JoinValueLaneSpec.java
@@ -76,8 +76,10 @@ public class JoinValueLaneSpec {
       @Override
       public void didUpdate(String key, String newValue, String oldValue) {
         System.out.println("join link didUpdate key: " + Format.debug(key) + "; newValue: " + Format.debug(newValue) + "; oldValue: " + Format.debug(oldValue));
-        didUpdate[0] += 1;
-        joinDidUpdate.countDown();
+        if ("".equals(oldValue) && ("x0".equals(newValue) || "y0".equals(newValue))) {
+          didUpdate[0] += 1;
+          joinDidUpdate.countDown();
+        }
       }
 
       @Override
@@ -154,11 +156,10 @@ public class JoinValueLaneSpec {
           .laneUri("value")
           .open();
       final CountDownLatch valueDownlinkLatch = new CountDownLatch(4);
-      x.set("x0");
-      y.set("y0");
       x.didSet((newValue, oldValue) -> valueDownlinkLatch.countDown());
       y.didSet((newValue, oldValue) -> valueDownlinkLatch.countDown());
-
+      x.set("x0");
+      y.set("y0");
       valueDownlinkLatch.await(2, TimeUnit.SECONDS);
       final MapDownlink<String, String> join = plane.downlinkMap()
           .keyClass(String.class)

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/MapLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/MapLaneSpec.java
@@ -72,8 +72,8 @@ public class MapLaneSpec {
     laneWillUpdate = new CountDownLatch(3);
     laneDidUpdate = new CountDownLatch(2);
 
-    CountDownLatch linkDidSync = new CountDownLatch(1);
-    CountDownLatch linkDidUpdate = new CountDownLatch(4);
+    final CountDownLatch linkDidSync = new CountDownLatch(1);
+    final CountDownLatch linkDidUpdate = new CountDownLatch(4);
     try {
       kernel.openService(WebServiceDef.standard().port(53556).spaceName("test"));
       kernel.start();

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/TraitSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/TraitSpec.java
@@ -174,6 +174,7 @@ public class TraitSpec {
     final CountDownLatch infoDidReceive = new CountDownLatch(1);
     final CountDownLatch infoDidSet = new CountDownLatch(1);
     final CountDownLatch valueDidSet = new CountDownLatch(1);
+    final CountDownLatch didSync = new CountDownLatch(1);
     class InfoLinkController implements WillSet<String>, DidSet<String>,
         WillReceive, DidReceive, WillLink, DidLink, WillSync, DidSync,
         WillUnlink, DidUnlink, DidConnect, DidDisconnect, DidClose {
@@ -225,6 +226,7 @@ public class TraitSpec {
       @Override
       public void didSync() {
         System.out.println("link didSync");
+        didSync.countDown();
       }
 
       @Override
@@ -264,6 +266,7 @@ public class TraitSpec {
           .laneUri("info")
           .observe(new InfoLinkController())
           .open();
+      didSync.await(2, TimeUnit.SECONDS);
       infoLink.set(testValue);
       valueDidSet.await(1, TimeUnit.SECONDS);
       infoDidReceive.await(1, TimeUnit.SECONDS);

--- a/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/ValueLaneSpec.java
+++ b/swim-java/swim-runtime-java/swim-host-java/swim.server/src/test/java/swim/server/ValueLaneSpec.java
@@ -258,7 +258,7 @@ public class ValueLaneSpec {
   private static CountDownLatch didSet;
   private static CountDownLatch didCommand;
 
-  private static void resetLatches(){
+  private static void resetLatches() {
     willUplink = new CountDownLatch(2);
     didUplink = new CountDownLatch(2);
     willCommand = new CountDownLatch(2);


### PR DESCRIPTION
Fixed intermittently failing test
Added tests

Noticed the following:
- didConnect callback is called twice
- EventDownlinks have willCommand but not onCommand/didCommand?
- willUplink and willLink do not get called
- _Map lanes will/didUpdate very sporadically get called with (oldValue, oldValue) instead of newValue_  - Race condition when using link to update same key twice in quick succession, the first update can override the second.