### PR TITLE
Adds support for custom routers.

### DIFF
--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServiceDef.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServiceDef.java
@@ -29,18 +29,20 @@ public class WebServiceDef implements ServiceDef, Debug {
   final int port;
   final boolean isSecure;
   final String spaceName;
+  final String routerClass;
   final UriPath documentRoot;
   final UriPath resourceRoot;
   final WarpSettings warpSettings;
 
   public WebServiceDef(String serviceName, String address, int port, boolean isSecure,
-                       String spaceName, UriPath documentRoot, UriPath resourceRoot,
-                       WarpSettings warpSettings) {
+                       String spaceName, String routerClass, UriPath documentRoot,
+                       UriPath resourceRoot, WarpSettings warpSettings) {
     this.serviceName = serviceName;
     this.address = address;
     this.port = port;
     this.isSecure = isSecure;
     this.spaceName = spaceName;
+    this.routerClass = routerClass;
     this.documentRoot = documentRoot;
     this.resourceRoot = resourceRoot;
     this.warpSettings = warpSettings;
@@ -53,7 +55,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef serviceName(String serviceName) {
     return this.copy(serviceName, this.address, this.port, this.isSecure,
-                     this.spaceName, this.documentRoot, this.resourceRoot, this.warpSettings);
+                     this.spaceName, this.routerClass, this.documentRoot, this.resourceRoot, this.warpSettings);
   }
 
   public final String address() {
@@ -62,7 +64,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef address(String address) {
     return this.copy(this.serviceName, address, this.port, this.isSecure,
-                     this.spaceName, this.documentRoot, this.resourceRoot, this.warpSettings);
+                     this.spaceName, this.routerClass, this.documentRoot, this.resourceRoot, this.warpSettings);
   }
 
   public final int port() {
@@ -71,7 +73,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef port(int port) {
     return this.copy(this.serviceName, this.address, port, this.isSecure,
-                     this.spaceName, this.documentRoot, this.resourceRoot, this.warpSettings);
+                     this.spaceName, this.routerClass, this.documentRoot, this.resourceRoot, this.warpSettings);
   }
 
   public final String spaceName() {
@@ -80,7 +82,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef spaceName(String spaceName) {
     return this.copy(this.serviceName, this.address, this.port, this.isSecure,
-                     spaceName, this.documentRoot, this.resourceRoot, this.warpSettings);
+                     spaceName, this.routerClass, this.documentRoot, this.resourceRoot, this.warpSettings);
   }
 
   public final UriPath documentRoot() {
@@ -89,7 +91,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef documentRoot(UriPath documentRoot) {
     return this.copy(this.serviceName, this.address, this.port, this.isSecure,
-                     this.spaceName, documentRoot, this.resourceRoot, this.warpSettings);
+                     this.spaceName, this.routerClass, documentRoot, this.resourceRoot, this.warpSettings);
   }
 
   public final UriPath resourceRoot() {
@@ -98,7 +100,7 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef resourceRoot(UriPath resourceRoot) {
     return this.copy(this.serviceName, this.address, this.port, this.isSecure,
-                     this.spaceName, this.documentRoot, resourceRoot, this.warpSettings);
+                     this.spaceName, this.routerClass, this.documentRoot, resourceRoot, this.warpSettings);
   }
 
   public final WarpSettings warpSettings() {
@@ -107,13 +109,13 @@ public class WebServiceDef implements ServiceDef, Debug {
 
   public WebServiceDef warpSettings(WarpSettings warpSettings) {
     return this.copy(this.serviceName, this.address, this.port, this.isSecure,
-                     this.spaceName, this.documentRoot, this.resourceRoot, warpSettings);
+                     this.spaceName, this.routerClass, this.documentRoot, this.resourceRoot, warpSettings);
   }
 
   protected WebServiceDef copy(String serviceName, String address, int port, boolean isSecure,
-                               String spaceName, UriPath documentRoot, UriPath resourceRoot,
+                               String spaceName, String routerClass, UriPath documentRoot, UriPath resourceRoot,
                                WarpSettings warpSettings) {
-    return new WebServiceDef(serviceName, address, port, isSecure, spaceName,
+    return new WebServiceDef(serviceName, address, port, isSecure, spaceName, routerClass,
                              documentRoot, resourceRoot, warpSettings);
   }
 
@@ -126,6 +128,7 @@ public class WebServiceDef implements ServiceDef, Debug {
       return (this.serviceName == null ? that.serviceName == null : this.serviceName.equals(that.serviceName))
           && this.address.equals(that.address) && this.port == that.port && this.isSecure == that.isSecure
           && (this.spaceName == null ? that.spaceName == null : this.spaceName.equals(that.spaceName))
+          && (this.routerClass == null ? that.routerClass == null : this.routerClass.equals(that.routerClass))
           && (this.documentRoot == null ? that.documentRoot == null : this.documentRoot.equals(that.documentRoot))
           && (this.resourceRoot == null ? that.resourceRoot == null : this.resourceRoot.equals(that.resourceRoot))
           && this.warpSettings.equals(that.warpSettings);
@@ -140,11 +143,11 @@ public class WebServiceDef implements ServiceDef, Debug {
     if (WebServiceDef.hashSeed == 0) {
       WebServiceDef.hashSeed = Murmur3.seed(WebServiceDef.class);
     }
-    return Murmur3.mash(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(
+    return Murmur3.mash(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(Murmur3.mix(
         Murmur3.mix(Murmur3.mix(WebServiceDef.hashSeed, Murmur3.hash(this.serviceName)),
         this.address.hashCode()), this.port), Murmur3.hash(this.isSecure)),
-        Murmur3.hash(this.spaceName)), Murmur3.hash(this.documentRoot)),
-        Murmur3.hash(this.resourceRoot)), this.warpSettings.hashCode()));
+        Murmur3.hash(this.spaceName)), Murmur3.hash(this.routerClass)),
+        Murmur3.hash(this.documentRoot)), Murmur3.hash(this.resourceRoot)), this.warpSettings.hashCode()));
   }
 
   @Override
@@ -162,6 +165,9 @@ public class WebServiceDef implements ServiceDef, Debug {
     }
     if (this.spaceName != null) {
       output = output.write('.').write("spaceName").write('(').debug(this.spaceName).write(')');
+    }
+    if (this.routerClass != null) {
+      output = output.write('.').write("routerClass").write('(').debug(this.routerClass).write(')');
     }
     if (this.documentRoot != null) {
       output = output.write('.').write("documentRoot").write('(').debug(this.documentRoot).write(')');
@@ -181,11 +187,11 @@ public class WebServiceDef implements ServiceDef, Debug {
   }
 
   public static WebServiceDef standard() {
-    return new WebServiceDef("web", "0.0.0.0", 80, false, null, null, null, WarpSettings.standard());
+    return new WebServiceDef("web", "0.0.0.0", 80, false, null, null, null, null, WarpSettings.standard());
   }
 
   public static WebServiceDef secure() {
-    return new WebServiceDef("web", "0.0.0.0", 443, true, null, null, null, WarpSettings.standard());
+    return new WebServiceDef("web", "0.0.0.0", 443, true, null, null, null, null, WarpSettings.standard());
   }
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServiceKernel.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServiceKernel.java
@@ -70,10 +70,19 @@ public class WebServiceKernel extends KernelProxy {
         if (spaceName == null) {
           spaceName = value.get("plane").stringValue(null); // deprecated
         }
+
+        String routerClass = null;
+        for (int i = 0, n = value.length(); i < n; i += 1) {
+          final Value router = value.getItem(i).getAttr("router");
+          if (router.isDefined()) {
+            routerClass = router.get("class").stringValue(null);
+          }
+        }
+
         final UriPath documentRoot = value.get("documentRoot").cast(UriPath.pathForm());
         final UriPath resourceRoot = value.get("resourceRoot").cast(UriPath.pathForm());
         final WarpSettings warpSettings = WarpSettings.form().cast(value);
-        return new WebServiceDef(serviceName, address, port, isSecure, spaceName,
+        return new WebServiceDef(serviceName, address, port, isSecure, spaceName, routerClass,
                                  documentRoot, resourceRoot, warpSettings);
       }
     }
@@ -96,7 +105,16 @@ public class WebServiceKernel extends KernelProxy {
   }
 
   protected WebRoute createWebRouter(WebServiceDef serviceDef) {
-    return new RejectRoute(); // TODO: parse from config
+    if (serviceDef.routerClass != null) {
+      try {
+        final Class<? extends WebRoute> webRouteClass = (Class<? extends WebRoute>) Class.forName(serviceDef.routerClass);
+        return webRouteClass.getDeclaredConstructor().newInstance();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      return new RejectRoute();
+    }
   }
 
   private static final double KERNEL_PRIORITY = 0.75;

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/test/java/swim/service/web/WebServerSpec.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/test/java/swim/service/web/WebServerSpec.java
@@ -39,7 +39,7 @@ public class WebServerSpec {
   @Test
   public void testExtensions() {
     final WsSettings wsSettings = WsSettings.bestCompression();
-    final WebServiceDef serviceDef = new WebServiceDef("web", "0.0.0.0", 80, false, null, null, null, WarpSettings.create(wsSettings));
+    final WebServiceDef serviceDef = new WebServiceDef("web", "0.0.0.0", 80, false, null, null, null, null, WarpSettings.create(wsSettings));
     final WebServer server = new WebServer(new WebServiceKernel(), serviceDef, request -> request.respond(HttpResponse.create(HttpStatus.OK))) {
       @Override
       protected RemoteHost openHost(Uri requestUri) {


### PR DESCRIPTION
The changes in this PR allow for easier creation and registration for custom routers.

Example:

`CustomRouter.java`
```java
package swim.example;

import swim.http.*;
import swim.uri.Uri;
import swim.web.WebRequest;
import swim.web.WebResponse;
import swim.web.WebRoute;

public class CustomRouter implements WebRoute {

  public CustomRouter() {}

  @Override
  public WebResponse routeRequest(WebRequest request) {
    if (request.httpUri().equals(Uri.parse("/authorised"))) {
      //Add your custom response here
      return request.respond(HttpResponse.create(HttpStatus.OK));
    } else {
      // Everything that is rejected by this router will go to the alternate router
      return request.reject();
    }
  }
}
```

`server.recon`
```
...

@web(port: 9001) {
  space: "example"
  documentRoot: "./ui/"

  # Specify the class for the custom router from above  
  @router(class: "swim.example.CustomRouter")
}

...
```