### PR TITLE
Fix for issue #125

### DIFF
--- a/swim-java/swim-runtime/swim-core/swim.json/src/main/java/swim/json/DocumentParser.java
+++ b/swim-java/swim-runtime/swim-core/swim.json/src/main/java/swim/json/DocumentParser.java
@@ -62,6 +62,8 @@ final class DocumentParser<I, V> extends Parser<V> {
         if (c == '{') {
           input = input.step();
           step = 2;
+        } else if (c == '[') {
+          return json.parseArray(input);
         } else {
           return Parser.error(Diagnostic.expected('{', input));
         }

--- a/swim-java/swim-runtime/swim-core/swim.json/src/test/java/swim/json/JsonParserSpec.java
+++ b/swim-java/swim-runtime/swim-core/swim.json/src/test/java/swim/json/JsonParserSpec.java
@@ -37,6 +37,7 @@ public class JsonParserSpec {
   @Test
   public void parseEmptyArrays() {
     assertParses("[]", Record.empty());
+    assertParsesObject("[]", Record.empty());
   }
 
   @Test
@@ -326,12 +327,17 @@ public class JsonParserSpec {
     assertParses("[{},[],\"\",0,true,false,null]",
                  Record.of(Record.empty(), Record.empty(), "", 0, Bool.from(true),
                            Bool.from(false), Value.extant()));
+    assertParsesObject("[{},[],\"\",0,true,false,null]",
+        Record.of(Record.empty(), Record.empty(), "", 0, Bool.from(true),
+            Bool.from(false), Value.extant()));
   }
 
   @Test
   public void parseArraysWithWhitespace() {
     assertParses(" [ ] ", Record.empty());
     assertParses(" [ 1 , 2 ] ", Record.of(1, 2));
+    assertParsesObject(" [ ] ", Record.empty());
+    assertParsesObject(" [ 1 , 2 ] ", Record.of(1, 2));
   }
 
   @Test


### PR DESCRIPTION
Overload the Document parser to check for top-level arrays to handle JsonArrays as well as JsonObjects