### PR TITLE
Close connections if there are no open uplinks or downlinks

### DIFF
--- a/swim-java/swim-runtime/swim-host/swim.remote/src/main/java/swim/remote/RemoteHostClient.java
+++ b/swim-java/swim-runtime/swim-host/swim.remote/src/main/java/swim/remote/RemoteHostClient.java
@@ -114,9 +114,10 @@ public class RemoteHostClient extends RemoteHost {
 
   @Override
   protected void reconnect() {
-    //if (this.uplinks.isEmpty()) {
-    //  close();
-    //}
+    if (RemoteHost.DOWNLINKS.get(this).isEmpty() && RemoteHost.UPLINKS.get(this).isEmpty()) {
+      close();
+      return;
+    }
     if (this.reconnectTimer != null && this.reconnectTimer.isScheduled()) {
       return;
     }


### PR DESCRIPTION
* Changed the `reconnect` method to retry only if there are any open downlinks or uplinks.


This fixes the `unresolvable host` exceptions.