### PR TITLE
Access control for HTTP lanes

### DIFF
--- a/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/AbstractPolicy.java
+++ b/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/AbstractPolicy.java
@@ -62,7 +62,12 @@ public class AbstractPolicy implements Policy, PlanePolicy, AgentRoutePolicy, Ag
   }
 
   @Override
-  public PolicyDirective<Object> canConnect(Uri requestUri) {
+  public PolicyDirective<Object> canConnect(HttpRequest<?> httpRequest) {
+    return this.allow();
+  }
+
+  @Override
+  public PolicyDirective<Object> authorizeHttpLane(Uri nodeUri, Uri laneUri, HttpRequest<?> httpRequest) {
     return this.allow();
   }
 

--- a/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/PlanePolicy.java
+++ b/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/PlanePolicy.java
@@ -16,7 +16,7 @@ package swim.api.policy;
 
 import swim.api.Downlink;
 import swim.api.agent.AgentRoute;
-import swim.uri.Uri;
+import swim.http.HttpRequest;
 
 public interface PlanePolicy extends Policy {
 
@@ -24,6 +24,6 @@ public interface PlanePolicy extends Policy {
 
   DownlinkPolicy downlinkPolicy(Downlink downlink);
 
-  PolicyDirective<Object> canConnect(Uri requestUri);
+  PolicyDirective<Object> canConnect(HttpRequest<?> httpRequest);
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/Policy.java
+++ b/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/Policy.java
@@ -18,6 +18,7 @@ import swim.api.auth.Identity;
 import swim.http.HttpMessage;
 import swim.http.HttpRequest;
 import swim.http.HttpResponse;
+import swim.uri.Uri;
 import swim.warp.CommandMessage;
 import swim.warp.EventMessage;
 import swim.warp.LinkRequest;
@@ -36,5 +37,7 @@ public interface Policy extends HttpPolicy {
   PolicyDirective<HttpMessage<?>> canRequest(HttpRequest<?> request);
 
   PolicyDirective<HttpResponse<?>> canRespond(HttpRequest<?> request, HttpResponse<?> response);
+
+  PolicyDirective<Object> authorizeHttpLane(Uri nodeUri, Uri laneUri, HttpRequest<?> httpRequest);
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/PolicyDirective.java
+++ b/swim-java/swim-runtime/swim-host/swim.api/src/main/java/swim/api/policy/PolicyDirective.java
@@ -182,6 +182,11 @@ public abstract class PolicyDirective<T> implements Debug {
     }
 
     @Override
+    public boolean isForbidden() {
+      return true;
+    }
+
+    @Override
     public Policy policy() {
       return this.policy;
     }
@@ -241,6 +246,11 @@ public abstract class PolicyDirective<T> implements Debug {
     Forbid(Policy policy, Object reason) {
       this.policy = policy;
       this.reason = reason;
+    }
+
+    @Override
+    public boolean isDenied() {
+      return true;
     }
 
     @Override

--- a/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
+++ b/swim-java/swim-runtime/swim-host/swim.service.web/src/main/java/swim/service/web/WebServer.java
@@ -91,7 +91,7 @@ public class WebServer extends AbstractWarpServer {
 
     // Verify request permission.
     if (policy != null) {
-      final PolicyDirective<?> directive = policy.canConnect(requestUri);
+      final PolicyDirective<?> directive = policy.canConnect(httpRequest);
       if (directive.isDenied()) {
         return new StaticHttpResponder<Object>(HttpResponse.create(HttpStatus.UNAUTHORIZED).content(HttpBody.empty()));
       }
@@ -112,6 +112,15 @@ public class WebServer extends AbstractWarpServer {
     try {
       final Uri laneUri = Uri.parse(requestUri.query().get("lane"));
       final Uri nodeUri = Uri.create(requestUri.path());
+
+      // Verify HTTP lane request permission.
+      if (policy != null) {
+        final PolicyDirective<?> directive = policy.authorizeHttpLane(nodeUri, laneUri, httpRequest);
+        if (directive.isDenied()) {
+          return new StaticHttpResponder<Object>(HttpResponse.create(HttpStatus.UNAUTHORIZED).content(HttpBody.empty()));
+        }
+      }
+
       final HttpLaneResponder httpBinding = new HttpLaneResponder(Uri.empty(), Uri.empty(), nodeUri, laneUri, httpRequest);
       final EdgeBinding edge = ((EdgeContext) space).edgeWrapper();
       edge.openUplink(httpBinding);


### PR DESCRIPTION
* Changed `canConnect` to accept the whole `HttpRequest` instead of only the URI.
* Added method specifically for http lane authentication.
* Changed PolicyDirective `deny` and `forbidden` to act the same way.

Closes #102 