### PR TITLE
Cookie authentication

### DIFF
--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/Cookie.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/Cookie.java
@@ -60,12 +60,12 @@ public class Cookie extends HttpPart implements Debug {
 
   @Override
   public Writer<?, ?> httpWriter(HttpWriter http) {
-    return new ParamWriter(http, this.name, this.value);
+    return new CookieWriter(http, this.name, this.value);
   }
 
   @Override
   public Writer<?, ?> writeHttp(Output<?> output, HttpWriter http) {
-    return ParamWriter.write(output, http, this.name, this.value);
+    return CookieWriter.write(output, http, this.name, this.value);
   }
 
   public static Cookie create(String name, String value) {

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/Cookie.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/Cookie.java
@@ -1,0 +1,83 @@
+package swim.http;
+
+import swim.codec.Debug;
+import swim.codec.Output;
+import swim.codec.Writer;
+import swim.util.Murmur3;
+
+public class Cookie extends HttpPart implements Debug {
+
+  final String name;
+  final String value;
+
+  Cookie(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getValue() {
+    return this.value;
+  }
+
+  @Override
+  public <T> Output<T> debug(Output<T> output) {
+    output = output.write("Cookie").write('.').write("create").write('(').debug(this.name);
+
+    if (this.value != null) {
+      output = output.write(", ").debug(this.value);
+    }
+
+    output = output.write(')');
+
+    return output;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other instanceof Cookie) {
+      final Cookie that = (Cookie) other;
+      return this.name.equals(that.name) && this.value.equals(that.value);
+    }
+    return false;
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public int hashCode() {
+    if (Cookie.hashSeed == 0) {
+      Cookie.hashSeed = Murmur3.seed(Cookie.class);
+    }
+    return Murmur3.mash(Murmur3.mix(Murmur3.mix(Cookie.hashSeed,
+         this.name.hashCode()), this.value.hashCode()));
+  }
+
+  @Override
+  public Writer<?, ?> httpWriter(HttpWriter http) {
+    return new ParamWriter(http, this.name, this.value);
+  }
+
+  @Override
+  public Writer<?, ?> writeHttp(Output<?> output, HttpWriter http) {
+    return ParamWriter.write(output, http, this.name, this.value);
+  }
+
+  public static Cookie create(String name, String value) {
+    return new Cookie(name, value);
+  }
+
+  public static Cookie create(String name) {
+    return new Cookie(name, "");
+  }
+
+  public static Cookie parse(String string) {
+    return Http.standardParser().parseCookieString(string);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieParser.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieParser.java
@@ -75,36 +75,20 @@ final class CookieParser extends Parser<Cookie> {
       }
       if (!input.isEmpty()) {
         step = 3;
-      } else if (input.isDone()) {
+      } else if (input.isDone() || !Http.isVisibleChar(c)) {
         return Parser.done(http.cookie(nameBuilder.toString(), ""));
       }
     }
     if (step == 3) {
       if (input.isCont() && c == '=') {
         input = input.step();
+        valueBuilder = new StringBuilder();
         step = 4;
-      } else if (!input.isEmpty()) {
+      } else if (!input.isEmpty() || !Http.isVisibleChar(c)) {
         return Parser.done(http.cookie(nameBuilder.toString(), ""));
       }
     }
     if (step == 4) {
-      if (input.isCont()) {
-        c = input.head();
-        if (Http.isVisibleChar(c) && c != '=' && c != ';') {
-          input = input.step();
-          if (valueBuilder == null) {
-            valueBuilder = new StringBuilder();
-          }
-          valueBuilder.appendCodePoint(c);
-          step = 5;
-        } else {
-          return Parser.error(Diagnostic.expected("cookie value", input));
-        }
-      } else if (input.isDone()) {
-        return Parser.error(Diagnostic.expected("cookie value", input));
-      }
-    }
-    if (step == 5) {
       while (input.isCont()) {
         c = input.head();
         if (Http.isVisibleChar(c) && c != '=' && c != ';') {
@@ -115,7 +99,7 @@ final class CookieParser extends Parser<Cookie> {
         }
       }
 
-      if (input.isDone() || c == ';') {
+      if (input.isDone() || c == ';' || !Http.isVisibleChar(c)) {
         return Parser.done(http.cookie(nameBuilder.toString(), valueBuilder.toString()));
       }
     }

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieParser.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieParser.java
@@ -1,0 +1,130 @@
+// Copyright 2015-2022 Swim.inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.http;
+
+import swim.codec.Diagnostic;
+import swim.codec.Input;
+import swim.codec.Parser;
+
+final class CookieParser extends Parser<Cookie> {
+
+  final HttpParser http;
+  final StringBuilder nameBuilder;
+  final StringBuilder valueBuilder;
+  final int step;
+
+  CookieParser(HttpParser http, StringBuilder nameBuilder,
+               StringBuilder valueBuilder, int step) {
+    this.http = http;
+    this.nameBuilder = nameBuilder;
+    this.valueBuilder = valueBuilder;
+    this.step = step;
+  }
+
+  CookieParser(HttpParser http) {
+    this(http, null, null, 1);
+  }
+
+  @Override
+  public Parser<Cookie> feed(Input input) {
+    return CookieParser.parse(input, this.http, this.nameBuilder,
+         this.valueBuilder, this.step);
+  }
+
+  static Parser<Cookie> parse(Input input, HttpParser http, StringBuilder nameBuilder,
+                              StringBuilder valueBuilder, int step) {
+    int c = 0;
+    if (step == 1) {
+      if (input.isCont()) {
+        c = input.head();
+        if (Http.isVisibleChar(c) && c != '=' && c != ';') {
+          input = input.step();
+          if (nameBuilder == null) {
+            nameBuilder = new StringBuilder();
+          }
+          nameBuilder.appendCodePoint(c);
+          step = 2;
+        } else {
+          return Parser.error(Diagnostic.expected("cookie name", input));
+        }
+      } else if (input.isDone()) {
+        return Parser.error(Diagnostic.expected("cookie name", input));
+      }
+    }
+    if (step == 2) {
+      while (input.isCont()) {
+        c = input.head();
+        if (Http.isVisibleChar(c) && c != '=' && c != ';') {
+          input = input.step();
+          nameBuilder.appendCodePoint(c);
+        } else {
+          break;
+        }
+      }
+      if (!input.isEmpty()) {
+        step = 3;
+      } else if (input.isDone()) {
+        return Parser.done(http.cookie(nameBuilder.toString(), ""));
+      }
+    }
+    if (step == 3) {
+      if (input.isCont() && c == '=') {
+        input = input.step();
+        step = 4;
+      } else if (!input.isEmpty()) {
+        return Parser.done(http.cookie(nameBuilder.toString(), ""));
+      }
+    }
+    if (step == 4) {
+      if (input.isCont()) {
+        c = input.head();
+        if (Http.isVisibleChar(c) && c != '=' && c != ';') {
+          input = input.step();
+          if (valueBuilder == null) {
+            valueBuilder = new StringBuilder();
+          }
+          valueBuilder.appendCodePoint(c);
+          step = 5;
+        } else {
+          return Parser.error(Diagnostic.expected("cookie value", input));
+        }
+      } else if (input.isDone()) {
+        return Parser.error(Diagnostic.expected("cookie value", input));
+      }
+    }
+    if (step == 5) {
+      while (input.isCont()) {
+        c = input.head();
+        if (Http.isVisibleChar(c) && c != '=' && c != ';') {
+          input = input.step();
+          valueBuilder.appendCodePoint(c);
+        } else {
+          break;
+        }
+      }
+
+      if (input.isDone() || c == ';') {
+        return Parser.done(http.cookie(nameBuilder.toString(), valueBuilder.toString()));
+      }
+    }
+
+    return new CookieParser(http, nameBuilder, valueBuilder, step);
+  }
+
+  static Parser<Cookie> parse(Input input, HttpParser http) {
+    return CookieParser.parse(input, http, null, null, 1);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieWriter.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/CookieWriter.java
@@ -1,0 +1,93 @@
+// Copyright 2015-2022 Swim.inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.http;
+
+import swim.codec.Output;
+import swim.codec.Writer;
+import swim.codec.WriterException;
+
+final class CookieWriter extends Writer<Object, Object> {
+
+  final HttpWriter http;
+  final String name;
+  final String value;
+  final Writer<?, ?> part;
+  final int step;
+
+  CookieWriter(HttpWriter http, String name, String value, Writer<?, ?> part, int step) {
+    this.http = http;
+    this.name = name;
+    this.value = value;
+    this.part = part;
+    this.step = step;
+  }
+
+  CookieWriter(HttpWriter http, String name, String value) {
+    this(http, name, value, null, 1);
+  }
+
+  @Override
+  public Writer<Object, Object> pull(Output<?> output) {
+    return CookieWriter.write(output, this.http, this.name, this.value, this.part, this.step);
+  }
+
+  static Writer<Object, Object> write(Output<?> output, HttpWriter http, String name,
+                                      String value, Writer<?, ?> part, int step) {
+    if (step == 1) {
+      if (part == null) {
+        part = http.writeToken(output, name);
+      } else {
+        part = part.pull(output);
+      }
+      if (part.isDone()) {
+        part = null;
+        step = 2;
+      } else if (part.isError()) {
+        return part.asError();
+      }
+    }
+    if (step == 2 && output.isCont()) {
+      output = output.write('=');
+      if (value.isEmpty()) {
+        return Writer.done();
+      } else {
+        step = 3;
+      }
+    }
+    if (step == 3) {
+      if (part == null) {
+        part = http.writeValue(output, value);
+      } else {
+        part = part.pull(output);
+      }
+      if (part.isDone()) {
+        return Writer.done();
+      } else if (part.isError()) {
+        return part.asError();
+      }
+    }
+    if (output.isDone()) {
+      return Writer.error(new WriterException("truncated"));
+    } else if (output.isError()) {
+      return Writer.error(output.trap());
+    }
+    return new CookieWriter(http, name, value, part, step);
+  }
+
+  static Writer<Object, Object> write(Output<?> output, HttpWriter http, String name, String value) {
+    return CookieWriter.write(output, http, name, value, null, 1);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/HttpWriter.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/HttpWriter.java
@@ -249,7 +249,11 @@ public class HttpWriter {
   }
 
   public Writer<?, ?> writeParamList(Output<?> output, Iterator<? extends HttpPart> params) {
-    return ParamListWriter.write(output, this, params);
+    return ParamListWriter.write(output, this, params, ',');
+  }
+
+  public Writer<?, ?> writeParamListWithSeparator(Output<?> output, Iterator<? extends HttpPart> params, char separator) {
+    return ParamListWriter.write(output, this, params, separator);
   }
 
   public Writer<?, ?> writeParamMap(Output<?> output, Iterator<? extends Map.Entry<?, ?>> params) {

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/ParamListWriter.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/ParamListWriter.java
@@ -25,27 +25,29 @@ final class ParamListWriter extends Writer<Object, Object> {
   final Iterator<? extends HttpPart> params;
   final Writer<?, ?> paramWriter;
   final int step;
+  final char separator;
 
-  ParamListWriter(HttpWriter http, Iterator<? extends HttpPart> params,
+  ParamListWriter(HttpWriter http, Iterator<? extends HttpPart> params, char separator,
                   Writer<?, ?> paramWriter, int step) {
     this.http = http;
     this.params = params;
     this.paramWriter = paramWriter;
     this.step = step;
+    this.separator = separator;
   }
 
-  ParamListWriter(HttpWriter http, Iterator<? extends HttpPart> params) {
-    this(http, params, null, 1);
+  ParamListWriter(HttpWriter http, Iterator<? extends HttpPart> params, char separator) {
+    this(http, params, separator, null, 1);
   }
 
   @Override
   public Writer<Object, Object> pull(Output<?> output) {
-    return ParamListWriter.write(output, this.http, this.params,
-                                 this.paramWriter, this.step);
+    return ParamListWriter.write(output, this.http, this.params, this.separator,
+         this.paramWriter, this.step);
   }
 
   static Writer<Object, Object> write(Output<?> output, HttpWriter http,
-                                      Iterator<? extends HttpPart> params,
+                                      Iterator<? extends HttpPart> params, char separator,
                                       Writer<?, ?> paramWriter, int step) {
     do {
       if (step == 1) {
@@ -70,7 +72,7 @@ final class ParamListWriter extends Writer<Object, Object> {
         }
       }
       if (step == 2 && output.isCont()) {
-        output = output.write(',');
+        output = output.write(separator);
         step = 3;
       }
       if (step == 3 && output.isCont()) {
@@ -85,12 +87,12 @@ final class ParamListWriter extends Writer<Object, Object> {
     } else if (output.isError()) {
       return Writer.error(output.trap());
     }
-    return new ParamListWriter(http, params, paramWriter, step);
+    return new ParamListWriter(http, params, separator, paramWriter, step);
   }
 
   static Writer<Object, Object> write(Output<?> output, HttpWriter http,
-                                      Iterator<? extends HttpPart> params) {
-    return ParamListWriter.write(output, http, params, null, 1);
+                                      Iterator<? extends HttpPart> params, char separator) {
+    return ParamListWriter.write(output, http, params, separator, null, 1);
   }
 
 }

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/CookieHeader.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/CookieHeader.java
@@ -1,0 +1,106 @@
+package swim.http.header;
+
+import swim.codec.Input;
+import swim.codec.Output;
+import swim.codec.Parser;
+import swim.codec.Writer;
+import swim.collections.FingerTrieSeq;
+import swim.http.Cookie;
+import swim.http.HttpHeader;
+import swim.http.HttpParser;
+import swim.http.HttpWriter;
+import swim.util.Builder;
+import swim.util.Murmur3;
+
+public class CookieHeader extends HttpHeader {
+
+  final FingerTrieSeq<Cookie> cookies;
+
+  CookieHeader(FingerTrieSeq<Cookie> cookies) {
+    this.cookies = cookies;
+  }
+
+  @Override
+  public boolean isBlank() {
+    return this.cookies.isEmpty();
+  }
+
+  @Override
+  public String lowerCaseName() {
+    return "cookie";
+  }
+
+  @Override
+  public String name() {
+    return "Cookie";
+  }
+
+  public FingerTrieSeq<Cookie> cookies() {
+    return this.cookies;
+  }
+
+  @Override
+  public Writer<?, ?> writeHeaderValue(Output<?> output, HttpWriter http) {
+    return http.writeParamListWithSeparator(output, this.cookies.iterator(), ';');
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other instanceof CookieHeader) {
+      final CookieHeader that = (CookieHeader) other;
+      return this.cookies.equals(that.cookies);
+    }
+    return false;
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public int hashCode() {
+    if (CookieHeader.hashSeed == 0) {
+      CookieHeader.hashSeed = Murmur3.seed(CookieHeader.class);
+    }
+    return Murmur3.mash(Murmur3.mix(CookieHeader.hashSeed, this.cookies.hashCode()));
+  }
+
+  @Override
+  public <T> Output<T> debug(Output<T> output) {
+    output = output.write("CookieHeader").write('.').write("create").write('(');
+    final int n = this.cookies.size();
+    if (n > 0) {
+      output = output.debug(this.cookies.head());
+      for (int i = 1; i < n; i += 1) {
+        output = output.write(", ").debug(this.cookies.get(i));
+      }
+    }
+    output = output.write(')');
+    return output;
+  }
+
+  public static CookieHeader empty() {
+    return new CookieHeader(FingerTrieSeq.empty());
+  }
+
+  public static CookieHeader create(FingerTrieSeq<Cookie> cookies) {
+    return new CookieHeader(cookies);
+  }
+
+  public static CookieHeader create(Cookie... cookies) {
+    return new CookieHeader(FingerTrieSeq.of(cookies));
+  }
+
+  public static CookieHeader create(String... cookiesString) {
+    final Builder<Cookie, FingerTrieSeq<Cookie>> cookies = FingerTrieSeq.builder();
+    for (int i = 0, n = cookiesString.length; i < n; i += 1) {
+      cookies.add(Cookie.parse(cookiesString[i]));
+    }
+    return new CookieHeader(cookies.bind());
+  }
+
+  public static Parser<CookieHeader> parseHeaderValue(Input input, HttpParser http) {
+    return CookieHeaderParser.parse(input, http);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/CookieHeaderParser.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/CookieHeaderParser.java
@@ -1,0 +1,106 @@
+package swim.http.header;
+
+import swim.codec.Input;
+import swim.codec.Parser;
+import swim.collections.FingerTrieSeq;
+import swim.http.Cookie;
+import swim.http.Http;
+import swim.http.HttpParser;
+import swim.util.Builder;
+
+public class CookieHeaderParser extends Parser<CookieHeader> {
+
+  final HttpParser http;
+  final Parser<Cookie> cookiesParser;
+  final Builder<Cookie, FingerTrieSeq<Cookie>> cookies;
+  final int step;
+
+  CookieHeaderParser(HttpParser http, Parser<Cookie> cookiesParser,
+                     Builder<Cookie, FingerTrieSeq<Cookie>> cookies, int step) {
+    this.http = http;
+    this.cookiesParser = cookiesParser;
+    this.cookies = cookies;
+    this.step = step;
+  }
+
+  CookieHeaderParser(HttpParser http) {
+    this(http, null, null, 1);
+  }
+
+  @Override
+  public Parser<CookieHeader> feed(Input input) {
+    return CookieHeaderParser.parse(input, this.http, this.cookiesParser, this.cookies, this.step);
+  }
+
+  static Parser<CookieHeader> parse(Input input, HttpParser http, Parser<Cookie> cookieParser,
+                                    Builder<Cookie, FingerTrieSeq<Cookie>> cookies, int step) {
+
+
+    int c = 0;
+    if (step == 1) {
+      if (cookieParser == null) {
+        cookieParser = http.parseCookie(input);
+      } else {
+        cookieParser = cookieParser.feed(input);
+      }
+      if (cookieParser.isDone()) {
+        if (cookies == null) {
+          cookies = FingerTrieSeq.builder();
+        }
+        cookies.add(cookieParser.bind());
+        cookieParser = null;
+        step = 2;
+      } else if (cookieParser.isError()) {
+        return cookieParser.asError();
+      }
+    }
+    do {
+      if (step == 2) {
+        if (input.isCont()) {
+          c = input.head();
+          if (c == ';') {
+            input = input.step();
+          }
+        }
+        while (input.isCont()) {
+          c = input.head();
+          if (Http.isSpace(c)) {
+            input = input.step();
+          } else {
+            break;
+          }
+        }
+        if (input.isCont() && Http.isVisibleChar(c)) {
+          step = 3;
+        } else if (!input.isEmpty()) {
+          return Parser.done(CookieHeader.create(cookies.bind()));
+        }
+      }
+      if (step == 3) {
+        if (cookieParser == null) {
+          cookieParser = http.parseCookie(input);
+        } else {
+          cookieParser = cookieParser.feed(input);
+        }
+        if (cookieParser.isDone()) {
+          cookies.add(cookieParser.bind());
+          cookieParser = null;
+          step = 2;
+          continue;
+        } else if (cookieParser.isError()) {
+          return cookieParser.asError();
+        }
+      }
+      break;
+    } while (true);
+    if (input.isError()) {
+      return Parser.error(input.trap());
+    }
+    return new CookieHeaderParser(http, cookieParser, cookies, step);
+  }
+
+  static Parser<CookieHeader> parse(Input input, HttpParser http) {
+    return CookieHeaderParser.parse(input, http, null, null, 1);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
@@ -1,0 +1,105 @@
+package swim.http.header;
+
+import swim.codec.Input;
+import swim.codec.Output;
+import swim.codec.Parser;
+import swim.codec.Writer;
+import swim.collections.FingerTrieSeq;
+import swim.http.Cookie;
+import swim.http.HttpHeader;
+import swim.http.HttpParser;
+import swim.http.HttpWriter;
+import swim.util.Builder;
+import swim.util.Murmur3;
+
+public class SetCookieHeader extends HttpHeader {
+
+  final FingerTrieSeq<Cookie> cookies;
+
+  SetCookieHeader(FingerTrieSeq<Cookie> cookies) {
+    this.cookies = cookies;
+  }
+
+  @Override
+  public boolean isBlank() {
+    return this.cookies.isEmpty();
+  }
+
+  @Override
+  public String lowerCaseName() {
+    return "set-cookie";
+  }
+
+  @Override
+  public String name() {
+    return "Set-Cookie";
+  }
+
+  public FingerTrieSeq<Cookie> cookies() {
+    return this.cookies;
+  }
+
+  @Override
+  public Writer<?, ?> writeHeaderValue(Output<?> output, HttpWriter http) {
+    return http.writeParamList(output, this.cookies.iterator());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other instanceof SetCookieHeader) {
+      final SetCookieHeader that = (SetCookieHeader) other;
+      return this.cookies.equals(that.cookies);
+    }
+    return false;
+  }
+
+  private static int hashSeed;
+
+  @Override
+  public int hashCode() {
+    if (SetCookieHeader.hashSeed == 0) {
+      SetCookieHeader.hashSeed = Murmur3.seed(SetCookieHeader.class);
+    }
+    return Murmur3.mash(Murmur3.mix(SetCookieHeader.hashSeed, this.cookies.hashCode()));
+  }
+
+  @Override
+  public <T> Output<T> debug(Output<T> output) {
+    output = output.write("SetCookieHeader").write('.').write("create").write('(');
+    final int n = this.cookies.size();
+    if (n > 0) {
+      output = output.debug(this.cookies.head());
+      for (int i = 1; i < n; i += 1) {
+        output = output.write(", ").debug(this.cookies.get(i));
+      }
+    }
+    output = output.write(')');
+    return output;
+  }
+
+  public static SetCookieHeader empty() {
+    return new SetCookieHeader(FingerTrieSeq.empty());
+  }
+
+  public static SetCookieHeader create(FingerTrieSeq<Cookie> cookies) {
+    return new SetCookieHeader(cookies);
+  }
+
+  public static SetCookieHeader create(Cookie... cookies) {
+    return new SetCookieHeader(FingerTrieSeq.of(cookies));
+  }
+
+  public static SetCookieHeader create(String... cookiesString) {
+    final Builder<Cookie, FingerTrieSeq<Cookie>> cookies = FingerTrieSeq.builder();
+    for (int i = 0, n = cookiesString.length; i < n; i += 1) {
+      cookies.add(Cookie.parse(cookiesString[i]));
+    }
+    return new SetCookieHeader(cookies.bind());
+  }
+
+  public static Parser<SetCookieHeader> parseHeaderValue(Input input, HttpParser http) {
+    return SetCookieHeaderParser.parse(input, http);
+  }
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
@@ -1,28 +1,27 @@
 package swim.http.header;
 
-import swim.codec.Input;
 import swim.codec.Output;
-import swim.codec.Parser;
 import swim.codec.Writer;
-import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieMap;
 import swim.http.Cookie;
 import swim.http.HttpHeader;
-import swim.http.HttpParser;
 import swim.http.HttpWriter;
-import swim.util.Builder;
+import swim.uri.UriPath;
 import swim.util.Murmur3;
 
 public class SetCookieHeader extends HttpHeader {
 
-  final FingerTrieSeq<Cookie> cookies;
+  final Cookie cookie;
+  HashTrieMap<String, String> params;
 
-  SetCookieHeader(FingerTrieSeq<Cookie> cookies) {
-    this.cookies = cookies;
+  SetCookieHeader(Cookie cookie, HashTrieMap<String, String> params) {
+    this.cookie = cookie;
+    this.params = params;
   }
 
   @Override
   public boolean isBlank() {
-    return this.cookies.isEmpty();
+    return this.cookie.getName().isEmpty();
   }
 
   @Override
@@ -35,13 +34,9 @@ public class SetCookieHeader extends HttpHeader {
     return "Set-Cookie";
   }
 
-  public FingerTrieSeq<Cookie> cookies() {
-    return this.cookies;
-  }
-
   @Override
   public Writer<?, ?> writeHeaderValue(Output<?> output, HttpWriter http) {
-    return http.writeParamList(output, this.cookies.iterator());
+    return SetCookieHeaderWriter.write(output, http, this.cookie, this.params);
   }
 
   @Override
@@ -50,7 +45,7 @@ public class SetCookieHeader extends HttpHeader {
       return true;
     } else if (other instanceof SetCookieHeader) {
       final SetCookieHeader that = (SetCookieHeader) other;
-      return this.cookies.equals(that.cookies);
+      return this.cookie.equals(that.cookie) && this.params.equals(that.params);
     }
     return false;
   }
@@ -62,44 +57,87 @@ public class SetCookieHeader extends HttpHeader {
     if (SetCookieHeader.hashSeed == 0) {
       SetCookieHeader.hashSeed = Murmur3.seed(SetCookieHeader.class);
     }
-    return Murmur3.mash(Murmur3.mix(SetCookieHeader.hashSeed, this.cookies.hashCode()));
+    return Murmur3.mash(Murmur3.mix(Murmur3.mix(SetCookieHeader.hashSeed, this.cookie.hashCode()), this.params.hashCode()));
   }
 
   @Override
   public <T> Output<T> debug(Output<T> output) {
-    output = output.write("SetCookieHeader").write('.').write("create").write('(');
-    final int n = this.cookies.size();
-    if (n > 0) {
-      output = output.debug(this.cookies.head());
-      for (int i = 1; i < n; i += 1) {
-        output = output.write(", ").debug(this.cookies.get(i));
+    output = output.write("SetCookieHeader").write('.').write("create").write('(').debug(this.cookie);
+
+    for (HashTrieMap.Entry<String, String> param : this.params) {
+      output = output.write('.').write("param").write('(').debug(param.getKey());
+
+      if (!param.getValue().isEmpty()) {
+        output.write(", ").debug(param.getValue());
       }
+
+      output.write(')');
     }
-    output = output.write(')');
+
+    output.write(')');
     return output;
   }
 
-  public static SetCookieHeader empty() {
-    return new SetCookieHeader(FingerTrieSeq.empty());
+  public static SetCookieHeader create(Cookie cookie) {
+    return new SetCookieHeader(cookie, HashTrieMap.empty());
   }
 
-  public static SetCookieHeader create(FingerTrieSeq<Cookie> cookies) {
-    return new SetCookieHeader(cookies);
+  public void expire() {
+    this.setMaxAge(0);
   }
 
-  public static SetCookieHeader create(Cookie... cookies) {
-    return new SetCookieHeader(FingerTrieSeq.of(cookies));
+  public void setSecure() {
+    this.params = this.params.updated("Secure", "");
   }
 
-  public static SetCookieHeader create(String... cookiesString) {
-    final Builder<Cookie, FingerTrieSeq<Cookie>> cookies = FingerTrieSeq.builder();
-    for (int i = 0, n = cookiesString.length; i < n; i += 1) {
-      cookies.add(Cookie.parse(cookiesString[i]));
-    }
-    return new SetCookieHeader(cookies.bind());
+  public void unsetSecure() {
+    this.params = this.params.removed("Secure");
   }
 
-  public static Parser<SetCookieHeader> parseHeaderValue(Input input, HttpParser http) {
-    return SetCookieHeaderParser.parse(input, http);
+  public void setHttpOnly() {
+    this.params = this.params.updated("HttpOnly", "");
   }
+
+  public void unsetHttpOnly() {
+    this.params = this.params.removed("HttpOnly");
+  }
+
+  public void setMaxAge(long maxAge) {
+    this.params = this.params.updated("Max-Age", Long.toString(maxAge));
+  }
+
+  public void unsetMaxAge() {
+    this.params = this.params.removed("Max-Age");
+  }
+
+  public void setDomain(String domain) {
+    this.params = this.params.updated("Domain", domain);
+  }
+
+  public void unsetDomain() {
+    this.params = this.params.removed("Domain");
+  }
+
+  public void setPath(String path) {
+    this.params = this.params.updated("Path", UriPath.of(path).toString());
+  }
+
+  public void unsetPath() {
+    this.params = this.params.removed("Path");
+  }
+
+  public void setSameSite(SameSite sameSite) {
+    this.params = this.params.updated("SameSite", sameSite.name());
+  }
+
+  public void unsetSameSite() {
+    this.params = this.params.removed("SameSite");
+  }
+
+  public enum SameSite {
+    Strict,
+    Lax,
+    None,
+  }
+
 }

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeader.java
@@ -82,6 +82,14 @@ public class SetCookieHeader extends HttpHeader {
     return new SetCookieHeader(cookie, HashTrieMap.empty());
   }
 
+  public static SetCookieHeader create(String name, String value) {
+    return new SetCookieHeader(Cookie.create(name, value), HashTrieMap.empty());
+  }
+
+  public static SetCookieHeader create(String name) {
+    return new SetCookieHeader(Cookie.create(name), HashTrieMap.empty());
+  }
+
   public void expire() {
     this.setMaxAge(0);
   }

--- a/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeaderWriter.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/main/java/swim/http/header/SetCookieHeaderWriter.java
@@ -1,0 +1,73 @@
+package swim.http.header;
+
+import swim.codec.Output;
+import swim.codec.Writer;
+import swim.collections.HashTrieMap;
+import swim.http.Cookie;
+import swim.http.HttpWriter;
+
+final class SetCookieHeaderWriter extends Writer<Object, Object> {
+
+  final HttpWriter http;
+  final Cookie cookie;
+  final HashTrieMap<String, String> params;
+  final Writer<?, ?> part;
+  final int step;
+
+  SetCookieHeaderWriter(HttpWriter http, Cookie cookie, HashTrieMap<String, String> params,
+                        Writer<?, ?> part, int step) {
+    this.http = http;
+    this.cookie = cookie;
+    this.params = params;
+    this.part = part;
+    this.step = step;
+  }
+
+  @Override
+  public Writer<Object, Object> pull(Output<?> output) {
+    return SetCookieHeaderWriter.write(output, this.http, this.cookie, this.params, this.part, this.step);
+  }
+
+  static Writer<Object, Object> write(Output<?> output, HttpWriter http,
+                                      Cookie cookie, HashTrieMap<String, String> params,
+                                      Writer<?, ?> part, int step) {
+
+    if (step == 1) {
+      if (part == null) {
+        part = cookie.writeHttp(output, http);
+      } else {
+        part = part.pull(output);
+      }
+
+      if (part.isDone()) {
+        part = null;
+        if (params.isEmpty()) {
+          return Writer.done();
+        } else {
+          step = 2;
+        }
+      } else if (part.isError()) {
+        return part.asError();
+      }
+    }
+    if (step == 2) {
+      if (part == null) {
+        part = http.writeParamMap(output, params.iterator());
+      } else {
+        part = part.pull(output);
+      }
+      if (part.isDone()) {
+        return Writer.done();
+      } else if (part.isError()) {
+        return part.asError();
+      }
+    }
+    return new SetCookieHeaderWriter(http, cookie, params, part, step);
+  }
+
+  static Writer<Object, Object> write(Output<?> output, HttpWriter http,
+                                      Cookie cookie, HashTrieMap<String, String> params) {
+    return SetCookieHeaderWriter.write(output, http, cookie, params, null, 1);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
@@ -37,7 +37,7 @@ public class CookieHeaderSpec {
   public void writesCookieHeader() {
     assertWrites(CookieHeader.create(Cookie.create("foo", "bar")), "Cookie: foo=bar");
     assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux")), "Cookie: foo=bar; baz=qux");
-    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")), "Cookie: foo=bar; baz=qux; qux=quux");
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")), "Cookie: foo=bar; qux=quux; baz=qux");
     assertWrites(CookieHeader.create(Cookie.create("foo")), "Cookie: foo=");
     assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")), "Cookie: foo=; bar=");
     assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")), "Cookie: foo=; bar=; baz=");

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
@@ -12,25 +12,25 @@ public class CookieHeaderSpec {
     assertParses("Cookie: foo=bar;", CookieHeader.create(Cookie.create("foo", "bar")));
     assertParses("Cookie: foo=bar; baz=qux", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux")));
     assertParses("Cookie: foo=bar; baz=qux; qux=quux", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")));
-    assertParses("Cookie: foo", CookieHeader.create(Cookie.create("foo")));
-    assertParses("Cookie: foo; bar", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")));
-    assertParses("Cookie: foo; bar; baz", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")));
-    assertParses("Cookie: foo=bar; baz", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")));
-    assertParses("Cookie: foo; bar=baz", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")));
-    assertParses("Cookie: foo; bar=baz; qux", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")));
-    assertParses("Cookie: foo; bar; baz=qux", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")));
+    assertParses("Cookie: foo=", CookieHeader.create(Cookie.create("foo")));
+    assertParses("Cookie: foo=; bar=", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")));
+    assertParses("Cookie: foo=; bar=; baz=", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")));
+    assertParses("Cookie: foo=bar; baz=", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")));
+    assertParses("Cookie: foo=; bar=baz", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")));
+    assertParses("Cookie: foo=; bar=baz; qux=", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")));
+    assertParses("Cookie: foo=; bar=; baz=qux", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")));
 
     assertParses("Cookie: {foo}={bar}", CookieHeader.create(Cookie.create("{foo}", "{bar}")));
     assertParses("Cookie: {foo}={bar};", CookieHeader.create(Cookie.create("{foo}", "{bar}")));
     assertParses("Cookie: {foo}={bar}; {baz}={qux}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}", "{qux}")));
     assertParses("Cookie: {foo}={bar}; {baz}={qux}; {qux}={quux}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}", "{qux}"), Cookie.create("{qux}", "{quux}")));
-    assertParses("Cookie: {foo}", CookieHeader.create(Cookie.create("{foo}")));
-    assertParses("Cookie: {foo}; {bar}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}")));
-    assertParses("Cookie: {foo}; {bar}; {baz}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}")));
-    assertParses("Cookie: {foo}={bar}; {baz}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}")));
-    assertParses("Cookie: {foo}; {bar}={baz}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}")));
-    assertParses("Cookie: {foo}; {bar}={baz}; {qux}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}"), Cookie.create("{qux}")));
-    assertParses("Cookie: {foo}; {bar}; {baz}={qux}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}", "{qux}")));
+    assertParses("Cookie: {foo}=", CookieHeader.create(Cookie.create("{foo}")));
+    assertParses("Cookie: {foo}=; {bar}=", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}")));
+    assertParses("Cookie: {foo}=; {bar}=; {baz}=", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}")));
+    assertParses("Cookie: {foo}={bar}; {baz}=", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}")));
+    assertParses("Cookie: {foo}=; {bar}={baz}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}")));
+    assertParses("Cookie: {foo}=; {bar}={baz}; {qux}=", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}"), Cookie.create("{qux}")));
+    assertParses("Cookie: {foo}=; {bar}=; {baz}={qux}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}", "{qux}")));
   }
 
   @Test
@@ -38,13 +38,13 @@ public class CookieHeaderSpec {
     assertWrites(CookieHeader.create(Cookie.create("foo", "bar")), "Cookie: foo=bar");
     assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux")), "Cookie: foo=bar; baz=qux");
     assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")), "Cookie: foo=bar; baz=qux; qux=quux");
-    assertWrites(CookieHeader.create(Cookie.create("foo")), "Cookie: foo");
-    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")), "Cookie: foo; bar");
-    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")), "Cookie: foo; bar; baz");
-    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")), "Cookie: foo=bar; baz");
-    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")), "Cookie: foo; bar=baz");
-    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")), "Cookie: foo; bar=baz; qux");
-    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")), "Cookie: foo; bar; baz=qux");
+    assertWrites(CookieHeader.create(Cookie.create("foo")), "Cookie: foo=");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")), "Cookie: foo=; bar=");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")), "Cookie: foo=; bar=; baz=");
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")), "Cookie: foo=bar; baz=");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")), "Cookie: foo=; bar=baz");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")), "Cookie: foo=; bar=baz; qux=");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")), "Cookie: foo=; bar=; baz=qux");
   }
 
   public static void assertParses(String string, CookieHeader cookieHeader) {

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieHeaderSpec.java
@@ -1,0 +1,54 @@
+package swim.http;
+
+import org.testng.annotations.Test;
+import swim.http.header.CookieHeader;
+import static swim.http.HttpAssertions.assertWrites;
+
+public class CookieHeaderSpec {
+
+  @Test
+  public void parseCookieHeader() {
+    assertParses("Cookie: foo=bar", CookieHeader.create(Cookie.create("foo", "bar")));
+    assertParses("Cookie: foo=bar;", CookieHeader.create(Cookie.create("foo", "bar")));
+    assertParses("Cookie: foo=bar; baz=qux", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux")));
+    assertParses("Cookie: foo=bar; baz=qux; qux=quux", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")));
+    assertParses("Cookie: foo", CookieHeader.create(Cookie.create("foo")));
+    assertParses("Cookie: foo; bar", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")));
+    assertParses("Cookie: foo; bar; baz", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")));
+    assertParses("Cookie: foo=bar; baz", CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")));
+    assertParses("Cookie: foo; bar=baz", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")));
+    assertParses("Cookie: foo; bar=baz; qux", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")));
+    assertParses("Cookie: foo; bar; baz=qux", CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")));
+
+    assertParses("Cookie: {foo}={bar}", CookieHeader.create(Cookie.create("{foo}", "{bar}")));
+    assertParses("Cookie: {foo}={bar};", CookieHeader.create(Cookie.create("{foo}", "{bar}")));
+    assertParses("Cookie: {foo}={bar}; {baz}={qux}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}", "{qux}")));
+    assertParses("Cookie: {foo}={bar}; {baz}={qux}; {qux}={quux}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}", "{qux}"), Cookie.create("{qux}", "{quux}")));
+    assertParses("Cookie: {foo}", CookieHeader.create(Cookie.create("{foo}")));
+    assertParses("Cookie: {foo}; {bar}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}")));
+    assertParses("Cookie: {foo}; {bar}; {baz}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}")));
+    assertParses("Cookie: {foo}={bar}; {baz}", CookieHeader.create(Cookie.create("{foo}", "{bar}"), Cookie.create("{baz}")));
+    assertParses("Cookie: {foo}; {bar}={baz}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}")));
+    assertParses("Cookie: {foo}; {bar}={baz}; {qux}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}", "{baz}"), Cookie.create("{qux}")));
+    assertParses("Cookie: {foo}; {bar}; {baz}={qux}", CookieHeader.create(Cookie.create("{foo}"), Cookie.create("{bar}"), Cookie.create("{baz}", "{qux}")));
+  }
+
+  @Test
+  public void writesCookieHeader() {
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar")), "Cookie: foo=bar");
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux")), "Cookie: foo=bar; baz=qux");
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz", "qux"), Cookie.create("qux", "quux")), "Cookie: foo=bar; baz=qux; qux=quux");
+    assertWrites(CookieHeader.create(Cookie.create("foo")), "Cookie: foo");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar")), "Cookie: foo; bar");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz")), "Cookie: foo; bar; baz");
+    assertWrites(CookieHeader.create(Cookie.create("foo", "bar"), Cookie.create("baz")), "Cookie: foo=bar; baz");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz")), "Cookie: foo; bar=baz");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar", "baz"), Cookie.create("qux")), "Cookie: foo; bar=baz; qux");
+    assertWrites(CookieHeader.create(Cookie.create("foo"), Cookie.create("bar"), Cookie.create("baz", "qux")), "Cookie: foo; bar; baz=qux");
+  }
+
+  public static void assertParses(String string, CookieHeader cookieHeader) {
+    HttpAssertions.assertParses(Http.standardParser().headerParser(), string, cookieHeader);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieSpec.java
@@ -1,0 +1,30 @@
+package swim.http;
+
+import org.testng.annotations.Test;
+import static swim.http.HttpAssertions.assertWrites;
+
+public class CookieSpec {
+
+  @Test
+  public void parseCookie() {
+    assertParses("foo=bar", Cookie.create("foo", "bar"));
+    assertParses("foo=baz.bar", Cookie.create("foo", "baz.bar"));
+    assertParses("foo.bar=baz.qux", Cookie.create("foo.bar", "baz.qux"));
+    assertParses("{foo.bar}={baz.qux}", Cookie.create("{foo.bar}", "{baz.qux}"));
+    assertParses("foo", Cookie.create("foo"));
+  }
+
+  @Test
+  public void writesCookie() {
+    assertWrites(Cookie.create("foo", "bar"), "foo=bar");
+    assertWrites(Cookie.create("foo", "baz.bar"), "foo=baz.bar");
+    assertWrites(Cookie.create("foo.bar", "baz.qux"), "foo.bar=baz.qux");
+    assertWrites(Cookie.create("foo", ""), "foo");
+
+  }
+
+  public static void assertParses(String string, Cookie cookie) {
+    HttpAssertions.assertParses(Http.standardParser().cookieParser(), string, cookie);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/CookieSpec.java
@@ -11,7 +11,7 @@ public class CookieSpec {
     assertParses("foo=baz.bar", Cookie.create("foo", "baz.bar"));
     assertParses("foo.bar=baz.qux", Cookie.create("foo.bar", "baz.qux"));
     assertParses("{foo.bar}={baz.qux}", Cookie.create("{foo.bar}", "{baz.qux}"));
-    assertParses("foo", Cookie.create("foo"));
+    assertParses("foo=", Cookie.create("foo"));
   }
 
   @Test
@@ -19,7 +19,7 @@ public class CookieSpec {
     assertWrites(Cookie.create("foo", "bar"), "foo=bar");
     assertWrites(Cookie.create("foo", "baz.bar"), "foo=baz.bar");
     assertWrites(Cookie.create("foo.bar", "baz.qux"), "foo.bar=baz.qux");
-    assertWrites(Cookie.create("foo", ""), "foo");
+    assertWrites(Cookie.create("foo", ""), "foo=");
 
   }
 

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/SetCookieHeaderSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/SetCookieHeaderSpec.java
@@ -40,33 +40,33 @@ public class SetCookieHeaderSpec {
 
     header = SetCookieHeader.create(Cookie.create("baz"));
     header.setSecure();
-    assertWrites(header, "Set-Cookie: baz; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Secure");
     header.setHttpOnly();
-    assertWrites(header, "Set-Cookie: baz; HttpOnly; Secure");
+    assertWrites(header, "Set-Cookie: baz=; HttpOnly; Secure");
     header.setMaxAge(1800);
-    assertWrites(header, "Set-Cookie: baz; HttpOnly; Max-Age=1800; Secure");
+    assertWrites(header, "Set-Cookie: baz=; HttpOnly; Max-Age=1800; Secure");
     header.setDomain("example.com");
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
     header.setDomain("example.com");
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
     header.setPath("/my/custom/path");
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; HttpOnly; Max-Age=1800; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; HttpOnly; Max-Age=1800; Secure");
     header.setSameSite(SetCookieHeader.SameSite.Strict);
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=1800; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=1800; Secure");
     header.expire();
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0; Secure");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0; Secure");
     header.unsetSecure();
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0");
     header.unsetHttpOnly();
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; Max-Age=0");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; Max-Age=0");
     header.unsetMaxAge();
-    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    assertWrites(header, "Set-Cookie: baz=; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
     header.unsetDomain();
-    assertWrites(header, "Set-Cookie: baz; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    assertWrites(header, "Set-Cookie: baz=; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
     header.unsetPath();
-    assertWrites(header, "Set-Cookie: baz; SameSite=Strict");
+    assertWrites(header, "Set-Cookie: baz=; SameSite=Strict");
     header.unsetSameSite();
-    assertWrites(header, "Set-Cookie: baz");
+    assertWrites(header, "Set-Cookie: baz=");
   }
 
 }

--- a/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/SetCookieHeaderSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.http/src/test/java/swim/http/SetCookieHeaderSpec.java
@@ -1,0 +1,72 @@
+package swim.http;
+
+import org.testng.annotations.Test;
+import swim.http.header.SetCookieHeader;
+import static swim.http.HttpAssertions.assertWrites;
+
+public class SetCookieHeaderSpec {
+
+  @Test
+  public void writesCookieHeader() {
+    SetCookieHeader header = SetCookieHeader.create(Cookie.create("foo", "bar"));
+    header.setSecure();
+    assertWrites(header, "Set-Cookie: foo=bar; Secure");
+    header.setHttpOnly();
+    assertWrites(header, "Set-Cookie: foo=bar; HttpOnly; Secure");
+    header.setMaxAge(1800);
+    assertWrites(header, "Set-Cookie: foo=bar; HttpOnly; Max-Age=1800; Secure");
+    header.setDomain("example.com");
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    header.setDomain("example.com");
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    header.setPath("/my/custom/path");
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; HttpOnly; Max-Age=1800; Secure");
+    header.setSameSite(SetCookieHeader.SameSite.Strict);
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=1800; Secure");
+    header.expire();
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0; Secure");
+    header.unsetSecure();
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0");
+    header.unsetHttpOnly();
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; Max-Age=0");
+    header.unsetMaxAge();
+    assertWrites(header, "Set-Cookie: foo=bar; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    header.unsetDomain();
+    assertWrites(header, "Set-Cookie: foo=bar; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    header.unsetPath();
+    assertWrites(header, "Set-Cookie: foo=bar; SameSite=Strict");
+    header.unsetSameSite();
+    assertWrites(header, "Set-Cookie: foo=bar");
+
+    header = SetCookieHeader.create(Cookie.create("baz"));
+    header.setSecure();
+    assertWrites(header, "Set-Cookie: baz; Secure");
+    header.setHttpOnly();
+    assertWrites(header, "Set-Cookie: baz; HttpOnly; Secure");
+    header.setMaxAge(1800);
+    assertWrites(header, "Set-Cookie: baz; HttpOnly; Max-Age=1800; Secure");
+    header.setDomain("example.com");
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    header.setDomain("example.com");
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; HttpOnly; Max-Age=1800; Secure");
+    header.setPath("/my/custom/path");
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; HttpOnly; Max-Age=1800; Secure");
+    header.setSameSite(SetCookieHeader.SameSite.Strict);
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=1800; Secure");
+    header.expire();
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0; Secure");
+    header.unsetSecure();
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; HttpOnly; Max-Age=0");
+    header.unsetHttpOnly();
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict; Max-Age=0");
+    header.unsetMaxAge();
+    assertWrites(header, "Set-Cookie: baz; Domain=example.com; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    header.unsetDomain();
+    assertWrites(header, "Set-Cookie: baz; Path=%2fmy%2fcustom%2fpath; SameSite=Strict");
+    header.unsetPath();
+    assertWrites(header, "Set-Cookie: baz; SameSite=Strict");
+    header.unsetSameSite();
+    assertWrites(header, "Set-Cookie: baz");
+  }
+
+}

--- a/swim-java/swim-runtime/swim-core/swim.ws/src/main/java/swim/ws/WsEngineSettings.java
+++ b/swim-java/swim-runtime/swim-core/swim.ws/src/main/java/swim/ws/WsEngineSettings.java
@@ -18,6 +18,7 @@ import swim.codec.Debug;
 import swim.codec.Format;
 import swim.codec.Output;
 import swim.collections.FingerTrieSeq;
+import swim.collections.HashTrieMap;
 import swim.http.HttpHeader;
 import swim.http.WebSocketExtension;
 import swim.http.WebSocketParam;
@@ -229,7 +230,7 @@ public class WsEngineSettings implements Debug {
   }
 
   public WsRequest handshakeRequest(Uri uri, FingerTrieSeq<String> protocols, FingerTrieSeq<HttpHeader> headers) {
-    return WsRequest.create(uri, protocols, this.extensions(), headers);
+    return WsRequest.create(uri, protocols, this.extensions(), HashTrieMap.empty(), headers);
   }
 
   public WsRequest handshakeRequest(Uri uri, FingerTrieSeq<String> protocols, HttpHeader... headers) {

--- a/swim-java/swim-runtime/swim-host/swim.remote/src/main/java/swim/remote/RemoteHost.java
+++ b/swim-java/swim-runtime/swim-host/swim.remote/src/main/java/swim/remote/RemoteHost.java
@@ -39,6 +39,7 @@ import swim.concurrent.Schedule;
 import swim.concurrent.Stage;
 import swim.concurrent.Stay;
 import swim.concurrent.StayContext;
+import swim.http.Cookie;
 import swim.http.HttpRequest;
 import swim.http.HttpResponse;
 import swim.io.FlowModifier;
@@ -46,6 +47,8 @@ import swim.io.IpSocket;
 import swim.io.warp.WarpSocket;
 import swim.io.warp.WarpSocketContext;
 import swim.store.StoreBinding;
+import swim.structure.Record;
+import swim.structure.Slot;
 import swim.structure.Value;
 import swim.system.AbstractTierBinding;
 import swim.system.HostAddress;
@@ -102,6 +105,7 @@ public class RemoteHost extends AbstractTierBinding implements HostBinding, Warp
   protected WarpSocketContext warpSocketContext;
   final Uri requestUri;
   final Uri baseUri;
+  final HashTrieMap<String, Cookie> cookies;
   Uri remoteUri;
 
   volatile int flags;
@@ -135,8 +139,13 @@ public class RemoteHost extends AbstractTierBinding implements HostBinding, Warp
   DemandLane<HostPulse> metaPulse;
 
   public RemoteHost(Uri requestUri, Uri baseUri) {
+    this(requestUri, baseUri, HashTrieMap.empty());
+  }
+
+  public RemoteHost(Uri requestUri, Uri baseUri, HashTrieMap<String, Cookie> cookies) {
     this.hostContext = null;
     this.warpSocketContext = null;
+    this.cookies = cookies;
     this.requestUri = requestUri;
     this.baseUri = baseUri;
     this.remoteUri = null;
@@ -979,7 +988,15 @@ public class RemoteHost extends AbstractTierBinding implements HostBinding, Warp
   }
 
   protected void onAuthRequest(AuthRequest request) {
-    final RemoteCredentials credentials = new RemoteCredentials(this.requestUri, this.remoteUri, request.body());
+    final RemoteCredentials credentials;
+
+    if (request.body().containsKey("cookie")) {
+      final Cookie authCookie = this.cookies.get(request.body().get("cookie").stringValue());
+      credentials = new RemoteCredentials(this.requestUri, this.remoteUri, Record.of(Slot.of("idToken", authCookie.getValue())));
+    } else {
+      credentials = new RemoteCredentials(this.requestUri, this.remoteUri, request.body());
+    }
+
     final PolicyDirective<Identity> directive = this.hostContext.authenticate(credentials);
     if (directive != null && directive.isAllowed()) {
       RemoteHost.REMOTE_IDENTITY.set(this, directive.get());

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
@@ -19,6 +19,8 @@ import swim.api.policy.PlanePolicy;
 import swim.api.policy.PolicyDirective;
 import swim.api.service.ServiceException;
 import swim.api.space.Space;
+import swim.collections.HashTrieMap;
+import swim.http.Cookie;
 import swim.http.HttpBody;
 import swim.http.HttpRequest;
 import swim.http.HttpResponse;
@@ -132,11 +134,11 @@ public class WebServer extends AbstractWarpServer {
   }
 
   protected HttpResponder<?> warpWebSocketResponder(WsRequest wsRequest, WsResponse wsResponse) {
-    final RemoteHost host = this.openHost(wsRequest.httpRequest().uri());
+    final RemoteHost host = this.openHost(wsRequest.httpRequest().uri(), wsRequest.cookies());
     return this.upgrade(host, wsResponse);
   }
 
-  protected RemoteHost openHost(Uri requestUri) {
+  protected RemoteHost openHost(Uri requestUri, HashTrieMap<String, Cookie> cookies) {
     final Uri baseUri = Uri.create(UriScheme.create("warp"),
                                    UriAuthority.create(UriHost.inetAddress(context.localAddress().getAddress()),
                                                        UriPort.create(context.localAddress().getPort())),
@@ -152,7 +154,7 @@ public class WebServer extends AbstractWarpServer {
       final EdgeBinding edge = ((EdgeContext) space).edgeWrapper();
       final MeshBinding mesh = edge.openMesh(remoteUri);
       final PartBinding gateway = mesh.openGateway();
-      final RemoteHost host = new RemoteHost(requestUri, baseUri);
+      final RemoteHost host = new RemoteHost(requestUri, baseUri, cookies);
       gateway.openHost(remoteUri, host);
       return host;
     } else {

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/test/java/swim/service/web/WebServerSpec.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/test/java/swim/service/web/WebServerSpec.java
@@ -15,6 +15,8 @@
 package swim.service.web;
 
 import org.testng.annotations.Test;
+import swim.collections.HashTrieMap;
+import swim.http.Cookie;
 import swim.http.HttpRequest;
 import swim.http.HttpResponse;
 import swim.http.HttpStatus;
@@ -42,7 +44,7 @@ public class WebServerSpec {
     final WebServiceDef serviceDef = new WebServiceDef("web", "0.0.0.0", 80, false, null, null, null, null, WarpSettings.create(wsSettings));
     final WebServer server = new WebServer(new WebServiceKernel(), serviceDef, request -> request.respond(HttpResponse.create(HttpStatus.OK))) {
       @Override
-      protected RemoteHost openHost(Uri requestUri) {
+      protected RemoteHost openHost(Uri requestUri, HashTrieMap<String, Cookie> cookies) {
         return new RemoteHost(requestUri);
       }
     };


### PR DESCRIPTION
Allows swim clients to authenticate with the server using cookies.

The swim clients can now authenticate using a cookie by sending `auth` messages like:

```
@auth(idToken: @cookie("cognito.access_token"))
```

The `cookie` attributes are substituted with the value of the cookie with the corresponding name (if it exists).