### PR TITLE
Add SystemPulse with CPU, Memory and Disk usage stats

### DIFF
--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/module-info.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/module-info.java
@@ -16,6 +16,7 @@
  * Swim system interfaces.
  */
 module swim.system {
+  requires transitive jdk.management;
   requires swim.util;
   requires transitive swim.codec;
   requires transitive swim.structure;

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/MeshPulse.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/MeshPulse.java
@@ -28,21 +28,24 @@ public class MeshPulse extends Pulse {
   protected final AgentPulse agents;
   protected final WarpDownlinkPulse downlinks;
   protected final WarpUplinkPulse uplinks;
+  protected final SystemPulse system;
 
   public MeshPulse(int partCount, int hostCount, long nodeCount, AgentPulse agents,
-                   WarpDownlinkPulse downlinks, WarpUplinkPulse uplinks) {
+                   WarpDownlinkPulse downlinks, WarpUplinkPulse uplinks, SystemPulse system) {
     this.partCount = partCount;
     this.hostCount = hostCount;
     this.nodeCount = nodeCount;
     this.agents = agents;
     this.downlinks = downlinks;
     this.uplinks = uplinks;
+    this.system = system;
   }
 
   @Override
   public boolean isDefined() {
     return this.partCount != 0 || this.hostCount != 0 || this.nodeCount != 0L
-        || this.agents.isDefined() || this.downlinks.isDefined() || this.uplinks.isDefined();
+        || this.agents.isDefined() || this.downlinks.isDefined() || this.uplinks.isDefined()
+        || this.system.isDefined();
   }
 
   public final int partCount() {
@@ -67,6 +70,10 @@ public class MeshPulse extends Pulse {
 
   public final WarpUplinkPulse uplinks() {
     return this.uplinks;
+  }
+
+  public SystemPulse system() {
+    return this.system;
   }
 
   @Override
@@ -96,7 +103,7 @@ final class MeshPulseForm extends Form<MeshPulse> {
   @Override
   public Item mold(MeshPulse pulse) {
     if (pulse != null) {
-      final Record record = Record.create(6);
+      final Record record = Record.create(7);
       if (pulse.partCount > 0) {
         record.slot("partCount", pulse.partCount);
       }
@@ -115,6 +122,9 @@ final class MeshPulseForm extends Form<MeshPulse> {
       if (pulse.uplinks.isDefined()) {
         record.slot("uplinks", pulse.uplinks.toValue());
       }
+      if (pulse.system != null && pulse.system.isDefined()) {
+        record.slot("system", pulse.system.toValue());
+      }
       return record;
     } else {
       return Item.extant();
@@ -130,7 +140,8 @@ final class MeshPulseForm extends Form<MeshPulse> {
     final AgentPulse agents = value.get("agents").coerce(AgentPulse.form());
     final WarpDownlinkPulse downlinks = value.get("downlinks").coerce(WarpDownlinkPulse.form());
     final WarpUplinkPulse uplinks = value.get("uplinks").coerce(WarpUplinkPulse.form());
-    return new MeshPulse(partCount, hostCount, nodeCount, agents, downlinks, uplinks);
+    final SystemPulse system = value.get("system").coerce(SystemPulse.form());
+    return new MeshPulse(partCount, hostCount, nodeCount, agents, downlinks, uplinks, system);
   }
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/PartPulse.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/PartPulse.java
@@ -27,20 +27,22 @@ public class PartPulse extends Pulse {
   protected final AgentPulse agents;
   protected final WarpDownlinkPulse downlinks;
   protected final WarpUplinkPulse uplinks;
+  protected final SystemPulse system;
 
   public PartPulse(int hostCount, long nodeCount, AgentPulse agents,
-                   WarpDownlinkPulse downlinks, WarpUplinkPulse uplinks) {
+                   WarpDownlinkPulse downlinks, WarpUplinkPulse uplinks, SystemPulse system) {
     this.hostCount = hostCount;
     this.nodeCount = nodeCount;
     this.agents = agents;
     this.downlinks = downlinks;
     this.uplinks = uplinks;
+    this.system = system;
   }
 
   @Override
   public boolean isDefined() {
     return this.hostCount != 0 || this.nodeCount != 0L || this.agents.isDefined()
-        || this.downlinks.isDefined() || this.uplinks.isDefined();
+        || this.downlinks.isDefined() || this.uplinks.isDefined() || this.system.isDefined();
   }
 
   public final int hostCount() {
@@ -61,6 +63,10 @@ public class PartPulse extends Pulse {
 
   public final WarpUplinkPulse uplinks() {
     return this.uplinks;
+  }
+
+  public SystemPulse system() {
+    return this.system;
   }
 
   @Override
@@ -90,7 +96,7 @@ final class PartPulseForm extends Form<PartPulse> {
   @Override
   public Item mold(PartPulse pulse) {
     if (pulse != null) {
-      final Record record = Record.create(5);
+      final Record record = Record.create(6);
       if (pulse.hostCount > 0) {
         record.slot("hostCount", pulse.hostCount);
       }
@@ -106,6 +112,9 @@ final class PartPulseForm extends Form<PartPulse> {
       if (pulse.uplinks.isDefined()) {
         record.slot("uplinks", pulse.uplinks.toValue());
       }
+      if (pulse.system != null && pulse.system.isDefined()) {
+        record.slot("system", pulse.system.toValue());
+      }
       return record;
     } else {
       return Item.extant();
@@ -120,7 +129,8 @@ final class PartPulseForm extends Form<PartPulse> {
     final AgentPulse agents = value.get("agents").coerce(AgentPulse.form());
     final WarpDownlinkPulse downlinks = value.get("downlinks").coerce(WarpDownlinkPulse.form());
     final WarpUplinkPulse uplinks = value.get("uplinks").coerce(WarpUplinkPulse.form());
-    return new PartPulse(hostCount, nodeCount, agents, downlinks, uplinks);
+    final SystemPulse system = value.get("system").coerce(SystemPulse.form());
+    return new PartPulse(hostCount, nodeCount, agents, downlinks, uplinks, system);
   }
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/SystemPulse.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/reflect/SystemPulse.java
@@ -1,0 +1,156 @@
+// Copyright 2015-2023 Swim.inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swim.system.reflect;
+
+import swim.structure.Form;
+import swim.structure.Item;
+import swim.structure.Kind;
+import swim.structure.Record;
+import swim.structure.Value;
+
+public class SystemPulse extends Pulse {
+
+  protected final int cpuUsage;
+  protected final int cpuTotal;
+  protected final long memUsage;
+  protected final long memTotal;
+  protected final long diskUsage;
+  protected final long diskTotal;
+  protected final long startTime;
+
+  public SystemPulse(int cpuUsage, int cpuTotal, long memUsage, long memTotal,
+                     long diskUsage, long diskTotal, long startTime) {
+    this.cpuUsage = cpuUsage;
+    this.cpuTotal = cpuTotal;
+    this.memUsage = memUsage;
+    this.memTotal = memTotal;
+    this.diskUsage = diskUsage;
+    this.diskTotal = diskTotal;
+    this.startTime = startTime;
+  }
+
+  @Override
+  public boolean isDefined() {
+    return this.cpuUsage != 0L || this.cpuTotal != 0 || this.memTotal != 0L
+        || this.memTotal != 0 || this.diskUsage != 0L || this.diskTotal != 0L
+        || this.startTime != 0;
+  }
+
+  public int cpuUsage() {
+    return this.cpuUsage;
+  }
+
+  public int cpuTotal() {
+    return this.cpuTotal;
+  }
+
+  public long memUsage() {
+    return this.memUsage;
+  }
+
+  public long memTotal() {
+    return this.memTotal;
+  }
+
+  public long diskUsage() {
+    return this.diskUsage;
+  }
+
+  public long diskTotal() {
+    return this.diskTotal;
+  }
+
+  public long startTime() {
+    return this.startTime;
+  }
+
+  @Override
+  public Value toValue() {
+    return SystemPulse.form().mold(this).toValue();
+  }
+
+  private static Form<SystemPulse> form;
+
+  @Kind
+  public static Form<SystemPulse> form() {
+    if (SystemPulse.form == null) {
+      SystemPulse.form = new SystemPulseForm();
+    }
+    return SystemPulse.form;
+  }
+
+  private static SystemPulse empty;
+
+  public static SystemPulse empty() {
+    if (SystemPulse.empty != null) {
+      SystemPulse.empty = new SystemPulse(0, 0, 0L, 0L, 0L, 0L, 0L);
+    }
+    return SystemPulse.empty;
+  }
+
+}
+
+final class SystemPulseForm extends Form<SystemPulse> {
+
+  @Override
+  public Class<?> type() {
+    return SystemPulse.class;
+  }
+
+  @Override
+  public Item mold(SystemPulse pulse) {
+    if (pulse != null) {
+      final Record record = Record.create(7);
+      if (pulse.cpuUsage > 0L) {
+        record.slot("cpuUsage", pulse.cpuUsage);
+      }
+      if (pulse.cpuTotal > 0) {
+        record.slot("cpuTotal", pulse.cpuTotal);
+      }
+      if (pulse.memUsage > 0L) {
+        record.slot("memUsage", pulse.memUsage);
+      }
+      if (pulse.memTotal > 0) {
+        record.slot("memTotal", pulse.memTotal);
+      }
+      if (pulse.diskUsage > 0L) {
+        record.slot("diskUsage", pulse.diskUsage);
+      }
+      if (pulse.diskTotal > 0L) {
+        record.slot("diskTotal", pulse.diskTotal);
+      }
+      if (pulse.startTime > 0L) {
+        record.slot("startTime", pulse.startTime);
+      }
+      return record;
+    } else {
+      return Item.extant();
+    }
+  }
+
+  @Override
+  public SystemPulse cast(Item item) {
+    final Value value = item.toValue();
+    final int cpuUsage = value.get("cpuUsage").intValue(0);
+    final int cpuTotal = value.get("cpuUsage").intValue(0);
+    final long memUsage = value.get("memUsage").longValue(0L);
+    final long memTotal = value.get("memTotal").longValue(0L);
+    final long diskUsage = value.get("diskUsage").longValue(0L);
+    final long diskTotal = value.get("diskTotal").longValue(0L);
+    final long startTime = value.get("startTime").longValue(0L);
+    return new SystemPulse(cpuUsage, cpuTotal, memUsage, memTotal, diskUsage, diskTotal, startTime);
+  }
+
+}

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/MeshTable.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/MeshTable.java
@@ -14,6 +14,14 @@
 
 package swim.system.router;
 
+import com.sun.management.OperatingSystemMXBean;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -28,9 +36,11 @@ import swim.api.lane.function.OnSyncKeys;
 import swim.api.policy.Policy;
 import swim.api.warp.WarpUplink;
 import swim.collections.FingerTrieSeq;
+import swim.concurrent.AbstractTimer;
 import swim.concurrent.Cont;
 import swim.concurrent.Schedule;
 import swim.concurrent.Stage;
+import swim.concurrent.TimerRef;
 import swim.store.StoreBinding;
 import swim.structure.Extant;
 import swim.structure.Form;
@@ -61,6 +71,7 @@ import swim.system.reflect.AgentPulse;
 import swim.system.reflect.LogEntry;
 import swim.system.reflect.MeshPulse;
 import swim.system.reflect.PartInfo;
+import swim.system.reflect.SystemPulse;
 import swim.system.reflect.WarpDownlinkPulse;
 import swim.system.reflect.WarpUplinkPulse;
 import swim.uri.Uri;
@@ -114,6 +125,7 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
   volatile int uplinkCommandDelta;
   volatile int uplinkCommandRate;
   volatile long uplinkCommandCount;
+  volatile SystemPulse systemPulse;
   volatile long lastReportTime;
 
   MeshPulse pulse;
@@ -126,6 +138,7 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
   SupplyLane<LogEntry> metaWarnLog;
   SupplyLane<LogEntry> metaErrorLog;
   SupplyLane<LogEntry> metaFailLog;
+  private TimerRef systemPulseTimer;
 
   public MeshTable() {
     this.meshContext = null;
@@ -175,8 +188,8 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
     this.uplinkCommandDelta = 0;
     this.uplinkCommandRate = 0;
     this.uplinkCommandCount = 0L;
+    this.systemPulse = SystemPulse.empty();
     this.lastReportTime = 0L;
-
 
     this.pulse = null;
     this.metaNode = null;
@@ -696,6 +709,11 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
   }
 
   @Override
+  protected void didOpen() {
+    this.systemPulseTimer = this.schedule().setTimer(POLL_INTERVAL, new MeshSystemPulseTimer(this));
+  }
+
+  @Override
   protected void willLoad() {
     super.willLoad();
     final Iterator<PartBinding> partsIterator = MeshTable.PARTS.get(this).iterator();
@@ -754,6 +772,11 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
       this.metaWarnLog = null;
       this.metaErrorLog = null;
       this.metaFailLog = null;
+    }
+    final TimerRef systemPulseTimer = this.systemPulseTimer;
+    if (systemPulseTimer != null) {
+      systemPulseTimer.cancel();
+      this.systemPulseTimer = null;
     }
     this.flushMetrics();
   }
@@ -919,7 +942,8 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
     final long uplinkCount = uplinkOpenCount - uplinkCloseCount;
     final WarpUplinkPulse uplinkPulse = new WarpUplinkPulse(uplinkCount, uplinkEventRate, uplinkEventCount,
                                                             uplinkCommandRate, uplinkCommandCount);
-    this.pulse = new MeshPulse(partCount, hostCount, nodeCount, agentPulse, downlinkPulse, uplinkPulse);
+    final SystemPulse systemPulse = MeshTable.SYSTEM_PULSE.getAndSet(this, SystemPulse.empty());
+    this.pulse = new MeshPulse(partCount, hostCount, nodeCount, agentPulse, downlinkPulse, uplinkPulse, systemPulse);
     final DemandLane<MeshPulse> metaPulse = this.metaPulse;
     if (metaPulse != null) {
       metaPulse.cue();
@@ -938,9 +962,36 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
                            uplinkOpenDelta, uplinkOpenCount, uplinkCloseDelta, uplinkCloseCount,
                            uplinkEventDelta, uplinkEventRate, uplinkEventCount,
                            uplinkCommandDelta, uplinkCommandRate, uplinkCommandCount);
+
+  }
+
+  protected void updateSystemPulse(OperatingSystemMXBean operatingSystemMXBean, RuntimeMXBean runtimeMXBean) {
+    final int cpuTotal = 100 * operatingSystemMXBean.getAvailableProcessors();
+    final int cpuUsage = (int) Math.round(operatingSystemMXBean.getProcessCpuLoad() * cpuTotal);
+
+    final long memTotal = operatingSystemMXBean.getTotalPhysicalMemorySize();
+    final long memUsage = memTotal - operatingSystemMXBean.getFreePhysicalMemorySize();
+
+    long diskTotal = 0L;
+    long diskFree = 0L;
+    try {
+      for (Path root : FileSystems.getDefault().getRootDirectories()) {
+        final FileStore store = Files.getFileStore(root);
+        diskTotal += store.getTotalSpace();
+        diskFree += store.getUsableSpace();
+      }
+    } catch (IOException swallow) {
+      // nop
+    }
+    final long diskUsage = diskTotal - diskFree;
+    final long startTime = runtimeMXBean.getStartTime();
+    final SystemPulse systemPulse = new SystemPulse(cpuUsage, cpuTotal, memUsage, memTotal, diskUsage, diskTotal, startTime);
+    SYSTEM_PULSE.set(this, systemPulse);
+    this.flushMetrics();
   }
 
   static final Uri PARTS_URI = Uri.parse("parts");
+  static final long POLL_INTERVAL = 2000L;
 
   @SuppressWarnings("unchecked")
   static final AtomicReferenceFieldUpdater<MeshTable, FingerTrieSeq<PartBinding>> PARTS =
@@ -1030,6 +1081,8 @@ public class MeshTable extends AbstractTierBinding implements MeshBinding {
       AtomicIntegerFieldUpdater.newUpdater(MeshTable.class, "uplinkCommandRate");
   static final AtomicLongFieldUpdater<MeshTable> UPLINK_COMMAND_COUNT =
       AtomicLongFieldUpdater.newUpdater(MeshTable.class, "uplinkCommandCount");
+  static final AtomicReferenceFieldUpdater<MeshTable, SystemPulse> SYSTEM_PULSE =
+      AtomicReferenceFieldUpdater.newUpdater(MeshTable.class, SystemPulse.class, "systemPulse");
   static final AtomicLongFieldUpdater<MeshTable> LAST_REPORT_TIME =
       AtomicLongFieldUpdater.newUpdater(MeshTable.class, "lastReportTime");
 
@@ -1095,6 +1148,26 @@ final class MeshTablePulseController implements OnCue<MeshPulse> {
   @Override
   public MeshPulse onCue(WarpUplink uplink) {
     return this.mesh.pulse;
+  }
+
+}
+
+final class MeshSystemPulseTimer extends AbstractTimer {
+
+  final MeshTable mesh;
+  private final OperatingSystemMXBean operatingSystemMXBean;
+  private final RuntimeMXBean runtimeMXBean;
+
+  MeshSystemPulseTimer(MeshTable mesh) {
+    this.mesh = mesh;
+    this.operatingSystemMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+    this.runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+  }
+
+  @Override
+  public void runTimer() {
+    this.mesh.updateSystemPulse(this.operatingSystemMXBean, this.runtimeMXBean);
+    reschedule(MeshTable.POLL_INTERVAL);
   }
 
 }

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/PartTable.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/PartTable.java
@@ -882,7 +882,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
   }
 
   static final Uri HOSTS_URI = Uri.parse("hosts");
-  static final long POLL_INTERVAL = 2000L;
 
   @SuppressWarnings("unchecked")
   static final AtomicReferenceFieldUpdater<PartTable, HashTrieMap<Uri, HostBinding>> HOSTS =

--- a/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/PartTable.java
+++ b/swim-java/swim-runtime/swim-host/swim.system/src/main/java/swim/system/router/PartTable.java
@@ -14,14 +14,6 @@
 
 package swim.system.router;
 
-import com.sun.management.OperatingSystemMXBean;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.nio.file.FileStore;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -36,11 +28,9 @@ import swim.api.lane.function.OnSyncKeys;
 import swim.api.policy.Policy;
 import swim.api.warp.WarpUplink;
 import swim.collections.HashTrieMap;
-import swim.concurrent.AbstractTimer;
 import swim.concurrent.Cont;
 import swim.concurrent.Schedule;
 import swim.concurrent.Stage;
-import swim.concurrent.TimerRef;
 import swim.store.StoreBinding;
 import swim.structure.Value;
 import swim.system.AbstractTierBinding;
@@ -121,7 +111,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
   volatile int uplinkCommandDelta;
   volatile int uplinkCommandRate;
   volatile long uplinkCommandCount;
-  volatile SystemPulse systemPulse;
   volatile long lastReportTime;
 
   PartPulse pulse;
@@ -134,7 +123,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
   SupplyLane<LogEntry> metaWarnLog;
   SupplyLane<LogEntry> metaErrorLog;
   SupplyLane<LogEntry> metaFailLog;
-  private TimerRef systemPulseTimer;
 
   public PartTable(PartPredicate predicate) {
     this.predicate = predicate;
@@ -181,7 +169,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
     this.uplinkCommandDelta = 0;
     this.uplinkCommandRate = 0;
     this.uplinkCommandCount = 0L;
-    this.systemPulse = SystemPulse.empty();
     this.lastReportTime = 0L;
 
     this.pulse = null;
@@ -659,11 +646,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
   }
 
   @Override
-  protected void didOpen() {
-    this.systemPulseTimer = this.schedule().setTimer(POLL_INTERVAL, new PartSystemPulseTimer(this));
-  }
-
-  @Override
   protected void willLoad() {
     super.willLoad();
     final Iterator<HostBinding> hostsIterator = PartTable.HOSTS.get(this).valueIterator();
@@ -722,11 +704,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
       this.metaWarnLog = null;
       this.metaErrorLog = null;
       this.metaFailLog = null;
-    }
-    final TimerRef systemPulseTimer = this.systemPulseTimer;
-    if (systemPulseTimer != null) {
-      systemPulseTimer.cancel();
-      this.systemPulseTimer = null;
     }
     this.flushMetrics();
   }
@@ -884,8 +861,7 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
     final long uplinkCount = uplinkOpenCount - uplinkCloseCount;
     final WarpUplinkPulse uplinkPulse = new WarpUplinkPulse(uplinkCount, uplinkEventRate, uplinkEventCount,
                                                             uplinkCommandRate, uplinkCommandCount);
-    final SystemPulse systemPulse = PartTable.SYSTEM_PULSE.getAndSet(this, SystemPulse.empty());
-    this.pulse = new PartPulse(hostCount, nodeCount, agentPulse, downlinkPulse, uplinkPulse, systemPulse);
+    this.pulse = new PartPulse(hostCount, nodeCount, agentPulse, downlinkPulse, uplinkPulse, SystemPulse.latest());
     final DemandLane<PartPulse> metaPulse = this.metaPulse;
     if (metaPulse != null) {
       metaPulse.cue();
@@ -903,31 +879,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
                            uplinkOpenDelta, uplinkOpenCount, uplinkCloseDelta, uplinkCloseCount,
                            uplinkEventDelta, uplinkEventRate, uplinkEventCount,
                            uplinkCommandDelta, uplinkCommandRate, uplinkCommandCount);
-  }
-
-  protected void updateSystemPulse(OperatingSystemMXBean operatingSystemMXBean, RuntimeMXBean runtimeMXBean) {
-    final int cpuTotal = 100 * operatingSystemMXBean.getAvailableProcessors();
-    final int cpuUsage = (int) Math.round(operatingSystemMXBean.getProcessCpuLoad() * cpuTotal);
-
-    final long memTotal = operatingSystemMXBean.getTotalPhysicalMemorySize();
-    final long memUsage = memTotal - operatingSystemMXBean.getFreePhysicalMemorySize();
-
-    long diskTotal = 0L;
-    long diskFree = 0L;
-    try {
-      for (Path root : FileSystems.getDefault().getRootDirectories()) {
-        final FileStore store = Files.getFileStore(root);
-        diskTotal += store.getTotalSpace();
-        diskFree += store.getUsableSpace();
-      }
-    } catch (IOException swallow) {
-      // nop
-    }
-    final long diskUsage = diskTotal - diskFree;
-    final long startTime = runtimeMXBean.getStartTime();
-    final SystemPulse systemPulse = new SystemPulse(cpuUsage, cpuTotal, memUsage, memTotal, diskUsage, diskTotal, startTime);
-    SYSTEM_PULSE.set(this, systemPulse);
-    this.flushMetrics();
   }
 
   static final Uri HOSTS_URI = Uri.parse("hosts");
@@ -1017,8 +968,6 @@ public class PartTable extends AbstractTierBinding implements PartBinding {
       AtomicIntegerFieldUpdater.newUpdater(PartTable.class, "uplinkCommandRate");
   static final AtomicLongFieldUpdater<PartTable> UPLINK_COMMAND_COUNT =
       AtomicLongFieldUpdater.newUpdater(PartTable.class, "uplinkCommandCount");
-  static final AtomicReferenceFieldUpdater<PartTable, SystemPulse> SYSTEM_PULSE =
-      AtomicReferenceFieldUpdater.newUpdater(PartTable.class, SystemPulse.class, "systemPulse");
   static final AtomicLongFieldUpdater<PartTable> LAST_REPORT_TIME =
       AtomicLongFieldUpdater.newUpdater(PartTable.class, "lastReportTime");
 
@@ -1063,23 +1012,3 @@ final class PartTablePulseController implements OnCue<PartPulse> {
 
 }
 
-final class PartSystemPulseTimer extends AbstractTimer {
-
-  final PartTable part;
-  private final OperatingSystemMXBean operatingSystemMXBean;
-  private final RuntimeMXBean runtimeMXBean;
-
-  PartSystemPulseTimer(PartTable part) {
-    this.part = part;
-    this.operatingSystemMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
-    this.runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-
-  }
-
-  @Override
-  public void runTimer() {
-    this.part.updateSystemPulse(this.operatingSystemMXBean, this.runtimeMXBean);
-    reschedule(PartTable.POLL_INTERVAL);
-  }
-
-}


### PR DESCRIPTION
Have confirmed that this works, was able to pull system pulse from `swim:meta:mesh` and `swim:meta:part`

Code duplication in `MeshTable` and `PartTable` as well, open to suggestions on refactoring this piece.
Using 2 seconds as the poll interval in `MeshTable` and `PartTable` for getting the `SystemPulse`- Is that okay?
