### PR TITLE
Missing payload for POST requests.

### DIFF
--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/HttpWebResponder.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/HttpWebResponder.java
@@ -1,0 +1,40 @@
+package swim.service.web;
+
+import swim.http.HttpRequest;
+import swim.io.http.AbstractHttpResponder;
+import swim.io.http.HttpResponder;
+import swim.kernel.KernelContext;
+import swim.web.WebRequest;
+import swim.web.WebResponse;
+import swim.web.WebRoute;
+import swim.web.WebServerRequest;
+
+public class HttpWebResponder<T> extends AbstractHttpResponder<T> {
+
+  WebRoute router;
+  KernelContext kernel;
+
+  public HttpWebResponder(WebRoute router, KernelContext kernel) {
+    this.router = router;
+    this.kernel = kernel;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void doRespond(HttpRequest<T> request) {
+
+    final WebRequest webRequest = new WebServerRequest(request);
+    // Route application requests.
+    WebResponse webResponse = this.router.routeRequest(webRequest);
+    if (webResponse.isRejected()) {
+      // Route kernel module requests.
+      webResponse = this.kernel.routeRequest(webRequest);
+    }
+
+    final HttpResponder<T> responder =  (HttpResponder<T>) webResponse.httpResponder();
+    responder.setHttpResponderContext(this.context);
+    responder.doRespond(request);
+
+  }
+
+}

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
@@ -40,10 +40,7 @@ import swim.uri.UriHost;
 import swim.uri.UriPath;
 import swim.uri.UriPort;
 import swim.uri.UriScheme;
-import swim.web.WebRequest;
-import swim.web.WebResponse;
 import swim.web.WebRoute;
-import swim.web.WebServerRequest;
 import swim.web.route.DirectoryRoute;
 import swim.web.route.ResourceDirectoryRoute;
 import swim.ws.WsRequest;
@@ -123,14 +120,7 @@ public class WebServer extends AbstractWarpServer {
       // nop
     }
 
-    final WebRequest webRequest = new WebServerRequest(httpRequest);
-    // Route application requests.
-    WebResponse webResponse = this.router.routeRequest(webRequest);
-    if (webResponse.isRejected()) {
-      // Route kernel module requests.
-      webResponse = this.kernel.routeRequest(webRequest);
-    }
-    return webResponse.httpResponder();
+    return new HttpWebResponder<Object>(this.router, this.kernel);
   }
 
   protected HttpResponder<?> warpWebSocketResponder(WsRequest wsRequest, WsResponse wsResponse) {


### PR DESCRIPTION
Deferred the call to `routeRequest` method until after the `HttpRequest` body is decoded for HTTP POST requests.